### PR TITLE
:ghost: use special kai-ide-reviewers as reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @konveyor/ui
+* @konveyor/kai-ide-reviewers


### PR DESCRIPTION
Created a team specifically for reviewing IDE related work. This PR makes them CODEOWNERS of this repository.