### PR TITLE
:seedling: Refactor shared package imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1518,10 +1518,6 @@
         "win32"
       ]
     },
-    "node_modules/@shared/types": {
-      "resolved": "shared",
-      "link": true
-    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
@@ -8663,7 +8659,7 @@
     },
     "shared": {
       "name": "@editor-extensions/shared",
-      "version": "1.0.0",
+      "version": "0.0.1",
       "devDependencies": {
         "rimraf": "^5.0.0",
         "typescript": "^5.0.0"
@@ -8673,7 +8669,6 @@
       "name": "editor-extensions-vscode",
       "version": "0.0.1",
       "dependencies": {
-        "@shared/types": "^1.0.0",
         "babel-loader": "^9.2.1",
         "diff": "^7.0.0"
       },
@@ -8781,7 +8776,6 @@
         "@patternfly/react-core": "6.0.0-prerelease.15",
         "@patternfly/react-icons": "^5.4.0",
         "@patternfly/react-table": "^5.4.1",
-        "@shared/types": "^1.0.0",
         "vscode-webview": "^1.0.1-beta.1"
       },
       "devDependencies": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "@editor-extensions/shared",
-    "version": "1.0.0",
-    "private": true,
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "scripts": {
-      "build": "tsc -b tsconfig.json",
-      "clean": "rimraf dist",
-      "prebuild": "npm run clean"
-    },
-    "devDependencies": {
-      "rimraf": "^5.0.0",
-      "typescript": "^5.0.0"
-    }
+  "name": "@editor-extensions/shared",
+  "version": "0.0.1",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b tsconfig.json",
+    "clean": "rimraf dist",
+    "prebuild": "npm run clean"
+  },
+  "devDependencies": {
+    "rimraf": "^5.0.0",
+    "typescript": "^5.0.0"
   }
+}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -473,7 +473,6 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "@shared/types": "^1.0.0",
     "babel-loader": "^9.2.1",
     "diff": "^7.0.0"
   }

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -2,7 +2,7 @@ import { ChildProcessWithoutNullStreams, exec, spawn } from "child_process";
 import * as vscode from "vscode";
 import * as os from "os";
 import * as fs from "fs";
-import { Incident, RuleSet } from "@shared/types";
+import { Incident, RuleSet } from "@editor-extensions/shared";
 
 import path from "path";
 

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -18,7 +18,7 @@ import {
   loadSolution,
   loadStaticResults,
 } from "./data";
-import { GetSolutionResult, RuleSet } from "@shared/types";
+import { GetSolutionResult, RuleSet } from "@editor-extensions/shared";
 import {
   applyAll,
   revertAll,

--- a/vscode/src/data/analyzerResults.ts
+++ b/vscode/src/data/analyzerResults.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as fs from "fs";
 import * as yaml from "js-yaml";
-import { RuleSet, Category, Incident } from "@shared/types";
+import { RuleSet, Category, Incident } from "@editor-extensions/shared";
 
 //Assuming that output is in form of yaml
 export function readYamlFile(filePath: string): RuleSet[] | undefined {

--- a/vscode/src/data/loadResults.ts
+++ b/vscode/src/data/loadResults.ts
@@ -1,4 +1,4 @@
-import { GetSolutionResult, RuleSet } from "@shared/types";
+import { GetSolutionResult, RuleSet } from "@editor-extensions/shared";
 import { processIncidents } from "./analyzerResults";
 import { ExtensionState } from "src/extensionState";
 import { writeDataFile } from "./storage";

--- a/vscode/src/data/loadStaticResults.ts
+++ b/vscode/src/data/loadStaticResults.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { RuleSet } from "@shared/types";
+import { RuleSet } from "@editor-extensions/shared";
 import { loadStateFromDataFolder, readDataFiles } from "./storage";
 
 export const loadStaticResults = async () => {

--- a/vscode/src/data/storage.ts
+++ b/vscode/src/data/storage.ts
@@ -2,7 +2,7 @@ import path from "path";
 import * as vscode from "vscode";
 import fs from "fs";
 
-import { RuleSet, GetSolutionResult } from "@shared/types";
+import { RuleSet, GetSolutionResult } from "@editor-extensions/shared";
 import {
   isAnalysis,
   isSolution,

--- a/vscode/src/data/virtualStorage.ts
+++ b/vscode/src/data/virtualStorage.ts
@@ -1,4 +1,4 @@
-import { GetSolutionResult } from "@shared/types";
+import { GetSolutionResult } from "@editor-extensions/shared";
 import { Uri, window, workspace } from "vscode";
 import { ExtensionState } from "src/extensionState";
 import * as Diff from "diff";

--- a/vscode/src/extensionState.ts
+++ b/vscode/src/extensionState.ts
@@ -4,7 +4,7 @@ import { MemFS } from "./data/fileSystemProvider";
 import { KonveyorGUIWebviewViewProvider } from "./KonveyorGUIWebviewViewProvider";
 import * as vscode from "vscode";
 import { LocalChange } from "./data/virtualStorage";
-import { RuleSet } from "@shared/types";
+import { RuleSet } from "@editor-extensions/shared";
 
 export class SharedState {
   private state: Map<string, any> = new Map();

--- a/vscode/src/test/analyzerResults.test.ts
+++ b/vscode/src/test/analyzerResults.test.ts
@@ -2,7 +2,7 @@ import * as assert from "assert";
 import { DiagnosticSeverity } from "vscode";
 import * as path from "path";
 import { processIncidents, readYamlFile } from "../data/analyzerResults";
-import { RuleSet } from "@shared/types";
+import { RuleSet } from "@editor-extensions/shared";
 
 suite("Extension Test Suite", () => {
   test("processIncidents should populate diagnostics correctly", () => {

--- a/vscode/src/utilities/typeGuards.ts
+++ b/vscode/src/utilities/typeGuards.ts
@@ -1,4 +1,4 @@
-import { GetSolutionResult, RuleSet } from "@shared/types";
+import { GetSolutionResult, RuleSet } from "@editor-extensions/shared";
 import { Uri } from "vscode";
 
 const isString = (obj: unknown): obj is string => typeof obj === "string";

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -14,8 +14,7 @@
     "@patternfly/react-core": "6.0.0-prerelease.15",
     "@patternfly/react-icons": "^5.4.0",
     "@patternfly/react-table": "^5.4.1",
-    "vscode-webview": "^1.0.1-beta.1",
-    "@shared/types": "^1.0.0"
+    "vscode-webview": "^1.0.1-beta.1"
   },
   "devDependencies": {
     "@types/vscode-webview": "^1.57.5",

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -20,7 +20,7 @@ import { vscode } from "./utils/vscode";
 import GuidedApproachWizard from "./components/GuidedApproachWizard";
 import ProgressIndicator from "./components/ProgressIndicator";
 import ViolationIncidentsList from "./components/ViolationIncidentsList";
-import { Incident, RuleSet } from "@shared/types";
+import { Incident, RuleSet } from "@editor-extensions/shared";
 
 const App: React.FC = () => {
   const [analysisResults, setAnalysisResults] = useState<RuleSet[] | null>();

--- a/webview-ui/src/components/GuidedApproachWizard.tsx
+++ b/webview-ui/src/components/GuidedApproachWizard.tsx
@@ -16,7 +16,7 @@ import {
 } from "@patternfly/react-core";
 import ViolationIncidentsList from "./ViolationIncidentsList";
 import { vscode } from "../utils/vscode";
-import { Incident, Violation } from "@shared/types/src/types";
+import { Incident, Violation } from "@editor-extensions/shared/src/types";
 
 interface GuidedApproachWizardProps {
   violations: Violation[];

--- a/webview-ui/src/components/ViolationIncidentsList.tsx
+++ b/webview-ui/src/components/ViolationIncidentsList.tsx
@@ -34,7 +34,7 @@ import {
   FileIcon,
   EllipsisVIcon,
 } from "@patternfly/react-icons";
-import { Incident, Violation } from "@shared/types";
+import { Incident, Violation } from "@editor-extensions/shared";
 
 type SortOption = "description" | "incidentCount" | "severity";
 


### PR DESCRIPTION
The `@shared/types` package does not actually exist. It was only working because there was a vestigial reference for it in the `package-lock.json` file from before the shared workspace package was renamed from `@shared/types` to `@editor-extensions/shared`. `@shared/types` was pointing to the shared workspace.

Fixes:
  - Remove the `@shared/types` reference in the lock file
  - Refactor all of the imports to pull from the current npm package name
