### PR TITLE
:book: fixed broken link at README.md and added items in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vscode/build
 vscode/tsconfig.tsbuildinfo
 vscode/tsbuildinfo
 .aider*
+.vscode

--- a/analyzer/README.md
+++ b/analyzer/README.md
@@ -1,5 +1,5 @@
 Analyzer
 ========
 
-Method of running [analyzer-lsp](github.com/konveyor/analyzer-lsp) using
+Method of running [analyzer-lsp](https://github.com/konveyor/analyzer-lsp) using
 jsonrpc over stdio.


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->

- Fixed broken link at `analyzer/README.md`
- Added items to`.vscode` 

Fixes : #42 