### PR TITLE
:seedling: Split `collect-assets.js` code, add `tar.gz` download

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "lint-staged": "^15.2.10",
         "prettier": "^3.3.3",
         "rimraf": "^6.0.1",
+        "tar": "^7.4.3",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.14.0",
         "unzipper": "^0.12.3"
@@ -1302,6 +1303,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -7534,6 +7548,52 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minizlib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
+      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.4",
+        "rimraf": "^5.0.5"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/minizlib/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -10083,6 +10143,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
@@ -10168,6 +10246,26 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/terser": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "lint-staged": "^15.2.10",
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
+    "tar": "^7.4.3",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.14.0",
     "unzipper": "^0.12.3"

--- a/scripts/_download.js
+++ b/scripts/_download.js
@@ -1,0 +1,208 @@
+import { join, extname, basename } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { createHash } from "node:crypto";
+import fs from "fs-extra";
+import unzipper from "unzipper";
+import * as tar from "tar";
+import { bold, green, yellow } from "colorette";
+import { chmodOwnerPlusX } from "./_util.js";
+
+const GITHUB_API = "https://api.github.com";
+
+/**
+ * Fetch the JSON metadata for a GitHub repository release.
+ *
+ * @param {string} org GitHub organization/user for the release
+ * @param {string} repo GitHub repository for the release
+ * @param {string} releaseTag The release's tag
+ * @returns {object}
+ */
+export async function getGitHubReleaseMetadata(org, repo, releaseTag) {
+  const url = `${GITHUB_API}/repos/${org}/${repo}/releases/tags/${releaseTag}`;
+  console.log(
+    `Fetching GitHub release metadata for ${yellow(`${org}/${repo}`)} release: ${yellow(releaseTag)}`,
+  );
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch release metadata: ${response.statusText}`);
+  }
+
+  return await response.json();
+}
+
+/**
+ * Fetch the commit sha for a GitHub repository release.
+ *
+ * @param {string} org GitHub organization/user for the release
+ * @param {string} repo GitHub repository for the release
+ * @param {string} releaseTag The release's tag
+ * @returns The release tag's commit sha
+ */
+export async function getGitHubReleaseTagSha(org, repo, releaseTag) {
+  const url = `${GITHUB_API}/repos/${org}/${repo}/commits/${releaseTag}`;
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github.sha",
+    },
+  });
+
+  return await response.text();
+}
+
+/**
+ * @param {string} targetFile
+ * @param {Response} fetchResponse
+ * @returns {Promise<string>} sha256 hash of the response data
+ */
+async function streamResponseToFile(targetFile, fetchResponse) {
+  const reader = Readable.fromWeb(fetchResponse.body);
+
+  // setup stream to file
+  const fileStream = fs.createWriteStream(targetFile);
+  const pipeToFile = pipeline(reader, fileStream);
+
+  // setup stream to calculate the sha256 hash of the file
+  const hash = createHash("sha256");
+  const pipeToHash = pipeline(reader, hash);
+
+  // run them both, reject if either rejects, resolve with the hash
+  try {
+    await Promise.all([pipeToFile, pipeToHash]);
+    return Promise.resolve(hash.digest("hex"));
+  } catch (e) {
+    return Promise.reject(e);
+  }
+}
+
+export async function downloadAndExtractGitHubAsset(
+  target,
+  gitHubReleaseAsset,
+  platform,
+  arch,
+  chmod = false,
+) {
+  const assetDir = join(target, `${platform}-${arch}`);
+  const assetFileName = join(assetDir, gitHubReleaseAsset.name);
+
+  await fs.ensureDir(assetDir);
+
+  console.log(`Downloading asset: ${gitHubReleaseAsset.name}`);
+  const response = await fetch(gitHubReleaseAsset.browser_download_url);
+  if (!response.ok) {
+    throw new Error(`Failed to download ${gitHubReleaseAsset.name}: ${response.statusText}`);
+  }
+  const sha256 = await streamResponseToFile(assetFileName, response);
+
+  console.log(`Asset sha256: ${green(sha256)}`);
+  console.log(`Extracting to: ${assetDir}`);
+  const zipFile = await unzipper.Open.file(assetFileName);
+  await zipFile.extract({ path: assetDir });
+
+  const extractedFiles = await fs.readdir(assetDir);
+  extractedFiles.forEach(async (file) => {
+    const oldPath = join(assetDir, file);
+    const newPath = join(assetDir, `${platform}-${file}`);
+    await fs.rename(oldPath, newPath);
+    if (chmod && extname(newPath) !== ".zip") {
+      chmodOwnerPlusX(newPath);
+    }
+  });
+
+  console.log(`Extracted: ${gitHubReleaseAsset.name}`);
+}
+
+export async function downloadGitHubRelease({
+  targetDirectory,
+  metaFile,
+  org,
+  repo,
+  releaseTag,
+  assets,
+}) {
+  try {
+    const releaseData = await getGitHubReleaseMetadata(org, repo, releaseTag);
+    const commitId = await getGitHubReleaseTagSha(org, repo, releaseTag);
+    const releaseAssets = releaseData.assets;
+
+    const metadata = {
+      org,
+      repo,
+      releaseTag,
+      commitId,
+      collectedAt: new Date().toISOString(),
+      assets: [],
+    };
+
+    for (const { name, platform, arch, chmod } of assets) {
+      const releaseAsset = releaseAssets.find((a) => a.name === name);
+      if (releaseAsset) {
+        try {
+          console.group(yellow(releaseAsset.name));
+          await downloadAndExtractGitHubAsset(targetDirectory, releaseAsset, platform, arch, chmod);
+        } finally {
+          console.groupEnd();
+        }
+        metadata.assets.push({
+          name: releaseAsset.name,
+          platform,
+          arch,
+          chmod: !!chmod,
+          updatedAt: releaseAsset.updated_at,
+        });
+      } else {
+        console.warn(`Asset [${name}] was not found in GitHub release ${releaseData.html_url}`);
+      }
+    }
+
+    await fs.writeJson(metaFile, metadata, { spaces: 2 });
+    console.log(`Metadata written to ${metaFile}`);
+    console.log(`All assets downloaded to: ${targetDirectory}`);
+  } catch (error) {
+    console.error("Error downloading the release:", error.message);
+  }
+}
+
+export async function downloadAndExtractTarGz({ targetDirectory, url, sha256 }) {
+  try {
+    console.group(yellow(url));
+    console.log(bold("Download:"), url, bold("To:"), targetDirectory);
+    await fs.ensureDir(targetDirectory);
+
+    // Download the tar.gz file
+    const fileName = basename(new URL(url).pathname);
+    const targetFile = join(targetDirectory, fileName);
+
+    console.log("Downloading:", yellow(fileName));
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to download ${url}: ${response.statusText}`);
+    }
+    const downloadSha256 = await streamResponseToFile(targetFile, response);
+
+    // If a sha256 is provided, verify against the downloaded file
+    console.log(`Asset sha256: ${green(downloadSha256)}`);
+    if (sha256) {
+      if (downloadSha256 === sha256) {
+        console.log(`${green("Verified!")} Asset's sha256 matches expected`);
+      } else {
+        throw new Error(
+          `Downloaded file ${targetFile} sha256 ${downloadSha256} does not match the expected sha256 ${sha256}`,
+        );
+      }
+    }
+
+    // Extract the tar.gz file
+    console.log(`Extracting to ${targetDirectory}`);
+    tar.extract({
+      f: targetFile,
+      z: true,
+      cwd: targetDirectory,
+    });
+  } catch (error) {
+    console.error("Error downloading/extracting tar.gz:", error);
+  } finally {
+    console.groupEnd();
+  }
+}

--- a/scripts/_util.js
+++ b/scripts/_util.js
@@ -1,9 +1,25 @@
 import process from "node:process";
 import path from "node:path";
+import fs from "node:fs";
+
 import { italic, gray } from "colorette";
 
+/**
+ * Change the process's cwd to the project root (as per the normal location of this file).
+ */
 export function cwdToProjectRoot() {
   const getProjectRoot = path.resolve(path.dirname(process.argv[1]), "..");
   process.chdir(getProjectRoot);
   console.log(gray(italic(`working from: ${getProjectRoot}`)));
+}
+
+/**
+ * `chmod` a file or directory to add owner execute permissions.  Same as
+ * running `chmod o+x {path}`.
+ *
+ * @param {string} path File or directory to chmod
+ */
+export function chmodOwnerPlusX(path) {
+  const { mode = fs.constants.S_IRUSR } = fs.statSync(path);
+  fs.chmodSync(path, mode | fs.constants.S_IXUSR);
 }

--- a/scripts/collect-assets.js
+++ b/scripts/collect-assets.js
@@ -1,128 +1,41 @@
 #! /usr/bin/env node
-import {
-  existsSync,
-  mkdirSync,
-  createWriteStream,
-  createReadStream,
-  writeFileSync,
-  readdirSync,
-  renameSync,
-} from "fs";
-import { resolve as _resolve, join, dirname } from "path";
-import { fileURLToPath } from "url";
-import { Extract } from "unzipper";
-import { Readable } from "stream";
+import { ensureDir } from "fs-extra/esm";
+import { resolve, join } from "path";
+import { cwdToProjectRoot } from "./_util.js";
+import { downloadAndExtractTarGz, downloadGitHubRelease } from "./_download.js";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+cwdToProjectRoot();
 
-const GITHUB_API = "https://api.github.com";
-const REPOSITORY = "konveyor/kai";
-const RELEASE_TAG = "v0.0.1";
-const DOWNLOAD_DIR = _resolve(__dirname, "../downloaded_assets");
-const META_FILE = _resolve(DOWNLOAD_DIR, "collect.json");
+// Setup download target
+const DOWNLOAD_DIR = resolve("downloaded_assets");
+await ensureDir(DOWNLOAD_DIR);
 
-const ASSETS_TO_DOWNLOAD = [
-  { name: "kai-rpc-server.linux-x86_64.zip", folder: "linux", platform: "linux" },
-  { name: "kai-rpc-server.macos-arm64.zip", folder: "macos-arm", platform: "macos-arm" },
-  { name: "kai-rpc-server.macos-x86_64.zip", folder: "macos-x86", platform: "macos-x86" },
-  { name: "kai-rpc-server.windows-x86_64.zip", folder: "windows", platform: "windows" },
-];
+// Download Kai assets
+await downloadGitHubRelease({
+  targetDirectory: join(DOWNLOAD_DIR, "kai/"),
+  metaFile: join(DOWNLOAD_DIR, "collect.json"),
 
-if (!existsSync(DOWNLOAD_DIR)) {
-  mkdirSync(DOWNLOAD_DIR, { recursive: true });
-}
+  org: "konveyor",
+  repo: "kai",
+  releaseTag: "v0.0.1",
 
-async function getReleaseMetadata() {
-  const url = `${GITHUB_API}/repos/${REPOSITORY}/releases/tags/${RELEASE_TAG}`;
-  console.log(`Fetching release metadata for tag: ${RELEASE_TAG}`);
+  /*
+    Release asset filenames and nodejs equivalent platform/arch
+      platform: https://nodejs.org/docs/latest-v22.x/api/process.html#processplatform
+      arch: https://nodejs.org/docs/latest-v22.x/api/process.html#processarch
+  */
+  assets: [
+    { name: "kai-rpc-server.linux-x86_64.zip", platform: "linux", arch: "x64", chmod: true },
+    { name: "kai-rpc-server.macos-arm64.zip", platform: "darwin", arch: "arm64", chmod: true },
+    { name: "kai-rpc-server.macos-x86_64.zip", platform: "darwin", arch: "x64", chmod: true },
+    { name: "kai-rpc-server.windows-x86_64.zip", platform: "win32", arch: "x64" },
+  ],
+});
 
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch release metadata: ${response.statusText}`);
-  }
-
-  return await response.json();
-}
-
-async function downloadAndExtractAsset(asset, folder, platform) {
-  const platformDir = join(DOWNLOAD_DIR, folder);
-  const assetPath = join(platformDir, asset.name);
-
-  if (!existsSync(platformDir)) {
-    mkdirSync(platformDir, { recursive: true });
-  }
-
-  console.log(`Downloading asset: ${asset.name}`);
-  const response = await fetch(asset.browser_download_url);
-  if (!response.ok) {
-    throw new Error(`Failed to download ${asset.name}: ${response.statusText}`);
-  }
-
-  const fileStream = createWriteStream(assetPath);
-  await new Promise((resolve, reject) => {
-    const reader = Readable.fromWeb(response.body);
-    reader.pipe(fileStream);
-    reader.on("error", reject);
-    fileStream.on("finish", resolve);
-  });
-
-  console.log(`Extracting asset: ${asset.name} to ${platformDir}`);
-  await createReadStream(assetPath)
-    .pipe(Extract({ path: platformDir }))
-    .promise();
-
-  const extractedFiles = readdirSync(platformDir);
-  extractedFiles.forEach((file) => {
-    const oldPath = join(platformDir, file);
-    const newPath = join(platformDir, `${platform}-${file}`);
-    renameSync(oldPath, newPath);
-  });
-
-  console.log(`Extracted files for: ${asset.name}`);
-}
-
-try {
-  const releaseData = await getReleaseMetadata();
-  const commitId = await getReleaseTagSha();
-  const assets = releaseData.assets;
-
-  const metadata = {
-    releaseTag: RELEASE_TAG,
-    commitId,
-    collectedAt: new Date().toISOString(),
-    assets: [],
-  };
-
-  for (const { name, folder, platform } of ASSETS_TO_DOWNLOAD) {
-    const asset = assets.find((a) => a.name === name);
-    if (asset) {
-      await downloadAndExtractAsset(asset, folder, platform);
-      metadata.assets.push({
-        name: asset.name,
-        updatedAt: asset.updated_at,
-        folder: folder,
-        platform: platform,
-      });
-    } else {
-      console.warn(`Asset not found: ${name}`);
-    }
-  }
-
-  writeFileSync(META_FILE, JSON.stringify(metadata, null, 2));
-  console.log(`Metadata written to ${META_FILE}`);
-  console.log(`All assets downloaded to: ${DOWNLOAD_DIR}`);
-} catch (error) {
-  console.error("Error:", error.message);
-}
-
-async function getReleaseTagSha() {
-  const url = `${GITHUB_API}/repos/${REPOSITORY}/commits/${RELEASE_TAG}`;
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/vnd.github.sha",
-    },
-  });
-
-  return await response.text();
-}
+// Download JDT.LS
+// Base release url: https://download.eclipse.org/jdtls/milestones/1.38.0/
+await downloadAndExtractTarGz({
+  targetDirectory: join(DOWNLOAD_DIR, "jdt.ls-1.38.0/"),
+  url: "https://download.eclipse.org/jdtls/milestones/1.38.0/jdt-language-server-1.38.0-202408011337.tar.gz",
+  sha256: "ba697788a19f2ba57b16302aba6b343c649928c95f76b0d170494ac12d17ac78",
+});


### PR DESCRIPTION
Split the contents of `collect-assets.js` into two files. The base file has the release details.  The new `_download.js` file has the functions that do the download and extract work.

This split helps keep the `collect-assets.js` script as small as possible to make future configuration changes easier.
