### PR TITLE
:sparkles:  Reintroduce multi-file support

### DIFF
--- a/mocks/coolstore_fixEverywhere_javax_ejb_Stateless.json
+++ b/mocks/coolstore_fixEverywhere_javax_ejb_Stateless.json
@@ -1,35 +1,50 @@
 {
-    "errors": [],
-    "changes": [
-        {
-            "original": "pom.xml",
-            "modified": "pom.xml",
-            "diff": "diff --git a/pom.xml b/pom.xml\nindex 0e760b8..afa5e9c 100644\n--- a/pom.xml\n+++ b/pom.xml\n@@ -21,6 +21,11 @@\n             <version>7.0</version>\n             <scope>provided</scope>\n         </dependency>\n+        <dependency>\n+            <groupId>jakarta.enterprise</groupId>\n+            <artifactId>jakarta.enterprise.cdi-api</artifactId>\n+            <version>4.1.0</version>\n+        </dependency>\n         <dependency>\n             <groupId>javax</groupId>\n             <artifactId>javaee-api</artifactId>\n"
-        },
-        {
-            "original": "src/main/java/com/redhat/coolstore/service/CatalogService.java",
-            "modified": "src/main/java/com/redhat/coolstore/service/CatalogService.java",
-            "diff": "diff --git a/src/main/java/com/redhat/coolstore/service/CatalogService.java b/src/main/java/com/redhat/coolstore/service/CatalogService.java\nindex 422a3f4..9a6feff 100644\n--- a/src/main/java/com/redhat/coolstore/service/CatalogService.java\n+++ b/src/main/java/com/redhat/coolstore/service/CatalogService.java\n@@ -9,12 +9,12 @@ import javax.persistence.criteria.CriteriaBuilder;\n import javax.persistence.criteria.CriteriaQuery;\n import javax.persistence.criteria.Root;\n \n-import javax.ejb.Stateless;\n+import jakarta.enterprise.context.ApplicationScoped;\n import javax.persistence.EntityManager;\n \n import com.redhat.coolstore.model.*;\n \n-@Stateless\n+@ApplicationScoped\n public class CatalogService {\n \n     @Inject\n"
-        },
-        {
-            "original": "src/main/java/com/redhat/coolstore/service/OrderService.java",
-            "modified": "src/main/java/com/redhat/coolstore/service/OrderService.java",
-            "diff": "diff --git a/src/main/java/com/redhat/coolstore/service/OrderService.java b/src/main/java/com/redhat/coolstore/service/OrderService.java\nindex 748e413..07ad379 100644\n--- a/src/main/java/com/redhat/coolstore/service/OrderService.java\n+++ b/src/main/java/com/redhat/coolstore/service/OrderService.java\n@@ -2,14 +2,14 @@ package com.redhat.coolstore.service;\n \n import com.redhat.coolstore.model.Order;\n import java.util.List;\n-import javax.ejb.Stateless;\n+import jakarta.enterprise.context.ApplicationScoped;\n import javax.inject.Inject;\n import javax.persistence.EntityManager;\n import javax.persistence.criteria.CriteriaBuilder;\n import javax.persistence.criteria.CriteriaQuery;\n import javax.persistence.criteria.Root;\n \n-@Stateless\n+@ApplicationScoped\n public class OrderService {\n \n   @Inject\n"
-        },
-        {
-            "original": "src/main/java/com/redhat/coolstore/service/ProductService.java",
-            "modified": "src/main/java/com/redhat/coolstore/service/ProductService.java",
-            "diff": "diff --git a/src/main/java/com/redhat/coolstore/service/ProductService.java b/src/main/java/com/redhat/coolstore/service/ProductService.java\nindex 33002fd..0e4b157 100644\n--- a/src/main/java/com/redhat/coolstore/service/ProductService.java\n+++ b/src/main/java/com/redhat/coolstore/service/ProductService.java\n@@ -4,14 +4,14 @@ import com.redhat.coolstore.model.CatalogItemEntity;\n import com.redhat.coolstore.model.Product;\n import com.redhat.coolstore.utils.Transformers;\n \n-import javax.ejb.Stateless;\n+import jakarta.enterprise.context.ApplicationScoped;\n import javax.inject.Inject;\n import java.util.List;\n import java.util.stream.Collectors;\n \n import static com.redhat.coolstore.utils.Transformers.toProduct;\n \n-@Stateless\n+@ApplicationScoped\n public class ProductService {\n \n     @Inject\n"
-        },
-        {
-            "original": "src/main/java/com/redhat/coolstore/service/ShippingService.java",
-            "modified": "src/main/java/com/redhat/coolstore/service/ShippingService.java",
-            "diff": "diff --git a/src/main/java/com/redhat/coolstore/service/ShippingService.java b/src/main/java/com/redhat/coolstore/service/ShippingService.java\nindex c820fcd..d92ef4f 100644\n--- a/src/main/java/com/redhat/coolstore/service/ShippingService.java\n+++ b/src/main/java/com/redhat/coolstore/service/ShippingService.java\n@@ -4,11 +4,11 @@ import java.math.BigDecimal;\n import java.math.RoundingMode;\n \n import javax.ejb.Remote;\n-import javax.ejb.Stateless;\n+import jakarta.enterprise.context.ApplicationScoped;\n \n import com.redhat.coolstore.model.ShoppingCart;\n \n-@Stateless\n+@ApplicationScoped\n @Remote\n public class ShippingService implements ShippingServiceRemote {\n \n"
-        },
-        {
-            "original": "src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java",
-            "modified": "src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java",
-            "diff": "diff --git a/src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java b/src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java\nindex e6ee388..5f9a1b6 100644\n--- a/src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java\n+++ b/src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java\n@@ -1,7 +1,7 @@\n package com.redhat.coolstore.service;\n \n import java.util.logging.Logger;\n-import javax.ejb.Stateless;\n+import jakarta.enterprise.context.ApplicationScoped;\n import javax.annotation.Resource;\n import javax.inject.Inject;\n import javax.jms.JMSContext;\n@@ -10,7 +10,7 @@ import javax.jms.Topic;\n import com.redhat.coolstore.model.ShoppingCart;\n import com.redhat.coolstore.utils.Transformers;\n \n-@Stateless\n+@ApplicationScoped\n public class ShoppingCartOrderProcessor  {\n \n     @Inject\n"
-        }
-    ]
+  "encountered_errors": [],
+  "scope": {
+    "incident": {
+      "uri": "src/main/java/com/redhat/coolstore/service/CatalogService.java",
+      "message": "Replace the `javax.ejb` import statement with `jakarta.ejb`",
+      "codeSnip": " 2  \n 3  import java.util.List;\n 4  import java.util.logging.Logger;\n 5  \n 6  import javax.inject.Inject;\n 7  \n 8  import javax.persistence.criteria.CriteriaBuilder;\n 9  import javax.persistence.criteria.CriteriaQuery;\n10  import javax.persistence.criteria.Root;\n11  \n12  import javax.ejb.Stateless;\n13  import javax.persistence.EntityManager;\n14  \n15  import com.redhat.coolstore.model.*;\n16  \n17  @Stateless\n18  public class CatalogService {\n19  \n20      @Inject\n21      Logger log;\n22  ",
+      "lineNumber": 12,
+      "variables": {
+        "file": "src/main/java/com/redhat/coolstore/service/CatalogService.java",
+        "kind": "Module",
+        "name": "javax.ejb.Stateless",
+        "package": "com.redhat.coolstore.service",
+        "renamed": "ejb"
+      }
+    }
+  },
+  "changes": [
+    {
+      "original": "pom.xml",
+      "modified": "pom.xml",
+      "diff": "diff --git a/pom.xml b/pom.xml\nindex 0e760b8..afa5e9c 100644\n--- a/pom.xml\n+++ b/pom.xml\n@@ -21,6 +21,11 @@\n             <version>7.0</version>\n             <scope>provided</scope>\n         </dependency>\n+        <dependency>\n+            <groupId>jakarta.enterprise</groupId>\n+            <artifactId>jakarta.enterprise.cdi-api</artifactId>\n+            <version>4.1.0</version>\n+        </dependency>\n         <dependency>\n             <groupId>javax</groupId>\n             <artifactId>javaee-api</artifactId>\n"
+    },
+    {
+      "original": "src/main/java/com/redhat/coolstore/service/CatalogService.java",
+      "modified": "src/main/java/com/redhat/coolstore/service/CatalogService.java",
+      "diff": "diff --git a/src/main/java/com/redhat/coolstore/service/CatalogService.java b/src/main/java/com/redhat/coolstore/service/CatalogService.java\nindex 422a3f4..9a6feff 100644\n--- a/src/main/java/com/redhat/coolstore/service/CatalogService.java\n+++ b/src/main/java/com/redhat/coolstore/service/CatalogService.java\n@@ -9,12 +9,12 @@ import javax.persistence.criteria.CriteriaBuilder;\n import javax.persistence.criteria.CriteriaQuery;\n import javax.persistence.criteria.Root;\n \n-import javax.ejb.Stateless;\n+import jakarta.enterprise.context.ApplicationScoped;\n import javax.persistence.EntityManager;\n \n import com.redhat.coolstore.model.*;\n \n-@Stateless\n+@ApplicationScoped\n public class CatalogService {\n \n     @Inject\n"
+    },
+    {
+      "original": "src/main/java/com/redhat/coolstore/service/OrderService.java",
+      "modified": "src/main/java/com/redhat/coolstore/service/OrderService.java",
+      "diff": "diff --git a/src/main/java/com/redhat/coolstore/service/OrderService.java b/src/main/java/com/redhat/coolstore/service/OrderService.java\nindex 748e413..07ad379 100644\n--- a/src/main/java/com/redhat/coolstore/service/OrderService.java\n+++ b/src/main/java/com/redhat/coolstore/service/OrderService.java\n@@ -2,14 +2,14 @@ package com.redhat.coolstore.service;\n \n import com.redhat.coolstore.model.Order;\n import java.util.List;\n-import javax.ejb.Stateless;\n+import jakarta.enterprise.context.ApplicationScoped;\n import javax.inject.Inject;\n import javax.persistence.EntityManager;\n import javax.persistence.criteria.CriteriaBuilder;\n import javax.persistence.criteria.CriteriaQuery;\n import javax.persistence.criteria.Root;\n \n-@Stateless\n+@ApplicationScoped\n public class OrderService {\n \n   @Inject\n"
+    },
+    {
+      "original": "src/main/java/com/redhat/coolstore/service/ProductService.java",
+      "modified": "src/main/java/com/redhat/coolstore/service/ProductService.java",
+      "diff": "diff --git a/src/main/java/com/redhat/coolstore/service/ProductService.java b/src/main/java/com/redhat/coolstore/service/ProductService.java\nindex 33002fd..0e4b157 100644\n--- a/src/main/java/com/redhat/coolstore/service/ProductService.java\n+++ b/src/main/java/com/redhat/coolstore/service/ProductService.java\n@@ -4,14 +4,14 @@ import com.redhat.coolstore.model.CatalogItemEntity;\n import com.redhat.coolstore.model.Product;\n import com.redhat.coolstore.utils.Transformers;\n \n-import javax.ejb.Stateless;\n+import jakarta.enterprise.context.ApplicationScoped;\n import javax.inject.Inject;\n import java.util.List;\n import java.util.stream.Collectors;\n \n import static com.redhat.coolstore.utils.Transformers.toProduct;\n \n-@Stateless\n+@ApplicationScoped\n public class ProductService {\n \n     @Inject\n"
+    },
+    {
+      "original": "src/main/java/com/redhat/coolstore/service/ShippingService.java",
+      "modified": "src/main/java/com/redhat/coolstore/service/ShippingService.java",
+      "diff": "diff --git a/src/main/java/com/redhat/coolstore/service/ShippingService.java b/src/main/java/com/redhat/coolstore/service/ShippingService.java\nindex c820fcd..d92ef4f 100644\n--- a/src/main/java/com/redhat/coolstore/service/ShippingService.java\n+++ b/src/main/java/com/redhat/coolstore/service/ShippingService.java\n@@ -4,11 +4,11 @@ import java.math.BigDecimal;\n import java.math.RoundingMode;\n \n import javax.ejb.Remote;\n-import javax.ejb.Stateless;\n+import jakarta.enterprise.context.ApplicationScoped;\n \n import com.redhat.coolstore.model.ShoppingCart;\n \n-@Stateless\n+@ApplicationScoped\n @Remote\n public class ShippingService implements ShippingServiceRemote {\n \n"
+    },
+    {
+      "original": "src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java",
+      "modified": "src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java",
+      "diff": "diff --git a/src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java b/src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java\nindex e6ee388..5f9a1b6 100644\n--- a/src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java\n+++ b/src/main/java/com/redhat/coolstore/service/ShoppingCartOrderProcessor.java\n@@ -1,7 +1,7 @@\n package com.redhat.coolstore.service;\n \n import java.util.logging.Logger;\n-import javax.ejb.Stateless;\n+import jakarta.enterprise.context.ApplicationScoped;\n import javax.annotation.Resource;\n import javax.inject.Inject;\n import javax.jms.JMSContext;\n@@ -10,7 +10,7 @@ import javax.jms.Topic;\n import com.redhat.coolstore.model.ShoppingCart;\n import com.redhat.coolstore.utils.Transformers;\n \n-@Stateless\n+@ApplicationScoped\n public class ShoppingCartOrderProcessor  {\n \n     @Inject\n"
+    }
+  ]
 }

--- a/mocks/coolstore_fix_catalog_source_javax_ejb_Stateless.json
+++ b/mocks/coolstore_fix_catalog_source_javax_ejb_Stateless.json
@@ -1,5 +1,20 @@
 {
-  "errors": [],
+  "encountered_errors": [],
+  "scope": {
+    "incident": {
+      "uri": "src/main/java/com/redhat/coolstore/service/CatalogService.java",
+      "message": "Replace the `javax.ejb` import statement with `jakarta.ejb`",
+      "codeSnip": " 2  \n 3  import java.util.List;\n 4  import java.util.logging.Logger;\n 5  \n 6  import javax.inject.Inject;\n 7  \n 8  import javax.persistence.criteria.CriteriaBuilder;\n 9  import javax.persistence.criteria.CriteriaQuery;\n10  import javax.persistence.criteria.Root;\n11  \n12  import javax.ejb.Stateless;\n13  import javax.persistence.EntityManager;\n14  \n15  import com.redhat.coolstore.model.*;\n16  \n17  @Stateless\n18  public class CatalogService {\n19  \n20      @Inject\n21      Logger log;\n22  ",
+      "lineNumber": 12,
+      "variables": {
+        "file": "src/main/java/com/redhat/coolstore/service/CatalogService.java",
+        "kind": "Module",
+        "name": "javax.ejb.Stateless",
+        "package": "com.redhat.coolstore.service",
+        "renamed": "ejb"
+      }
+    }
+  },
   "changes": [
     {
       "original": "src/main/java/com/redhat/coolstore/service/CatalogService.java",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8379,6 +8379,12 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -11634,6 +11640,7 @@
         "@patternfly/react-core": "6.0.0-prerelease.15",
         "@patternfly/react-icons": "^5.4.0",
         "@patternfly/react-table": "^5.4.1",
+        "path-browserify": "^1.0.1",
         "vscode-webview": "^1.0.1-beta.1"
       },
       "devDependencies": {

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -81,8 +81,9 @@ export interface Change {
 }
 
 export interface GetSolutionResult {
-  errors: string[];
+  encountered_errors: string[];
   changes: Change[];
+  scope: Scope;
 }
 
 export interface LocalChange {
@@ -104,8 +105,11 @@ export interface SolutionResponse {
   diff: string;
   encountered_errors: string[];
   modified_files: string[];
+}
+
+export interface Scope {
   incident: Incident;
-  violation: Violation;
+  violation?: Violation;
 }
 
 export type Solution = GetSolutionResult | SolutionResponse;

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -19,7 +19,7 @@ import {
   loadStaticResults,
   reloadLastResolutions,
 } from "./data";
-import { Incident, RuleSet, SolutionResponse, Violation } from "@editor-extensions/shared";
+import { Incident, RuleSet, Scope, Solution, Violation } from "@editor-extensions/shared";
 import {
   applyAll,
   discardAll,
@@ -49,26 +49,20 @@ const commandsMap: (state: ExtensionState) => {
   return {
     "konveyor.startAnalyzer": async () => {
       const analyzerClient = state.analyzerClient;
-      if (!(await analyzerClient.canAnalyze())) {
+      if (!(await analyzerClient.canAnalyzeInteractive())) {
         return;
       }
 
-      await analyzerClient.start(state);
-      await analyzerClient.initialize(state);
+      await analyzerClient.start();
+      await analyzerClient.initialize();
     },
     "konveyor.runAnalysis": async () => {
       const analyzerClient = state.analyzerClient;
-      if (!analyzerClient || !(await analyzerClient.canAnalyze())) {
-        window.showErrorMessage("Analyzer must be started before run!");
+      if (!analyzerClient || !analyzerClient.canAnalyze()) {
+        window.showErrorMessage("Analyzer must be started and configured before run!");
         return;
       }
-      if (fullScreenPanel && fullScreenPanel.webview) {
-        analyzerClient.runAnalysis(fullScreenPanel.webview, state);
-      } else if (sidebarProvider?.webview) {
-        analyzerClient.runAnalysis(sidebarProvider.webview, state);
-      } else {
-        window.showErrorMessage("No webview available to run analysis!");
-      }
+      analyzerClient.runAnalysis();
     },
     "konveyor.getSolution": async (incident: Incident, violation: Violation) => {
       const analyzerClient = state.analyzerClient;
@@ -351,7 +345,8 @@ const commandsMap: (state: ExtensionState) => {
     "konveyor.cleanRuleSets": () => cleanRuleSets(state),
     "konveyor.loadStaticResults": loadStaticResults,
     "konveyor.loadResultsFromDataFolder": loadResultsFromDataFolder,
-    "konveyor.loadSolution": async (solution: SolutionResponse) => loadSolution(state, solution),
+    "konveyor.loadSolution": async (solution: Solution, scope?: Scope) =>
+      loadSolution(state, solution, scope),
     "konveyor.applyAll": async () => applyAll(state),
     "konveyor.applyFile": async (item: FileItem | Uri) => applyFile(item, state),
     "konveyor.copyDiff": async (item: FileItem | Uri) => copyDiff(item, state),

--- a/vscode/src/extensionState.ts
+++ b/vscode/src/extensionState.ts
@@ -3,7 +3,7 @@ import { KonveyorFileModel } from "./diffView";
 import { MemFS } from "./data/fileSystemProvider";
 import { KonveyorGUIWebviewViewProvider } from "./KonveyorGUIWebviewViewProvider";
 import * as vscode from "vscode";
-import { LocalChange, RuleSet, SolutionResponse } from "@editor-extensions/shared";
+import { LocalChange, RuleSet, Scope, Solution } from "@editor-extensions/shared";
 import { Immutable } from "immer";
 
 export interface ExtensionData {
@@ -13,7 +13,18 @@ export interface ExtensionData {
   isAnalyzing: boolean;
   isFetchingSolution: boolean;
   isStartingServer: boolean;
-  solutionData?: SolutionResponse;
+  serverState: ServerState;
+  solutionData?: Solution;
+  solutionScope?: Scope;
+}
+
+export enum ServerState {
+  Initial = "initial",
+  Starting = "starting",
+  StartFailed = "startFailed",
+  Running = "running",
+  Stopping = "stopping",
+  Stopped = "stopped",
 }
 
 export interface ExtensionState {

--- a/vscode/src/utilities/typeGuards.ts
+++ b/vscode/src/utilities/typeGuards.ts
@@ -10,13 +10,14 @@ export function isGetSolutionResult(object: unknown): object is GetSolutionResul
     return false;
   }
 
-  const { errors, changes, ...rest } = object as GetSolutionResult;
+  const { encountered_errors, changes, scope, ...rest } = object as GetSolutionResult;
 
   return (
-    Array.isArray(errors) &&
+    Array.isArray(encountered_errors) &&
     Array.isArray(changes) &&
+    isObject(scope) &&
     isEmpty(rest) &&
-    errors.every(isString) &&
+    encountered_errors.every(isString) &&
     changes.every(isObject) &&
     changes.every(
       ({ diff, original, modified, ...rest }) =>

--- a/vscode/src/webviewMessageHandler.ts
+++ b/vscode/src/webviewMessageHandler.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { ExtensionState } from "./extensionState";
-import path from "path";
+import { LocalChange } from "@editor-extensions/shared";
 
 export function setupWebviewMessageListener(webview: vscode.Webview, state: ExtensionState) {
   webview.onDidReceiveMessage(async (message) => {
@@ -25,47 +25,29 @@ export function setupWebviewMessageListener(webview: vscode.Webview, state: Exte
         break;
       }
       case "viewFix": {
-        const { change, incident } = message;
-        let incidentUri: vscode.Uri;
-
-        if (incident.uri.startsWith("file://")) {
-          incidentUri = vscode.Uri.parse(incident.uri);
-        } else {
-          incidentUri = vscode.Uri.file(incident.uri);
-        }
-        vscode.commands.executeCommand("konveyor.diffView.viewFix", incidentUri, true);
+        vscode.commands.executeCommand(
+          "konveyor.diffView.viewFix",
+          vscode.Uri.from((message.change as LocalChange).originalUri),
+          true,
+        );
         break;
       }
       case "applyFile": {
-        console.log("applyFile WHAT IS CHANGE", message.filePath, message);
-        const filePath = message.filePath;
-
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-        if (!workspaceFolder) {
-          vscode.window.showErrorMessage("No workspace folder is open.");
-          break;
-        }
-
-        let currentURI: vscode.Uri;
-
-        console.log("applyFile WHAT IS FILEPATH", filePath);
-
-        if (path.isAbsolute(filePath)) {
-          console.log("applyFile IS ABSOLUTE");
-          currentURI = vscode.Uri.file(filePath);
-          console.log("applyFile WHAT IS CURRENTURI", currentURI);
-        } else {
-          console.log("applyFile IS NOT ABSOLUTE");
-          const absolutePath = path.resolve(workspaceFolder.uri.fsPath, filePath);
-          currentURI = vscode.Uri.file(absolutePath);
-          console.log("applyFile WHAT IS CURRENTURI", currentURI);
-        }
-
-        vscode.commands.executeCommand("konveyor.applyFile", currentURI, true);
-
+        vscode.commands.executeCommand(
+          "konveyor.applyFile",
+          vscode.Uri.from((message.change as LocalChange).originalUri),
+          true,
+        );
         break;
       }
-
+      case "discardFile": {
+        vscode.commands.executeCommand(
+          "konveyor.discardFile",
+          vscode.Uri.from((message.change as LocalChange).originalUri),
+          true,
+        );
+        break;
+      }
       case "requestQuickfix": {
         const { uri, line } = message.data;
         await handleRequestQuickFix(uri, line);

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -22,6 +22,7 @@
     "@patternfly/react-core": "6.0.0-prerelease.15",
     "@patternfly/react-icons": "^5.4.0",
     "@patternfly/react-table": "^5.4.1",
+    "path-browserify": "^1.0.1",
     "vscode-webview": "^1.0.1-beta.1"
   },
   "devDependencies": {

--- a/webview-ui/src/components/AnalysisPage.tsx
+++ b/webview-ui/src/components/AnalysisPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo } from "react";
 import {
   Button,
   ButtonVariant,
@@ -49,16 +49,6 @@ const AnalysisPage: React.FC = () => {
       line: incident.lineNumber,
     });
   };
-
-  const fetchServerStatus = () => {
-    vscode.postMessage({ command: "checkServerStatus" });
-  };
-
-  useEffect(() => {
-    fetchServerStatus();
-    const interval = setInterval(fetchServerStatus, 5000);
-    return () => clearInterval(interval);
-  }, []);
 
   const messageHandler = (message: any) => {
     console.log("Received message from VS Code:", message);
@@ -119,7 +109,7 @@ const AnalysisPage: React.FC = () => {
     );
   }
 
-  if (!serverRunning) {
+  if (!serverRunning && !hasViolations) {
     return (
       <Page>
         <PageSection>

--- a/webview-ui/src/components/IncidentList.tsx
+++ b/webview-ui/src/components/IncidentList.tsx
@@ -72,15 +72,10 @@ const IncidentList: React.FC<IncidentListProps> = ({
                       </Content>
                     </FlexItem>
                     <FlexItem className="line-number">
-                      <Content component={"small"}>
-                        :{incident.lineNumber}
-                      </Content>
+                      <Content component={"small"}>:{incident.lineNumber}</Content>
                     </FlexItem>
                     <FlexItem>
-                      <Label
-                        isCompact
-                        color={getSeverityColor(incident.severity)}
-                      >
+                      <Label isCompact color={getSeverityColor(incident.severity)}>
                         {incident.severity || "Low"}
                       </Label>
                     </FlexItem>

--- a/webview-ui/src/components/ProgressIndicator.tsx
+++ b/webview-ui/src/components/ProgressIndicator.tsx
@@ -6,13 +6,7 @@ interface ProgressIndicatorProps {
 }
 
 const ProgressIndicator: React.FC<ProgressIndicatorProps> = ({ progress }) => {
-  return (
-    <Progress
-      value={progress}
-      title="Analysis Progress"
-      size={ProgressSize.sm}
-    />
-  );
+  return <Progress value={progress} title="Analysis Progress" size={ProgressSize.sm} />;
 };
 
 export default ProgressIndicator;

--- a/webview-ui/src/components/SolutionCard.tsx
+++ b/webview-ui/src/components/SolutionCard.tsx
@@ -17,10 +17,7 @@ interface SolutionCardProps {
   onViewFix: (change: Change) => void;
 }
 
-export const SolutionCard: React.FC<SolutionCardProps> = ({
-  changes,
-  onViewFix,
-}) => (
+export const SolutionCard: React.FC<SolutionCardProps> = ({ changes, onViewFix }) => (
   <Card>
     <CardHeader>
       <CardTitle>File Changes</CardTitle>

--- a/webview-ui/src/components/ViolationCard.tsx
+++ b/webview-ui/src/components/ViolationCard.tsx
@@ -17,10 +17,7 @@ interface ViolationCardProps {
   violation: Violation | null;
 }
 
-export const ViolationCard: React.FC<ViolationCardProps> = ({
-  incident,
-  violation,
-}) => {
+export const ViolationCard: React.FC<ViolationCardProps> = ({ incident, violation }) => {
   if (!violation) {
     // Handle the case where violation data is not available
     return (

--- a/webview-ui/src/components/ViolationIncidentsList.tsx
+++ b/webview-ui/src/components/ViolationIncidentsList.tsx
@@ -28,12 +28,7 @@ import {
   CardExpandableContent,
   CardFooter,
 } from "@patternfly/react-core";
-import {
-  SortAmountDownIcon,
-  TimesIcon,
-  FileIcon,
-  LightbulbIcon,
-} from "@patternfly/react-icons";
+import { SortAmountDownIcon, TimesIcon, FileIcon, LightbulbIcon } from "@patternfly/react-icons";
 import { Incident, Violation } from "@editor-extensions/shared";
 
 type SortOption = "description" | "incidentCount" | "severity";
@@ -83,10 +78,8 @@ const ViolationIncidentsList: React.FC<ViolationIncidentsListProps> = ({
   const getHighestSeverity = (incidents: Incident[]): string => {
     const severityOrder = { high: 3, medium: 2, low: 1 };
     return incidents.reduce((highest, incident) => {
-      const currentSeverity =
-        severityOrder[incident.severity as keyof typeof severityOrder] || 0;
-      const highestSeverity =
-        severityOrder[highest as keyof typeof severityOrder] || 0;
+      const currentSeverity = severityOrder[incident.severity as keyof typeof severityOrder] || 0;
+      const highestSeverity = severityOrder[highest as keyof typeof severityOrder] || 0;
       return currentSeverity > highestSeverity ? incident.severity : highest;
     }, "low");
   };
@@ -129,13 +122,9 @@ const ViolationIncidentsList: React.FC<ViolationIncidentsListProps> = ({
         case "severity": {
           const severityOrder = { high: 3, medium: 2, low: 1 };
           const aMaxSeverity =
-            severityOrder[
-              getHighestSeverity(a.incidents) as keyof typeof severityOrder
-            ];
+            severityOrder[getHighestSeverity(a.incidents) as keyof typeof severityOrder];
           const bMaxSeverity =
-            severityOrder[
-              getHighestSeverity(b.incidents) as keyof typeof severityOrder
-            ];
+            severityOrder[getHighestSeverity(b.incidents) as keyof typeof severityOrder];
           return bMaxSeverity - aMaxSeverity;
         }
         default:
@@ -163,11 +152,7 @@ const ViolationIncidentsList: React.FC<ViolationIncidentsListProps> = ({
               dataListCells={[
                 <DataListCell key="icon" width={1}>
                   <FileIcon />
-                  <Button
-                    component="a"
-                    variant="link"
-                    onClick={() => onIncidentSelect(incident)}
-                  >
+                  <Button component="a" variant="link" onClick={() => onIncidentSelect(incident)}>
                     {fileName}
                   </Button>
                 </DataListCell>,
@@ -237,9 +222,7 @@ const ViolationIncidentsList: React.FC<ViolationIncidentsListProps> = ({
             onExpand={() => toggleViolation(violation.description)}
           >
             <Tooltip content={violation.description}>
-              <Content style={{ marginBottom: "5px" }}>
-                {truncatedDescription}
-              </Content>
+              <Content style={{ marginBottom: "5px" }}>{truncatedDescription}</Content>
             </Tooltip>
             <Flex>
               <Label color="blue" isCompact>
@@ -310,11 +293,7 @@ const ViolationIncidentsList: React.FC<ViolationIncidentsListProps> = ({
                 onChange={(_event, value) => setSearchTerm(value)}
               />
               {searchTerm && (
-                <Button
-                  variant="control"
-                  onClick={clearSearch}
-                  aria-label="Clear search"
-                >
+                <Button variant="control" onClick={clearSearch} aria-label="Clear search">
                   <TimesIcon />
                 </Button>
               )}
@@ -345,9 +324,7 @@ const ViolationIncidentsList: React.FC<ViolationIncidentsListProps> = ({
             overflowY: "auto",
           }}
         >
-          {filteredAndSortedViolations.map((violation) =>
-            renderViolation(violation),
-          )}
+          {filteredAndSortedViolations.map((violation) => renderViolation(violation))}
         </div>
       </StackItem>
     </Stack>


### PR DESCRIPTION
Refactor and where necessary partially revert the code introduced in feature/kai branch.

Changes:
1. base the webview view/apply/discard actions on state property
   localChanges which contains parsed and localized resolutions.
2. refactor async code in analyzer client
   a) use promisfied versions of exec and setTimeout
   b) create synchronous version of  canAnalyze
   c) extract extension state mutations to dedicated fire*Change methods
   d) introduce ServerState enum
3. save raw response (solutionData) and scope using loadSolution command
   to better link those entities.
4. re-create Uri objects received in the message handler from webviews.
   After crossing the iframe boundary only data props are preserved.
5. remove triggering checkServerStatus message from the webviews as the
   new onDataChanged event should provide the notifications already
6. derive the list of unprocessed resolution from LocalChange.state
7. create Scope interface - to be extended with more combinations in the
   future.
8. add scope property to Solution and allow viewing incidents without
   running server. Together this allows end-to-end testing with mocks.
9. name error property in GetSolutionResult(ideal response) for better
   alignment with SolutionResponse(actual response)
