### PR TITLE
:sparkles: Retrieve the list of modified files from the diff

### DIFF
--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -94,7 +94,7 @@ export interface LocalChange {
 
 export interface ResolutionMessage {
   type: string;
-  solution: GetSolutionResult;
+  solution: Solution;
   violation: Violation;
   incident: Incident;
   isRelevantSolution: boolean;
@@ -107,3 +107,5 @@ export interface SolutionResponse {
   incident: Incident;
   violation: Violation;
 }
+
+export type Solution = GetSolutionResult | SolutionResponse;

--- a/vscode/src/data/loadResults.ts
+++ b/vscode/src/data/loadResults.ts
@@ -1,4 +1,4 @@
-import { LocalChange, RuleSet, SolutionResponse } from "@editor-extensions/shared";
+import { LocalChange, RuleSet, Solution } from "@editor-extensions/shared";
 import { processIncidents } from "./analyzerResults";
 import { ExtensionState } from "src/extensionState";
 import { writeDataFile } from "./storage";
@@ -24,7 +24,7 @@ export const cleanRuleSets = (state: ExtensionState) => {
   });
 };
 
-export const loadSolution = async (state: ExtensionState, solution: SolutionResponse) => {
+export const loadSolution = async (state: ExtensionState, solution: Solution) => {
   console.log("what is solution here in loadSolution", solution);
 
   await writeDataFile(solution, SOLUTION_DATA_FILE_PREFIX);

--- a/vscode/src/data/storage.ts
+++ b/vscode/src/data/storage.ts
@@ -2,7 +2,7 @@ import path from "path";
 import * as vscode from "vscode";
 import fs from "fs";
 
-import { RuleSet, GetSolutionResult, SolutionResponse } from "@editor-extensions/shared";
+import { RuleSet, Solution } from "@editor-extensions/shared";
 import {
   isAnalysis,
   isSolution,
@@ -65,7 +65,7 @@ const deleteOldestDataFiles = async (prefix: string, maxCount: number) => {
 };
 
 export async function writeDataFile(
-  content: RuleSet[] | SolutionResponse,
+  content: RuleSet[] | Solution,
   prefix: string,
   format: "json" = "json",
 ) {
@@ -87,11 +87,11 @@ export async function writeDataFile(
     Buffer.from(JSON.stringify(content, undefined, 2)),
   );
 
-  // deleteOldestDataFiles(prefix, MAX_FILES);
+  deleteOldestDataFiles(prefix, MAX_FILES);
 }
 
 export const loadStateFromDataFolder = async (): Promise<
-  [RuleSet[] | undefined, GetSolutionResult | undefined]
+  [RuleSet[] | undefined, Solution | undefined]
 > => {
   const dataFolder = getDataFolder();
   if (!dataFolder) {
@@ -113,7 +113,7 @@ export const loadStateFromDataFolder = async (): Promise<
 
 export const readDataFiles = async (
   uris: vscode.Uri[],
-): Promise<[RuleSet[] | undefined, GetSolutionResult | undefined]> => {
+): Promise<[RuleSet[] | undefined, Solution | undefined]> => {
   let analysisResults = undefined;
   let solution = undefined;
   for (const uri of uris) {

--- a/vscode/src/utilities/typeGuards.ts
+++ b/vscode/src/utilities/typeGuards.ts
@@ -1,11 +1,11 @@
-import { GetSolutionResult, RuleSet } from "@editor-extensions/shared";
+import { GetSolutionResult, RuleSet, Solution, SolutionResponse } from "@editor-extensions/shared";
 import { Uri } from "vscode";
 
 const isString = (obj: unknown): obj is string => typeof obj === "string";
 const isEmpty = (obj: unknown) => isObject(obj) && Object.keys(obj).length === 0;
 const isObject = (obj: unknown): obj is object => typeof obj === "object";
 
-export function isSolution(object: unknown): object is GetSolutionResult {
+export function isGetSolutionResult(object: unknown): object is GetSolutionResult {
   if (!object || typeof object !== "object") {
     return false;
   }
@@ -52,4 +52,13 @@ export function isUri(obj: unknown): obj is Uri {
   }
   const uri = obj as Uri;
   return !!(uri["toJSON"] && uri["with"] && uri.scheme);
+}
+
+export function isSolutionResponse(obj: unknown): obj is SolutionResponse {
+  const response = obj as SolutionResponse;
+  return isString(response.diff) && Array.isArray(response.modified_files);
+}
+
+export function isSolution(obj: unknown): obj is Solution {
+  return isGetSolutionResult(obj) || isSolutionResponse(obj);
 }


### PR DESCRIPTION
Map solution response to internal format using only information from the provided diff.

Main advantages:
1. automatically map files to corresponding diffs - apply/discard operations are file based and require single-file diff
2. allows incremental update to support add/delete/rename
3. file paths in git diffs are relative to repository root which usually maps to VS Code workspace

Main disadvantage is increasing the dependency on the git diff format.

Reference-Url: https://github.com/konveyor/kai/issues/502
