### PR TITLE
:sparkles: Support reviewing resolutions with merge editor

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -163,10 +163,22 @@
         "title": "Apply Block"
       },
       {
+        "command": "konveyor.diffView.applySelectionInline",
+        "icon": "$(check)",
+        "category": "diffEditor",
+        "title": "Apply Selection"
+      },
+      {
         "command": "konveyor.diffView.applyBlock",
         "icon": "$(arrow-left)",
         "category": "diffEditor",
         "title": "Apply Block"
+      },
+      {
+        "command": "konveyor.diffView.applySelection",
+        "icon": "$(arrow-left)",
+        "category": "diffEditor",
+        "title": "Apply Selection"
       }
     ],
     "submenus": [
@@ -262,26 +274,26 @@
       ],
       "diffEditor/gutter/selection": [
         {
-          "command": "konveyor.diffView.applyBlockInline",
+          "command": "konveyor.diffView.applySelectionInline",
           "group": "primary",
-          "when": "diffEditorModifiedWritable && diffEditorInlineMode && (diffEditorModifiedUri =~ /^konveyorMemFs\\:.*$/ || diffEditorOriginalUri =~ /^konveyorMemFs\\:.*$/)"
+          "when": "diffEditorInlineMode && ((diffEditorModifiedUri =~ /^konveyorMemFs\\:.*$/ && diffEditorOriginalWritable) || (diffEditorOriginalUri =~ /^konveyorMemFs\\:.*$/ && diffEditorModifiedWritable))"
         },
         {
-          "command": "konveyor.diffView.applyBlock",
+          "command": "konveyor.diffView.applySelection",
           "group": "primary",
-          "when": "diffEditorModifiedWritable && !diffEditorInlineMode && (diffEditorModifiedUri =~ /^konveyorMemFs\\:.*$/ || diffEditorOriginalUri =~ /^konveyorMemFs\\:.*$/)"
+          "when": "!diffEditorInlineMode && ((diffEditorModifiedUri =~ /^konveyorMemFs\\:.*$/ && diffEditorOriginalWritable) || (diffEditorOriginalUri =~ /^konveyorMemFs\\:.*$/ && diffEditorModifiedWritable))"
         }
       ],
       "diffEditor/gutter/hunk": [
         {
           "command": "konveyor.diffView.applyBlockInline",
           "group": "primary",
-          "when": "diffEditorModifiedWritable && diffEditorInlineMode && (diffEditorModifiedUri =~ /^konveyorMemFs\\:.*$/ || diffEditorOriginalUri =~ /^konveyorMemFs\\:.*$/)"
+          "when": "diffEditorInlineMode && ((diffEditorModifiedUri =~ /^konveyorMemFs\\:.*$/ && diffEditorOriginalWritable) || (diffEditorOriginalUri =~ /^konveyorMemFs\\:.*$/ && diffEditorModifiedWritable))"
         },
         {
           "command": "konveyor.diffView.applyBlock",
           "group": "primary",
-          "when": "diffEditorModifiedWritable && !diffEditorInlineMode && (diffEditorModifiedUri =~ /^konveyorMemFs\\:.*$/ || diffEditorOriginalUri =~ /^konveyorMemFs\\:.*$/)"
+          "when": "!diffEditorInlineMode && ((diffEditorModifiedUri =~ /^konveyorMemFs\\:.*$/ && diffEditorOriginalWritable) || (diffEditorOriginalUri =~ /^konveyorMemFs\\:.*$/ && diffEditorModifiedWritable))"
         }
       ],
       "explorer/context": [

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -355,6 +355,8 @@ const commandsMap: (state: ExtensionState) => {
     "konveyor.reloadLastResolutions": () => reloadLastResolutions(state),
     "konveyor.diffView.applyBlock": applyBlock,
     "konveyor.diffView.applyBlockInline": applyBlock,
+    "konveyor.diffView.applySelection": applyBlock,
+    "konveyor.diffView.applySelectionInline": applyBlock,
   };
 };
 

--- a/vscode/src/data/readOnlyStorage.ts
+++ b/vscode/src/data/readOnlyStorage.ts
@@ -1,0 +1,17 @@
+import {
+  CancellationToken,
+  Event,
+  ProviderResult,
+  TextDocumentContentProvider,
+  Uri,
+  workspace,
+} from "vscode";
+
+export default class KonveyorReadOnlyProvider implements TextDocumentContentProvider {
+  onDidChange?: Event<Uri> | undefined;
+  provideTextDocumentContent(uri: Uri, _token: CancellationToken): ProviderResult<string> {
+    return workspace.fs
+      .readFile(Uri.from({ ...uri, scheme: "file" }))
+      .then((buffer) => buffer?.toString() ?? "");
+  }
+}

--- a/vscode/src/diffView/register.ts
+++ b/vscode/src/diffView/register.ts
@@ -2,7 +2,8 @@ import * as vscode from "vscode";
 import { KonveyorTreeDataProvider } from "./fileModel";
 import { Navigation } from "./navigation";
 import { ExtensionState } from "src/extensionState";
-import { KONVEYOR_SCHEME } from "../utilities";
+import { KONVEYOR_READ_ONLY_SCHEME, KONVEYOR_SCHEME } from "../utilities";
+import KonveyorReadOnlyProvider from "../data/readOnlyStorage";
 
 export function registerDiffView({
   extensionContext: context,
@@ -29,4 +30,13 @@ export function registerDiffView({
   provider.onDidChangeTreeData(() => {
     treeView.message = model.message;
   });
+
+  const readOnlyProvider = new KonveyorReadOnlyProvider();
+
+  context.subscriptions.push(
+    vscode.workspace.registerTextDocumentContentProvider(
+      KONVEYOR_READ_ONLY_SCHEME,
+      readOnlyProvider,
+    ),
+  );
 }

--- a/vscode/src/utilities/constants.ts
+++ b/vscode/src/utilities/constants.ts
@@ -1,3 +1,4 @@
 export const KONVEYOR_SCHEME = "konveyorMemFs";
+export const KONVEYOR_READ_ONLY_SCHEME = "konveyorReadOnly";
 export const RULE_SET_DATA_FILE_PREFIX = "analysis";
 export const SOLUTION_DATA_FILE_PREFIX = "solution";


### PR DESCRIPTION
Changes:
1. add optional configuration property "diffEditorType". If set to
   "merge" then open resolutions using merge editor. Otherwise use
   the diff editor.
2. create text document content provider for serving read only virtual
   files to be used as left side of the merge. Register the provider
   under "konveyorReadOnly" scheme.
    
