### PR TITLE
Enable webpack watch

### DIFF
--- a/vscode/.vscode/launch.json
+++ b/vscode/.vscode/launch.json
@@ -15,7 +15,10 @@
 			"outFiles": [
 				"${workspaceFolder}/dist/**/*.js"
 			],
-			"preLaunchTask": "${defaultBuildTask}"
+			"preLaunchTask": "${defaultBuildTask}",
+			"env": {
+				"VSCODE_DEBUG_MODE": "true"
+			}
 		}
 	]
 }

--- a/vscode/src/KonveyorGUIWebviewViewProvider.ts
+++ b/vscode/src/KonveyorGUIWebviewViewProvider.ts
@@ -78,7 +78,9 @@ export class KonveyorGUIWebviewViewProvider
       <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; script-src 'nonce-${nonce}' ${webview.cspSource} 'unsafe-inline';">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${
+          webview.cspSource
+        }; script-src 'nonce-${nonce}' ${webview.cspSource} 'unsafe-inline';">
         <title>Konveyor</title>
         <link rel="stylesheet" href="${styleUri}">
       </head>
@@ -91,7 +93,7 @@ export class KonveyorGUIWebviewViewProvider
             console.log('HTML started up. Full screen:', ${isFullScreen});
           });
         </script>
-        <script nonce="${nonce}" src="${scriptUri}" onerror="console.error('Failed to load script')"></script>
+        ${`<script nonce="${nonce}" src="${scriptUri}"></script>`}
       </body>
     </html>
     `;

--- a/vscode/src/styles.css
+++ b/vscode/src/styles.css
@@ -1,0 +1,4 @@
+body {
+    background-color: aliceblue;
+  }
+  

--- a/vscode/webpack.config.ts
+++ b/vscode/webpack.config.ts
@@ -62,6 +62,11 @@ const webviewConfig: webpack.Configuration = {
       },
     ],
   },
+  watch: true,
+  watchOptions: {
+    ignored: /node_modules/,
+    poll: 1000,
+  },
 };
 
 export default [webviewConfig, extensionConfig];


### PR DESCRIPTION
Enable webpack watch mode to allow npm run watch to work as expected rather than needing to npm run compile every time you make a change. 