### PR TITLE
:sparkles: Add cross webview messaging 

### DIFF
--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import { KonveyorGUIWebviewViewProvider } from "./KonveyorGUIWebviewViewProvider";
 import { setupWebviewMessageListener } from "./webviewMessageHandler";
 import { ExtensionState } from "./extensionState";
 import { getWebviewContent } from "./webviewContent";

--- a/vscode/src/extensionState.ts
+++ b/vscode/src/extensionState.ts
@@ -1,7 +1,25 @@
-// extensionState.ts
 import { KonveyorGUIWebviewViewProvider } from "./KonveyorGUIWebviewViewProvider";
 
 export interface ExtensionState {
   sidebarProvider: KonveyorGUIWebviewViewProvider;
+  sharedState: SharedState;
+  webviewProviders: Set<KonveyorGUIWebviewViewProvider>;
   // Add other shared components as needed
+}
+
+// src/sharedState.ts
+export class SharedState {
+  private state: { [key: string]: any } = {};
+
+  set(key: string, value: any) {
+    this.state[key] = value;
+  }
+
+  get(key: string) {
+    return this.state[key];
+  }
+
+  getAll() {
+    return this.state;
+  }
 }

--- a/vscode/src/webview/components/App.tsx
+++ b/vscode/src/webview/components/App.tsx
@@ -8,7 +8,7 @@ declare const vscode: vscode;
 
 const sendMessage = () => {
   console.log("button clicked");
-  vscode.postMessage({ command: "testing" });
+  vscode.postMessage({ command: "testing", data: { test: "test" } });
 };
 
 const App = () => {
@@ -21,6 +21,10 @@ const App = () => {
         case "refactor":
           setButtonText("The brain is working");
           break;
+        case "updateState":
+            console.log('Receive updated state:', message.data)
+          break;
+
       }
     });
   });


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
