### PR TITLE
:seedling: Update husky to run across the repo

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+
+#
+# Auto-fix any list errors in staged files
+#
+npx lint-staged
+

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "test": "npm run lint && npm run build && npm run test -w vscode",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",

--- a/vscode/.husky/pre-commit
+++ b/vscode/.husky/pre-commit
@@ -1,3 +1,0 @@
-# hooks need to be in root
-cd vscode
-npx lint-staged


### PR DESCRIPTION
  - Current husky version has a different way to install
  - The `lint-staged` action should run at the repo root so all repos are linted/fixed by the pre-commit script
