### PR TITLE
:bug:  Reset Path

### DIFF
--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -139,16 +139,17 @@ const commandsMap: (state: ExtensionState) => {
       };
 
       const fileUri = await window.showOpenDialog(options);
-
+      const config = workspace.getConfiguration("konveyor");
       if (fileUri && fileUri[0]) {
         const filePath = fileUri[0].fsPath;
 
         // Update the user settings
-        const config = workspace.getConfiguration("konveyor");
         await config.update("analyzerPath", filePath, ConfigurationTarget.Global);
 
         window.showInformationMessage(`Analyzer binary path updated to: ${filePath}`);
       } else {
+        // Reset the setting to undefined or remove it
+        await config.update("analyzerPath", undefined, ConfigurationTarget.Global);
         window.showInformationMessage("No analyzer binary selected.");
       }
     },
@@ -163,16 +164,17 @@ const commandsMap: (state: ExtensionState) => {
       };
 
       const fileUri = await window.showOpenDialog(options);
-
+      const config = workspace.getConfiguration("konveyor");
       if (fileUri && fileUri[0]) {
         const filePath = fileUri[0].fsPath;
 
         // Update the user settings
-        const config = workspace.getConfiguration("konveyor");
         await config.update("kaiRpcServerPath", filePath, ConfigurationTarget.Global);
 
         window.showInformationMessage(`Kai rpc server binary path updated to: ${filePath}`);
       } else {
+        // Reset the setting to undefined or remove it
+        await config.update("kaiRpcServerPath", undefined, ConfigurationTarget.Global);
         window.showInformationMessage("No Kai rpc-server binary selected.");
       }
     },


### PR DESCRIPTION
Previously, when you selected a file to override the default path, the path was saved and couldn't be reset. With this update:

- If you open the file selection dialog but don’t choose a file, the path will reset to undefined.
- When no path is set, the default binary from the /assets/bin folder will be used.

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
