### PR TITLE
:sparkles: Start kai/rpc-server

### DIFF
--- a/vscode/media/walkthroughs/override-analyzer.md
+++ b/vscode/media/walkthroughs/override-analyzer.md
@@ -2,4 +2,4 @@
 
 The Konveyor extension comes packaged with default analyzer and Generative AI binaries. However, you may want to use a custom or updated version of these binaries.
 
-To override the default analyzer, run the [Konveyor: Override Analyzer Binaries](command:konveyor.overrideAnalyzerBinaries) command, and to override the Generative AI binary, run the[Konveyor: Override Generative AI Binaries](command:konveyor.overriderpcServerBinaries) command. 
+To override the default analyzer, run the [Konveyor: Override Analyzer Binaries](command:konveyor.overrideAnalyzerBinaries) command, and to override the Generative AI binary, run the [Konveyor: Override Generative AI Binaries](command:konveyor.overrideKaiRpcServerBinaries) command. 

--- a/vscode/media/walkthroughs/override-analyzer.md
+++ b/vscode/media/walkthroughs/override-analyzer.md
@@ -1,6 +1,5 @@
 # Override Analyzer Binary
 
-The Konveyor extension comes packaged with a default analyzer binary. However,
-you may want to use a custom or updated version of the analyzer.
+The Konveyor extension comes packaged with default analyzer and Generative AI binaries. However, you may want to use a custom or updated version of these binaries.
 
-To override the default analyzer run the [Konveyor: Override Analyzer Binaries](command:konveyor.overrideAnalyzerBinaries) command.
+To override the default analyzer, run the [Konveyor: Override Analyzer Binaries](command:konveyor.overrideAnalyzerBinaries) command, and to override the Generative AI binary, run the[Konveyor: Override Generative AI Binaries](command:konveyor.overriderpcServerBinaries) command. 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -40,6 +40,12 @@
         "icon": "$(gear)"
       },
       {
+        "command": "konveyor.overriderpcServerBinaries",
+        "title": "Override Generative AI Binaries",
+        "category": "Konveyor",
+        "icon": "$(gear)"
+      },
+      {
         "command": "konveyor.configureCustomRules",
         "title": "Configure Custom Rules",
         "category": "Konveyor",
@@ -159,6 +165,13 @@
           "scope": "machine",
           "order": 0
         },
+        "konveyor.rpcServerPath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to the rpc-server binary. If not set, the extension will use the bundled binary.",
+          "scope": "machine",
+          "order": 0
+        },
         "konveyor.incidentLimit": {
           "type": "number",
           "default": 10000,
@@ -236,7 +249,7 @@
           {
             "id": "override-analyzer",
             "title": "Override Analyzer Binary",
-            "description": "Specify a custom path for the analyzer binary\n[Override Analyzer Binary](command:konveyor.overrideAnalyzerBinaries)",
+            "description": "Specify a custom path for the analyzer binary\n[Override Analyzer Binary](command:konveyor.overrideAnalyzerBinaries)\n[Override GenerativeAI Binary](command:konveyor.overriderpcServerBinaries)",
             "completionEvents": [],
             "media": {
               "markdown": "media/walkthroughs/override-analyzer.md"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -40,7 +40,7 @@
         "icon": "$(gear)"
       },
       {
-        "command": "konveyor.overriderpcServerBinaries",
+        "command": "konveyor.overrideKaiRpcServerBinaries",
         "title": "Override Generative AI Binaries",
         "category": "Konveyor",
         "icon": "$(gear)"
@@ -165,7 +165,7 @@
           "scope": "machine",
           "order": 0
         },
-        "konveyor.rpcServerPath": {
+        "konveyor.kaiRpcServerPath": {
           "type": "string",
           "default": "",
           "description": "Path to the rpc-server binary. If not set, the extension will use the bundled binary.",
@@ -249,7 +249,7 @@
           {
             "id": "override-analyzer",
             "title": "Override Analyzer Binary",
-            "description": "Specify a custom path for the analyzer binary\n[Override Analyzer Binary](command:konveyor.overrideAnalyzerBinaries)\n[Override GenerativeAI Binary](command:konveyor.overriderpcServerBinaries)",
+            "description": "Specify a custom path for the analyzer binary\n[Override Analyzer Binary](command:konveyor.overrideAnalyzerBinaries)\n[Override GenerativeAI Binary](command:konveyor.overrideKaiRpcServerBinaries)",
             "completionEvents": [],
             "media": {
               "markdown": "media/walkthroughs/override-analyzer.md"

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -147,13 +147,56 @@ export class AnalyzerClient {
     vscode.window.showErrorMessage("Not yet implemented");
   }
 
-  public async shudtown(): Promise<any> {
-    vscode.window.showErrorMessage("Not yet implemented");
-  }
+  // Shutdown the server
+ // Shutdown the server
+public async shutdown(): Promise<void> {
+  return new Promise((resolve, reject) => {
+      const requestId = this.requestId++;
+      const request = JSON.stringify({
+          jsonrpc: "2.0",
+          id: requestId,
+          method: "shutdown",
+          params: {},
+      }) + "\n";
+      this.analyzerServer?.stdin.write(request);
+      this.outputChannel.appendLine("Shuting down Server");
+      this.analyzerServer?.stdout.on("data", (data) => {
+          try {
+              const response = JSON.parse(data.toString());
+              if (response.id === requestId && !response.error) {
+                  resolve();
+              }
+          } catch (err: any) {
+              reject(err);
+          }
+      });
+  });
+}
 
-  public async exit(): Promise<any> {
-    vscode.window.showErrorMessage("Not yet implemented");
-  }
+// Exit the server
+public async exit(): Promise<void> {
+  return new Promise((resolve, reject) => {
+      const requestId = this.requestId++;
+      const request = JSON.stringify({
+          jsonrpc: "2.0",
+          id: requestId,
+          method: "exit",
+          params: {},
+      }) + "\n";     
+      this.analyzerServer?.stdin.write(request);   
+      this.outputChannel.appendLine("Exiting Server");
+      this.analyzerServer?.stdout.on("data", (data) => {
+          try {
+              const response = JSON.parse(data.toString());
+              if (response.id === requestId && !response.error) {
+                resolve();
+              }
+          } catch (err: any) {
+             reject(err);
+          }
+      });
+  });
+}
 
   public async canAnalyze(): Promise<boolean> {
     const labelSelector = this.config!.get("labelSelector") as string;

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -21,7 +21,7 @@ export class AnalyzerClient {
   }
 
   public start(): void {
-    if (!this.canAnalyze) {
+    if (!this.canAnalyze()) {
       return;
     }
     exec("java -version", (err) => {
@@ -35,8 +35,7 @@ export class AnalyzerClient {
         vscode.window.showErrorMessage("Maven is not installed. Please install it to continue.");
         return;
       }
-    });
-
+    });   
     this.analyzerServer = spawn(this.getAnalyzerPath(), this.getAnalyzerArgs(), {
       cwd: this.extContext!.extensionPath,
     });
@@ -206,6 +205,11 @@ export class AnalyzerClient {
   }
 
   public getAnalyzerPath(): string {
+    const analyzerPath = this.config?.get<string>("analyzerPath");
+    if (analyzerPath && fs.existsSync(analyzerPath)) {
+      return analyzerPath;
+    }
+
     const platform = os.platform();
     const arch = os.arch();
 
@@ -215,14 +219,52 @@ export class AnalyzerClient {
     }
 
     // Full path to the analyzer binary
-    const analyzerPath = path.join(this.extContext!.extensionPath, "assets", "bin", binaryName);
+    const defaultAnalyzerPath = path.join(
+      this.extContext!.extensionPath,
+      "assets",
+      "bin",
+      binaryName,
+    );
 
     // Check if the binary exists
-    if (!fs.existsSync(analyzerPath)) {
-      vscode.window.showErrorMessage(`Analyzer binary doesn't exist at ${analyzerPath}`);
+    if (!fs.existsSync(defaultAnalyzerPath)) {
+      vscode.window.showErrorMessage(`Analyzer binary doesn't exist at ${defaultAnalyzerPath}`);
     }
 
-    return analyzerPath;
+    return defaultAnalyzerPath;
+  }
+  public getRpcServerPath(): string {
+    // Retrieve the rpcServerPath
+    const rpcServerPath = this.config?.get<string>("rpcServerPath");
+    if (rpcServerPath && fs.existsSync(rpcServerPath)) {
+      return rpcServerPath;
+    }
+    // Might not needed. 
+    // Fallback to default rpc-server binary path if user did not provid path
+    const platform = os.platform();
+    const arch = os.arch();
+
+    let binaryName = `kai-rpc-server.${platform}.${arch}`;
+    if (platform === "win32") {
+      binaryName += ".exe";
+    }
+
+    // Construct the full path
+    const defaultRpcServerPath = path.join(
+      this.extContext!.extensionPath,
+      "assets",
+      "bin",
+      binaryName,
+    );
+
+    // Check if the default rpc-server binary exists, else show an error message
+    if (!fs.existsSync(defaultRpcServerPath)) {
+      vscode.window.showErrorMessage(`RPC server binary doesn't exist at ${defaultRpcServerPath}`);
+      throw new Error(`RPC server binary not found at ${defaultRpcServerPath}`);
+    }
+
+    // Return the default path
+    return defaultRpcServerPath;
   }
 
   public getAnalyzerArgs(): string[] {

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -35,7 +35,7 @@ export class AnalyzerClient {
         vscode.window.showErrorMessage("Maven is not installed. Please install it to continue.");
         return;
       }
-    });   
+    });
     this.analyzerServer = spawn(this.getAnalyzerPath(), this.getAnalyzerArgs(), {
       cwd: this.extContext!.extensionPath,
     });
@@ -148,55 +148,56 @@ export class AnalyzerClient {
   }
 
   // Shutdown the server
- // Shutdown the server
-public async shutdown(): Promise<void> {
-  return new Promise((resolve, reject) => {
+  public async shutdown(): Promise<void> {
+    return new Promise((resolve, reject) => {
       const requestId = this.requestId++;
-      const request = JSON.stringify({
+      const request =
+        JSON.stringify({
           jsonrpc: "2.0",
           id: requestId,
           method: "shutdown",
           params: {},
-      }) + "\n";
+        }) + "\n";
       this.analyzerServer?.stdin.write(request);
       this.outputChannel.appendLine("Shuting down Server");
       this.analyzerServer?.stdout.on("data", (data) => {
-          try {
-              const response = JSON.parse(data.toString());
-              if (response.id === requestId && !response.error) {
-                  resolve();
-              }
-          } catch (err: any) {
-              reject(err);
+        try {
+          const response = JSON.parse(data.toString());
+          if (response.id === requestId && !response.error) {
+            resolve();
           }
+        } catch (err: any) {
+          reject(err);
+        }
       });
-  });
-}
+    });
+  }
 
-// Exit the server
-public async exit(): Promise<void> {
-  return new Promise((resolve, reject) => {
+  // Exit the server
+  public async exit(): Promise<void> {
+    return new Promise((resolve, reject) => {
       const requestId = this.requestId++;
-      const request = JSON.stringify({
+      const request =
+        JSON.stringify({
           jsonrpc: "2.0",
           id: requestId,
           method: "exit",
           params: {},
-      }) + "\n";     
-      this.analyzerServer?.stdin.write(request);   
+        }) + "\n";
+      this.analyzerServer?.stdin.write(request);
       this.outputChannel.appendLine("Exiting Server");
       this.analyzerServer?.stdout.on("data", (data) => {
-          try {
-              const response = JSON.parse(data.toString());
-              if (response.id === requestId && !response.error) {
-                resolve();
-              }
-          } catch (err: any) {
-             reject(err);
+        try {
+          const response = JSON.parse(data.toString());
+          if (response.id === requestId && !response.error) {
+            resolve();
           }
+        } catch (err: any) {
+          reject(err);
+        }
       });
-  });
-}
+    });
+  }
 
   public async canAnalyze(): Promise<boolean> {
     const labelSelector = this.config!.get("labelSelector") as string;
@@ -276,13 +277,13 @@ public async exit(): Promise<void> {
 
     return defaultAnalyzerPath;
   }
-  public getRpcServerPath(): string {
+  public getKaiRpcServerPath(): string {
     // Retrieve the rpcServerPath
-    const rpcServerPath = this.config?.get<string>("rpcServerPath");
+    const rpcServerPath = this.config?.get<string>("kaiRpcServerPath");
     if (rpcServerPath && fs.existsSync(rpcServerPath)) {
       return rpcServerPath;
     }
-    // Might not needed. 
+    // Might not needed.
     // Fallback to default rpc-server binary path if user did not provid path
     const platform = os.platform();
     const arch = os.arch();

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -136,7 +136,7 @@ const commandsMap: (state: ExtensionState) => {
         window.showInformationMessage("No analyzer binary selected.");
       }
     },
-    "konveyor.overriderpcServerBinaries": async () => {
+    "konveyor.overrideKaiRpcServerBinaries": async () => {
       const options: OpenDialogOptions = {
         canSelectMany: false,
         openLabel: "Select GenAI Binary",
@@ -153,11 +153,11 @@ const commandsMap: (state: ExtensionState) => {
 
         // Update the user settings
         const config = workspace.getConfiguration("konveyor");
-        await config.update("rpcServerPath", filePath, ConfigurationTarget.Global);
+        await config.update("kaiRpcServerPath", filePath, ConfigurationTarget.Global);
 
-        window.showInformationMessage(`rpc server binary path updated to: ${filePath}`);
+        window.showInformationMessage(`Kai rpc server binary path updated to: ${filePath}`);
       } else {
-        window.showInformationMessage("No rpc-server binary selected.");
+        window.showInformationMessage("No Kai rpc-server binary selected.");
       }
     },
     "konveyor.configureCustomRules": async () => {

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -136,6 +136,30 @@ const commandsMap: (state: ExtensionState) => {
         window.showInformationMessage("No analyzer binary selected.");
       }
     },
+    "konveyor.overriderpcServerBinaries": async () => {
+      const options: OpenDialogOptions = {
+        canSelectMany: false,
+        openLabel: "Select GenAI Binary",
+        filters: {
+          "Executable Files": ["exe", "sh", "bat", ""],
+          "All Files": ["*"],
+        },
+      };
+
+      const fileUri = await window.showOpenDialog(options);
+
+      if (fileUri && fileUri[0]) {
+        const filePath = fileUri[0].fsPath;
+
+        // Update the user settings
+        const config = workspace.getConfiguration("konveyor");
+        await config.update("rpcServerPath", filePath, ConfigurationTarget.Global);
+
+        window.showInformationMessage(`rpc server binary path updated to: ${filePath}`);
+      } else {
+        window.showInformationMessage("No rpc-server binary selected.");
+      }
+    },
     "konveyor.configureCustomRules": async () => {
       const options: OpenDialogOptions = {
         canSelectMany: true,


### PR DESCRIPTION
- Add kai-rpc server Path property which user can override


Fixes #62 #64 

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
