### PR TITLE
:seedling: Disable husky git hooks in github actions

### DIFF
--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -18,6 +18,10 @@ concurrency:
   group: ci-repo-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
+# https://typicode.github.io/husky/how-to.html#ci-server-and-docker
+env:
+  HUSKY: 0
+
 jobs:
   build:
     name: Build (${{ matrix.arch }})

--- a/.github/workflows/nightly-ci-repo.yaml
+++ b/.github/workflows/nightly-ci-repo.yaml
@@ -6,6 +6,10 @@ on:
 
   workflow_dispatch:
 
+# https://typicode.github.io/husky/how-to.html#ci-server-and-docker
+env:
+  HUSKY: 0
+
 jobs:
   nightly:
     uses: ./.github/workflows/ci-repo.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,18 +3,23 @@ name: Release
 on:
   push:
     tags:
-      - '*'  
+      - "*"
+
   workflow_dispatch:
     inputs:
       tag_name:
-        description: 'Enter Tag for the release'
+        description: "Enter Tag for the release"
         required: true
 
       prerelease:
-        description: 'Is this a pre-release?'
+        description: "Is this a pre-release?"
         required: true
         type: boolean
-        default: false 
+        default: false
+
+# https://typicode.github.io/husky/how-to.html#ci-server-and-docker
+env:
+  HUSKY: 0
 
 jobs:
   release_prereq:
@@ -31,7 +36,7 @@ jobs:
             arch: windows
       max-parallel: 3
     outputs:
-      tag_name: ${{ steps.determine_tag.outputs.tag_name }}  
+      tag_name: ${{ steps.determine_tag.outputs.tag_name }}
 
     steps:
       - name: Checkout code
@@ -60,8 +65,7 @@ jobs:
       - name: Run tests (Linux)
         if: matrix.arch == 'linux'
         working-directory: ./vscode
-        run: 
-          xvfb-run -a npm run test
+        run: xvfb-run -a npm run test
 
       # Run tests on macOS
       - name: Run tests (macOS)
@@ -95,7 +99,7 @@ jobs:
   release:
     name: Final Release
     runs-on: ubuntu-latest
-    needs: release_prereq  
+    needs: release_prereq
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Avoid installing our git hooks when running CI in github actions since the `lint-staged` work doesn't matter in CI.

See https://typicode.github.io/husky/how-to.html#ci-server-and-docker
