### PR TITLE
:sparkles: Load state from files and create apply/revert/copy commands

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -81,6 +81,11 @@
         "category": "Konveyor"
       },
       {
+        "command": "konveyor.loadResultsFromDataFolder",
+        "title": "Reload results",
+        "category": "Konveyor"
+      },
+      {
         "command": "konveyor.cleanRuleSets",
         "title": "Reset analysis results",
         "category": "Konveyor"
@@ -96,9 +101,9 @@
         "category": "Konveyor"
       },
       {
-        "command": "konveyor.diffView.applyAll",
+        "command": "konveyor.applyAll",
         "title": "Apply All",
-        "category": "Resolutions",
+        "category": "Konveyor",
         "icon": {
           "light": "resources/icons/light/check.svg",
           "dark": "resources/icons/dark/check.svg"
@@ -107,15 +112,16 @@
       {
         "command": "konveyor.diffView.revertAll",
         "title": "Discard local changes to Resolutions",
-        "category": "Resolutions",
+        "category": "Konveyor",
         "icon": {
           "light": "resources/icons/light/discard.svg",
           "dark": "resources/icons/dark/discard.svg"
         }
       },
       {
-        "command": "konveyor.diffView.applyFile",
+        "command": "konveyor.applyFile",
         "title": "Apply",
+        "category": "Konveyor",
         "icon": {
           "light": "resources/icons/light/check.svg",
           "dark": "resources/icons/dark/check.svg"
@@ -124,26 +130,36 @@
       {
         "command": "konveyor.diffView.revertFile",
         "title": "Discard local changes to Resolutions",
+        "category": "Konveyor",
         "icon": {
           "light": "resources/icons/light/discard.svg",
           "dark": "resources/icons/dark/discard.svg"
         }
       },
       {
-        "command": "konveyor.diffView.copyDiff",
+        "command": "konveyor.copyDiff",
+        "category": "Konveyor",
         "title": "Copy Diff"
       },
       {
-        "command": "konveyor.diffView.copyPath",
+        "command": "konveyor.copyPath",
+        "category": "Konveyor",
         "title": "Copy Path"
       },
       {
         "command": "konveyor.diffView.next",
+        "category": "Konveyor",
         "title": "Go to Next File"
       },
       {
         "command": "konveyor.diffView.prev",
+        "category": "Konveyor",
         "title": "Go to Previous File"
+      },
+      {
+        "command": "konveyor.diffView.viewFix",
+        "category": "Konveyor",
+        "title": "View suggested fix"
       }
     ],
     "submenus": [
@@ -183,7 +199,7 @@
           "when": "view == konveyor.konveyorGUIView"
         },
         {
-          "command": "konveyor.diffView.applyAll",
+          "command": "konveyor.applyAll",
           "group": "navigation@1",
           "when": "view == konveyor.diffView"
         },
@@ -195,7 +211,7 @@
       ],
       "view/item/context": [
         {
-          "command": "konveyor.diffView.applyFile",
+          "command": "konveyor.applyFile",
           "group": "inline",
           "when": "view == konveyor.diffView && viewItem == file-item"
         },
@@ -205,7 +221,7 @@
           "when": "view == konveyor.diffView && viewItem == file-item"
         },
         {
-          "command": "konveyor.diffView.applyFile",
+          "command": "konveyor.applyFile",
           "group": "1@1",
           "when": "view == konveyor.diffView && viewItem == file-item"
         },
@@ -215,12 +231,12 @@
           "when": "view == konveyor.diffView && viewItem == file-item"
         },
         {
-          "command": "konveyor.diffView.copyDiff",
+          "command": "konveyor.copyDiff",
           "group": "2@1",
           "when": "view == konveyor.diffView && viewItem == file-item"
         },
         {
-          "command": "konveyor.diffView.copyPath",
+          "command": "konveyor.copyPath",
           "group": "2@2",
           "when": "view == konveyor.diffView && viewItem == file-item"
         }
@@ -249,7 +265,7 @@
           "when": "never"
         },
         {
-          "command": "konveyor.diffView.applyFile",
+          "command": "konveyor.applyFile",
           "when": "never"
         },
         {
@@ -257,11 +273,11 @@
           "when": "never"
         },
         {
-          "command": "konveyor.diffView.copyDiff",
+          "command": "konveyor.copyDiff",
           "when": "never"
         },
         {
-          "command": "konveyor.diffView.copyPath",
+          "command": "konveyor.copyPath",
           "when": "never"
         },
         {
@@ -273,10 +289,8 @@
           "when": "never"
         },
         {
-          "command": "konveyor.diffView.applyAll"
-        },
-        {
-          "command": "konveyor.diffView.revertAll"
+          "command": "konveyor.diffView.viewFix",
+          "when": "never"
         }
       ]
     },

--- a/vscode/src/KonveyorGUIWebviewViewProvider.ts
+++ b/vscode/src/KonveyorGUIWebviewViewProvider.ts
@@ -134,7 +134,7 @@ export class KonveyorGUIWebviewViewProvider implements WebviewViewProvider {
 
   private _loadInitialContent() {
     if (this._isWebviewReady && this._view) {
-      const data = this._extensionState.extensionContext.workspaceState.get("storedRuleSets");
+      const data = this._extensionState.ruleSets;
       this._view.webview.postMessage({
         type: "loadStoredAnalysis",
         data,

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -11,9 +11,24 @@ import {
   ViewColumn,
   workspace,
 } from "vscode";
-import { cleanRuleSets, loadRuleSets, loadSolution, loadStaticResults } from "./data";
+import {
+  cleanRuleSets,
+  loadResultsFromDataFolder,
+  loadRuleSets,
+  loadSolution,
+  loadStaticResults,
+} from "./data";
 import { GetSolutionResult, RuleSet } from "@shared/types";
-import { applyAll, revertAll, copyDiff, copyPath, FileItem, viewFix } from "./diffView";
+import {
+  applyAll,
+  revertAll,
+  copyDiff,
+  copyPath,
+  FileItem,
+  viewFix,
+  applyFile,
+  revertFile,
+} from "./diffView";
 
 let fullScreenPanel: WebviewPanel | undefined;
 
@@ -321,14 +336,15 @@ const commandsMap: (state: ExtensionState) => {
     "konveyor.loadRuleSets": (ruleSets: RuleSet[]): void => loadRuleSets(state, ruleSets),
     "konveyor.cleanRuleSets": () => cleanRuleSets(state),
     "konveyor.loadStaticResults": loadStaticResults,
+    "konveyor.loadResultsFromDataFolder": loadResultsFromDataFolder,
     "konveyor.loadSolution": async (solution: GetSolutionResult) => loadSolution(state, solution),
     "konveyor.applyAll": () => applyAll(state),
-    "konveyor.applyFile": (item: FileItem) => item.apply(),
-    "konveyor.copyDiff": copyDiff,
+    "konveyor.applyFile": (item: FileItem | Uri) => applyFile(item, state),
+    "konveyor.copyDiff": (item: FileItem | Uri) => copyDiff(item, state),
     "konveyor.copyPath": copyPath,
     "konveyor.diffView.viewFix": viewFix,
     "konveyor.diffView.revertAll": () => revertAll(state),
-    "konveyor.diffView.revertFile": (item: FileItem) => item.revert(),
+    "konveyor.diffView.revertFile": (item: FileItem | Uri) => revertFile(item, state),
   };
 };
 

--- a/vscode/src/data/index.ts
+++ b/vscode/src/data/index.ts
@@ -1,3 +1,4 @@
 export * from "./loadStaticResults";
 export * from "./loadResults";
 export * from "./fileSystemProvider";
+export * from "./storage";

--- a/vscode/src/data/virtualStorage.ts
+++ b/vscode/src/data/virtualStorage.ts
@@ -12,13 +12,8 @@ export interface LocalChange {
   diff: string;
 }
 
-export const writeSolutionsToMemFs = async (
-  solution: GetSolutionResult,
-  { memFs }: ExtensionState,
-) => {
-  memFs.removeAll(KONVEYOR_SCHEME);
-  // TODO: implement logic for deleted/added files
-  const localChanges = solution.changes.map(({ modified, original, diff }) => ({
+export const toLocalChanges = (solution: GetSolutionResult) =>
+  solution.changes.map(({ modified, original, diff }) => ({
     modifiedUri: fromRelativeToKonveyor(modified),
     originalUri: Uri.from({
       scheme: "file",
@@ -26,6 +21,12 @@ export const writeSolutionsToMemFs = async (
     }),
     diff,
   }));
+
+export const writeSolutionsToMemFs = async (
+  localChanges: LocalChange[],
+  { memFs }: ExtensionState,
+) => {
+  // TODO: implement logic for deleted/added files
 
   // create all the dirs synchronously
   localChanges.forEach(({ modifiedUri }) =>

--- a/vscode/src/diffView/fileModel.ts
+++ b/vscode/src/diffView/fileModel.ts
@@ -29,6 +29,7 @@
 
 import * as vscode from "vscode";
 import { FileItemNavigation } from "./diff-view";
+import { isUri } from "../utilities";
 
 export class KonveyorFileModel implements FileItemNavigation<FileItem> {
   private _onDidChange = new vscode.EventEmitter<FileItem | undefined>();
@@ -126,6 +127,13 @@ export class KonveyorFileModel implements FileItemNavigation<FileItem> {
     }
     return result;
   }
+
+  markedAsApplied(fileUri: vscode.Uri) {
+    const item = this.items.find((item) => item.uri.toString() === fileUri?.toString());
+    if (item) {
+      this.remove(item);
+    }
+  }
 }
 
 export class KonveyorTreeDataProvider implements vscode.TreeDataProvider<FileItem> {
@@ -183,7 +191,7 @@ export class FileItem {
   }
 
   apply(): void {
-    this.model.apply(this);
+    vscode.commands.executeCommand("konveyor.applyFile", this.uri);
   }
 
   revert(): void {
@@ -196,3 +204,14 @@ export class FileItem {
     return result;
   }
 }
+
+export const toUri = (item: FileItem | vscode.Uri | unknown): vscode.Uri | undefined => {
+  if (isUri(item)) {
+    return item;
+  }
+  const fileItem = item as FileItem;
+  if (isUri(fileItem?.uri)) {
+    return fileItem.uri;
+  }
+  return undefined;
+};

--- a/vscode/src/diffView/solutionCommands.ts
+++ b/vscode/src/diffView/solutionCommands.ts
@@ -1,15 +1,24 @@
 import * as vscode from "vscode";
 import { ExtensionState } from "src/extensionState";
 import { fromRelativeToKonveyor } from "../utilities";
+import { writeSolutionsToMemFs } from "../data/virtualStorage";
+import { FileItem, toUri } from "./fileModel";
 
 export const applyAll = async (state: ExtensionState) => {
-  console.log(state.fileModel.message);
-  vscode.window.showInformationMessage(`[TODO] Apply all resolutions`);
+  const localChanges = state.localChanges;
+  await Promise.all(
+    localChanges.map(({ originalUri, modifiedUri }) =>
+      vscode.workspace.fs.copy(modifiedUri, originalUri, { overwrite: true }),
+    ),
+  );
+  vscode.window.showInformationMessage(`All resolutions applied successfully`);
+  state.fileModel.updateLocations([]);
 };
 
 export const revertAll = async (state: ExtensionState) => {
-  console.log(state.fileModel.message);
-  vscode.window.showInformationMessage(`[TODO] Revert all resolutions`);
+  const localChanges = state.localChanges;
+  await writeSolutionsToMemFs(localChanges, state);
+  vscode.window.showInformationMessage(`Discarded all local changes to the resolutions`);
 };
 
 export const viewFix = (uri: vscode.Uri, preserveFocus: boolean = false) =>
@@ -22,3 +31,29 @@ export const viewFix = (uri: vscode.Uri, preserveFocus: boolean = false) =>
       preserveFocus,
     },
   );
+
+export const applyFile = async (item: FileItem | vscode.Uri | unknown, state: ExtensionState) => {
+  const originalUri = toUri(item);
+  if (!originalUri) {
+    vscode.window.showErrorMessage("Failed to apply changes");
+    console.error("Failed to apply changes", item, originalUri);
+    return;
+  }
+  const modifiedUri = fromRelativeToKonveyor(vscode.workspace.asRelativePath(originalUri));
+  await vscode.workspace.fs.copy(modifiedUri, originalUri, { overwrite: true });
+  state.fileModel.markedAsApplied(originalUri);
+};
+
+export const revertFile = async (item: FileItem | vscode.Uri | unknown, state: ExtensionState) => {
+  const originalUri = toUri(item);
+  if (!originalUri) {
+    vscode.window.showErrorMessage("Failed to discard changes");
+    console.error("Failed to apply changes", item, originalUri);
+    return;
+  }
+  const localChanges = state.localChanges;
+  const change = localChanges.filter(
+    (change) => change.originalUri.toString() === originalUri.toString(),
+  );
+  await writeSolutionsToMemFs(change, state);
+};

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -5,7 +5,7 @@ import { ExtensionState, SharedState } from "./extensionState";
 import { ViolationCodeActionProvider } from "./ViolationCodeActionProvider";
 import { AnalyzerClient } from "./client/analyzerClient";
 import { registerDiffView, KonveyorFileModel } from "./diffView";
-import { MemFS } from "./data";
+import { MemFS, loadStateFromDataFolder } from "./data";
 
 class VsCodeExtension {
   private state: ExtensionState;
@@ -20,6 +20,8 @@ class VsCodeExtension {
       diagnosticCollection: vscode.languages.createDiagnosticCollection("konveyor"),
       memFs: new MemFS(),
       fileModel: new KonveyorFileModel(),
+      localChanges: [],
+      ruleSets: [],
     };
 
     this.initializeExtension(context);
@@ -32,6 +34,8 @@ class VsCodeExtension {
       registerDiffView(this.state);
       this.registerCommands();
       this.registerLanguageProviders(context);
+      // async
+      vscode.commands.executeCommand("konveyor.loadResultsFromDataFolder");
     } catch (error) {
       console.error("Error initializing extension:", error);
       vscode.window.showErrorMessage(`Failed to initialize Konveyor extension: ${error}`);

--- a/vscode/src/extensionState.ts
+++ b/vscode/src/extensionState.ts
@@ -3,6 +3,8 @@ import { KonveyorFileModel } from "./diffView";
 import { MemFS } from "./data/fileSystemProvider";
 import { KonveyorGUIWebviewViewProvider } from "./KonveyorGUIWebviewViewProvider";
 import * as vscode from "vscode";
+import { LocalChange } from "./data/virtualStorage";
+import { RuleSet } from "@shared/types";
 
 export class SharedState {
   private state: Map<string, any> = new Map();
@@ -25,4 +27,6 @@ export interface ExtensionState {
   diagnosticCollection: vscode.DiagnosticCollection;
   memFs: MemFS;
   fileModel: KonveyorFileModel;
+  localChanges: LocalChange[];
+  ruleSets: RuleSet[];
 }

--- a/vscode/src/utilities/constants.ts
+++ b/vscode/src/utilities/constants.ts
@@ -1,1 +1,3 @@
 export const KONVEYOR_SCHEME = "konveyorMemFs";
+export const RULE_SET_DATA_FILE_PREFIX = "analysis";
+export const SOLUTION_DATA_FILE_PREFIX = "solution";

--- a/vscode/src/utilities/index.ts
+++ b/vscode/src/utilities/index.ts
@@ -2,3 +2,4 @@ export * from "./constants";
 export * from "./uris";
 export * from "./getNonce";
 export * from "./getUri";
+export * from "./typeGuards";

--- a/vscode/src/utilities/typeGuards.ts
+++ b/vscode/src/utilities/typeGuards.ts
@@ -1,4 +1,5 @@
 import { GetSolutionResult, RuleSet } from "@shared/types";
+import { Uri } from "vscode";
 
 const isString = (obj: unknown): obj is string => typeof obj === "string";
 const isEmpty = (obj: unknown) => isObject(obj) && Object.keys(obj).length === 0;
@@ -43,4 +44,12 @@ export function isAnalysis(obj: unknown): obj is RuleSet {
       ([key, value]) => typeof value === (knownKeys as Record<string, string>)[key],
     )
   );
+}
+
+export function isUri(obj: unknown): obj is Uri {
+  if (!isObject(obj)) {
+    return false;
+  }
+  const uri = obj as Uri;
+  return !!(uri["toJSON"] && uri["with"] && uri.scheme);
 }


### PR DESCRIPTION
Key points:
1. make the data folder(.vscode/konveyor) the main permanent storage.
   This replaces the current usages of vscode.workspaceState.
2. store analysis results and received solutions directly in the
   extension state. Both values are frequently read from the command
   layer. Retrieval from the DB adds unnecessary delay.
3. load initial data asynchronously on extension start
4. implement commands: applyAll,applyFile, revertAll, revertFile,
   copyPath, copyDiff
5. create loadResultsFromDataFolder command ("Reload results" in the
   command palette)for initial data load and development.

Resolves: https://github.com/konveyor/editor-extensions/issues/48
Resolves: https://github.com/konveyor/editor-extensions/issues/72
