### PR TITLE
:sparkles: Add kai configurables to extension config

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -456,16 +456,15 @@
           "description": "URL for the Kai solution server",
           "scope": "window"
         },
-        "konveyor.kai.providerModel": {
-          "type": "string",
-          "default": "meta-llama/llama-3-1-70b-instruct",
-          "description": "URL for the Kai solution server",
-          "scope": "window"
-        },
-        "konveyor.kai.providerParameters": {
+        "konveyor.kai.providerArgs": {
           "type": "object",
-          "default": {},
-          "description": "Provider parameters",
+          "default": {
+            "model_id": "meta-llama/llama-3-1-70b-instruct",
+            "parameters": {
+              "max_new_tokens": 2048
+            }
+          },
+          "description": "Kai provider arguments",
           "scope": "window"
         }
       }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -363,37 +363,44 @@
           "default": "",
           "description": "Path to the rpc-server binary. If not set, the extension will use the bundled binary.",
           "scope": "machine",
-          "order": 0
+          "order": 1
         },
-        "konveyor.incidentLimit": {
+        "konveyor.logLevel": {
+          "type": "string",
+          "default": "debug",
+          "description": "Log level to use with extension",
+          "scope": "window",
+          "order": 2
+        },
+        "konveyor.analysis.incidentLimit": {
           "type": "number",
           "default": 10000,
           "description": "Maximum number of incidents to report",
           "scope": "window",
           "order": 1
         },
-        "konveyor.contextLines": {
+        "konveyor.analysis.contextLines": {
           "type": "number",
           "default": 10,
           "description": "Number of lines of context to include in incident reports",
           "scope": "window",
           "order": 2
         },
-        "konveyor.codeSnipLimit": {
+        "konveyor.analysis.codeSnipLimit": {
           "type": "number",
           "default": 10,
           "description": "Number of lines of code to include in incident reports",
           "scope": "window",
           "order": 3
         },
-        "konveyor.useDefaultRulesets": {
+        "konveyor.analysis.useDefaultRulesets": {
           "type": "boolean",
           "default": true,
           "description": "Whether analysis should use the default rulesets, included in the extension",
           "scope": "window",
           "order": 4
         },
-        "konveyor.customRules": {
+        "konveyor.analysis.customRules": {
           "type": "array",
           "items": {
             "type": "string"
@@ -403,33 +410,63 @@
           "scope": "window",
           "order": 5
         },
-        "konveyor.labelSelector": {
+        "konveyor.analysis.labelSelector": {
           "type": "string",
           "default": "discovery",
           "description": "Expression to select incidents based on custom variables. Example: (!package=io.konveyor.demo.config-utils)",
           "scope": "window",
           "order": 6
         },
-        "konveyor.analyzeKnownLibraries": {
+        "konveyor.analysis.analyzeKnownLibraries": {
           "type": "boolean",
           "default": false,
           "description": "Whether analysis should include known open-source libraries",
           "scope": "window",
           "order": 7
         },
-        "konveyor.analyzeDependencies": {
+        "konveyor.analysis.analyzeDependencies": {
           "type": "boolean",
           "default": true,
           "description": "Whether analysis should include dependencies",
           "scope": "window",
           "order": 8
         },
-        "konveyor.analyzeOnSave": {
+        "konveyor.analysis.analyzeOnSave": {
           "type": "boolean",
           "default": true,
           "description": "Whether analysis of file should be run when saved",
           "scope": "window",
           "order": 9
+        },
+        "konveyor.diffEditorType": {
+          "type": "string",
+          "default": "diff",
+          "description": "Diff editor to use when resolving proposed solutions",
+          "scope": "window"
+        },
+        "konveyor.kai.backendURL": {
+          "type": "string",
+          "default": "0.0.0.0:8080",
+          "description": "Kai Backend URL",
+          "scope": "window"
+        },
+        "konveyor.kai.providerName": {
+          "type": "string",
+          "default": "ChatIBMGenAI",
+          "description": "URL for the Kai solution server",
+          "scope": "window"
+        },
+        "konveyor.kai.providerModel": {
+          "type": "string",
+          "default": "meta-llama/llama-3-1-70b-instruct",
+          "description": "URL for the Kai solution server",
+          "scope": "window"
+        },
+        "konveyor.kai.providerParameters": {
+          "type": "object",
+          "default": {},
+          "description": "Provider parameters",
+          "scope": "window"
         }
       }
     },

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -7,13 +7,26 @@ import * as rpc from "vscode-jsonrpc/node";
 import path from "path";
 import { Incident, RuleSet, SolutionResponse, Violation } from "@editor-extensions/shared";
 import { buildDataFolderPath } from "../data";
+import { Extension } from "../helpers/Extension";
 import { ExtensionState } from "../extensionState";
 import { ExtensionData, ServerState } from "@editor-extensions/shared";
 import { setTimeout } from "timers/promises";
+import {
+  getConfigAnalyzerPath,
+  getConfigKaiRpcServerPath,
+  getConfigKaiBackendURL,
+  getConfigLogLevel,
+  getConfigUseDefaultRulesets,
+  getConfigCustomRules,
+  getConfigKaiProviderName,
+  getConfigKaiProviderModel,
+  getConfigKaiProviderParameters,
+  getConfigLabelSelector,
+  updateUseDefaultRulesets,
+} from "../utilities";
 
 const exec = util.promisify(callbackExec);
 export class AnalyzerClient {
-  private config: vscode.WorkspaceConfiguration | null = null;
   private kaiRpcServer: ChildProcessWithoutNullStreams | null = null;
   private outputChannel: vscode.OutputChannel;
   private rpcConnection: rpc.MessageConnection | null = null;
@@ -42,7 +55,6 @@ export class AnalyzerClient {
         draft.isFetchingSolution = flag;
       });
     this.outputChannel = vscode.window.createOutputChannel("Konveyor-Analyzer");
-    this.config = vscode.workspace.getConfiguration("konveyor");
     this.kaiDir = path.join(buildDataFolderPath()!, "kai");
     this.kaiConfigToml = path.join(this.kaiDir, "kai-config.toml");
   }
@@ -98,6 +110,8 @@ export class AnalyzerClient {
   }
 
   public async initialize(): Promise<void> {
+    const isProd = Extension.getInstance(this.extContext).isProductionMode;
+
     if (!this.rpcConnection) {
       vscode.window.showErrorMessage("RPC connection is not established.");
       return;
@@ -106,21 +120,19 @@ export class AnalyzerClient {
     // Define the initialize request parameters if needed
     const initializeParams = {
       process_id: null,
-      kai_backend_url: "0.0.0.0:8080",
+      kai_backend_url: getConfigKaiBackendURL(),
       root_path: vscode.workspace.workspaceFolders![0].uri.fsPath,
-      log_level: "debug",
+      log_level: getConfigLogLevel(),
       log_dir_path: this.kaiDir,
       model_provider: {
-        provider: "ChatOpenAI",
+        provider: getConfigKaiProviderName(),
         args: {
-          model: "gpt-3.5-turbo",
-          // parameters: {
-          //   max_new_tokens: 2048,
-          // },
+          model: getConfigKaiProviderModel(),
+          parameters: getConfigKaiProviderParameters(),
         },
       },
-      file_log_level: "debug",
-      demo_mode: true,
+      file_log_level: getConfigLogLevel(),
+      demo_mode: Extension.getInstance(this.extContext).isProductionMode ? "false" : "true",
       cache_dir: "",
 
       analyzer_lsp_java_bundle_path: path.join(
@@ -192,7 +204,7 @@ export class AnalyzerClient {
           this.fireAnalysisStateChange(true);
 
           const requestParams = {
-            label_selector: this.getLabelSelector(),
+            label_selector: getConfigLabelSelector(),
           };
 
           this.outputChannel.appendLine(
@@ -292,11 +304,11 @@ export class AnalyzerClient {
   }
 
   public canAnalyze(): boolean {
-    return !!this.config?.get("labelSelector") && this.getRules().length !== 0;
+    return !!getConfigLabelSelector() && this.getRules().length !== 0;
   }
 
   public async canAnalyzeInteractive(): Promise<boolean> {
-    const labelSelector = this.config!.get("labelSelector") as string;
+    const labelSelector = getConfigLabelSelector();
 
     if (!labelSelector) {
       const selection = await vscode.window.showErrorMessage(
@@ -327,11 +339,7 @@ export class AnalyzerClient {
 
       switch (selection) {
         case "Enable Default Rulesets":
-          await this.config!.update(
-            "useDefaultRulesets",
-            true,
-            vscode.ConfigurationTarget.Workspace,
-          );
+          await updateUseDefaultRulesets(true);
           vscode.window.showInformationMessage("Default rulesets have been enabled.");
           break;
         case "Configure Custom Rules":
@@ -345,7 +353,7 @@ export class AnalyzerClient {
   }
 
   public getAnalyzerPath(): string {
-    const analyzerPath = this.config?.get<string>("analyzerPath");
+    const analyzerPath = getConfigAnalyzerPath();
     if (analyzerPath && fs.existsSync(analyzerPath)) {
       return analyzerPath;
     }
@@ -376,7 +384,7 @@ export class AnalyzerClient {
 
   public getKaiRpcServerPath(): string {
     // Retrieve the rpcServerPath
-    const rpcServerPath = this.config?.get<string>("kaiRpcServerPath");
+    const rpcServerPath = getConfigKaiRpcServerPath();
     if (rpcServerPath && fs.existsSync(rpcServerPath)) {
       return rpcServerPath;
     }
@@ -412,39 +420,18 @@ export class AnalyzerClient {
     return ["--config", this.getKaiConfigTomlPath()];
   }
 
-  public getNumWorkers(): number {
-    return this.config!.get("workers") as number;
-  }
+  public getRules(): string[] {
+    const useDefaultRulesets = getConfigUseDefaultRulesets();
+    const customRules = getConfigCustomRules();
+    const rules: string[] = [];
 
-  public getIncidentLimit(): number {
-    return this.config!.get("incidentLimit") as number;
-  }
-
-  public getContextLines(): number {
-    return this.config!.get("contextLines") as number;
-  }
-
-  public getCodeSnipLimit(): number {
-    return this.config!.get("codeSnipLimit") as number;
-  }
-
-  public getRules(): string {
-    return path.join(this.extContext!.extensionPath, "assets/rulesets");
-    // const useDefaultRulesets = this.config!.get("useDefaultRulesets") as boolean;
-    // const customRules = this.config!.get("customRules") as string[];
-    // const rules: string[] = [];
-
-    // if (useDefaultRulesets) {
-    //   rules.push(path.join(this.extContext!.extensionPath, "assets/rulesets"));
-    // }
-    // if (customRules.length > 0) {
-    //   rules.push(...customRules);
-    // }
-    // return rules;
-  }
-
-  public getLabelSelector(): string {
-    return vscode.workspace.getConfiguration("konveyor").get("labelSelector") as string;
+    if (useDefaultRulesets) {
+      rules.push(path.join(this.extContext!.extensionPath, "assets/rulesets"));
+    }
+    if (customRules.length > 0) {
+      rules.push(...customRules);
+    }
+    return rules;
   }
 
   public getJavaConfig(): object {

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -17,11 +17,8 @@ import {
   getConfigKaiRpcServerPath,
   getConfigKaiBackendURL,
   getConfigLogLevel,
-  getConfigUseDefaultRulesets,
-  getConfigCustomRules,
   getConfigKaiProviderName,
-  getConfigKaiProviderModel,
-  getConfigKaiProviderParameters,
+  getConfigKaiProviderArgs,
   getConfigLabelSelector,
   updateUseDefaultRuleSets,
 } from "../utilities";
@@ -136,10 +133,7 @@ export class AnalyzerClient {
       log_dir_path: this.kaiDir,
       model_provider: {
         provider: getConfigKaiProviderName(),
-        args: {
-          model: getConfigKaiProviderModel(),
-          parameters: getConfigKaiProviderParameters(),
-        },
+        args: getConfigKaiProviderArgs(),
       },
       file_log_level: getConfigLogLevel(),
       demo_mode: demoMode,
@@ -430,18 +424,20 @@ export class AnalyzerClient {
     return ["--config", this.getKaiConfigTomlPath()];
   }
 
-  public getRules(): string[] {
-    const useDefaultRulesets = getConfigUseDefaultRulesets();
-    const customRules = getConfigCustomRules();
-    const rules: string[] = [];
+  public getRules(): string {
+    return path.join(this.extContext!.extensionPath, "assets/rulesets");
+    // TODO(djzager): konveyor/kai#509
+    // const useDefaultRulesets = getConfigUseDefaultRulesets();
+    // const customRules = getConfigCustomRules();
+    // const rules: string[] = [];
 
-    if (useDefaultRulesets) {
-      rules.push(path.join(this.extContext!.extensionPath, "assets/rulesets"));
-    }
-    if (customRules.length > 0) {
-      rules.push(...customRules);
-    }
-    return rules;
+    // if (useDefaultRulesets) {
+    //   rules.push(path.join(this.extContext!.extensionPath, "assets/rulesets"));
+    // }
+    // if (customRules.length > 0) {
+    //   rules.push(...customRules);
+    // }
+    // return rules;
   }
 
   public getJavaConfig(): object {

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -26,7 +26,7 @@ import {
   updateAnalyzerPath,
   updateKaiRpcServerPath,
   updateCustomRules,
-  updateUseDefaultRulesets,
+  updateUseDefaultRuleSets,
   getConfigLabelSelector,
   updateLabelSelector,
 } from "./utilities/configuration";
@@ -209,9 +209,9 @@ const commandsMap: (state: ExtensionState) => {
         });
 
         if (useDefaultRulesets === "Yes") {
-          await updateUseDefaultRulesets(true);
+          await updateUseDefaultRuleSets(true);
         } else if (useDefaultRulesets === "No") {
-          await updateUseDefaultRulesets(false);
+          await updateUseDefaultRuleSets(false);
         }
 
         window.showInformationMessage(

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -1,16 +1,7 @@
 import { setupWebviewMessageListener } from "./webviewMessageHandler";
 import { ExtensionState } from "./extensionState";
 import { sourceOptions, targetOptions } from "./config/labels";
-import {
-  WebviewPanel,
-  window,
-  commands,
-  Uri,
-  ConfigurationTarget,
-  OpenDialogOptions,
-  ViewColumn,
-  workspace,
-} from "vscode";
+import { WebviewPanel, window, commands, Uri, OpenDialogOptions, ViewColumn } from "vscode";
 import {
   cleanRuleSets,
   loadResultsFromDataFolder,
@@ -31,6 +22,14 @@ import {
   discardFile,
   applyBlock,
 } from "./diffView";
+import {
+  updateAnalyzerPath,
+  updateKaiRpcServerPath,
+  updateCustomRules,
+  updateUseDefaultRulesets,
+  getConfigLabelSelector,
+  updateLabelSelector,
+} from "./utilities/configuration";
 
 let fullScreenPanel: WebviewPanel | undefined;
 
@@ -145,17 +144,16 @@ const commandsMap: (state: ExtensionState) => {
       };
 
       const fileUri = await window.showOpenDialog(options);
-      const config = workspace.getConfiguration("konveyor");
       if (fileUri && fileUri[0]) {
         const filePath = fileUri[0].fsPath;
 
         // Update the user settings
-        await config.update("analyzerPath", filePath, ConfigurationTarget.Global);
+        await updateAnalyzerPath(filePath);
 
         window.showInformationMessage(`Analyzer binary path updated to: ${filePath}`);
       } else {
         // Reset the setting to undefined or remove it
-        await config.update("analyzerPath", undefined, ConfigurationTarget.Global);
+        await updateAnalyzerPath(undefined);
         window.showInformationMessage("No analyzer binary selected.");
       }
     },
@@ -170,17 +168,16 @@ const commandsMap: (state: ExtensionState) => {
       };
 
       const fileUri = await window.showOpenDialog(options);
-      const config = workspace.getConfiguration("konveyor");
       if (fileUri && fileUri[0]) {
         const filePath = fileUri[0].fsPath;
 
         // Update the user settings
-        await config.update("kaiRpcServerPath", filePath, ConfigurationTarget.Global);
+        await updateKaiRpcServerPath(filePath);
 
         window.showInformationMessage(`Kai rpc server binary path updated to: ${filePath}`);
       } else {
         // Reset the setting to undefined or remove it
-        await config.update("kaiRpcServerPath", undefined, ConfigurationTarget.Global);
+        await updateKaiRpcServerPath(undefined);
         window.showInformationMessage("No Kai rpc-server binary selected.");
       }
     },
@@ -203,8 +200,7 @@ const commandsMap: (state: ExtensionState) => {
         // TODO(djzager): Should we verify the rules provided are valid?
 
         // Update the user settings
-        const config = workspace.getConfiguration("konveyor");
-        await config.update("customRules", customRules, ConfigurationTarget.Workspace);
+        await updateCustomRules(customRules);
 
         // Ask the user if they want to disable the default ruleset
         const useDefaultRulesets = await window.showQuickPick(["Yes", "No"], {
@@ -213,9 +209,9 @@ const commandsMap: (state: ExtensionState) => {
         });
 
         if (useDefaultRulesets === "Yes") {
-          await config.update("useDefaultRulesets", true, ConfigurationTarget.Workspace);
+          await updateUseDefaultRulesets(true);
         } else if (useDefaultRulesets === "No") {
-          await config.update("useDefaultRulesets", false, ConfigurationTarget.Workspace);
+          await updateUseDefaultRulesets(false);
         }
 
         window.showInformationMessage(
@@ -226,8 +222,7 @@ const commandsMap: (state: ExtensionState) => {
       }
     },
     "konveyor.configureSourcesTargets": async () => {
-      const config = workspace.getConfiguration("konveyor");
-      const currentLabelSelector = config.get<string>("labelSelector", "");
+      const currentLabelSelector = getConfigLabelSelector();
 
       // Function to extract values from label selector
       const extractValuesFromSelector = (selector: string, key: string): string[] => {
@@ -318,15 +313,14 @@ const commandsMap: (state: ExtensionState) => {
       state.labelSelector = modifiedLabelSelector;
 
       // Update the user settings
-      await config.update("labelSelector", state.labelSelector, ConfigurationTarget.Workspace);
+      await updateLabelSelector(state.labelSelector);
 
       window.showInformationMessage(
         `Configuration updated: Sources: ${state.sources.join(", ")}, Targets: ${state.targets.join(", ")}, Label Selector: ${state.labelSelector}`,
       );
     },
     "konveyor.configureLabelSelector": async () => {
-      const config = workspace.getConfiguration("konveyor");
-      const currentLabelSelector = config.get<string>("labelSelector", "");
+      const currentLabelSelector = getConfigLabelSelector();
 
       const modifiedLabelSelector = await window.showInputBox({
         prompt: "Modify the label selector if needed",
@@ -339,7 +333,7 @@ const commandsMap: (state: ExtensionState) => {
       }
 
       // Update the user settings
-      await config.update("labelSelector", modifiedLabelSelector, ConfigurationTarget.Workspace);
+      await updateLabelSelector(modifiedLabelSelector);
     },
     "konveyor.loadRuleSets": async (ruleSets: RuleSet[]) => loadRuleSets(state, ruleSets),
     "konveyor.cleanRuleSets": () => cleanRuleSets(state),

--- a/vscode/src/diffView/solutionCommands.ts
+++ b/vscode/src/diffView/solutionCommands.ts
@@ -4,6 +4,7 @@ import { fromRelativeToKonveyor, KONVEYOR_READ_ONLY_SCHEME } from "../utilities"
 import { FileItem, toUri } from "./fileModel";
 import { LocalChange } from "@editor-extensions/shared";
 import { Immutable } from "immer";
+import { getConfigDiffEditorType } from "../utilities";
 
 export const applyAll = async (state: ExtensionState) => {
   const localChanges = state.data.localChanges;
@@ -26,7 +27,7 @@ export const discardAll = async (state: ExtensionState) => {
 };
 
 export const viewFix = async (uri: vscode.Uri, preserveFocus: boolean) =>
-  vscode.workspace.getConfiguration("konveyor")?.get("diffEditorType") === "merge"
+  getConfigDiffEditorType() === "merge"
     ? viewFixInMergeEditor(uri, preserveFocus)
     : viewFixInDiffEditor(uri, preserveFocus);
 

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -1,0 +1,150 @@
+import { KONVEYOR_CONFIG_KEY } from "./constants";
+import * as vscode from "vscode";
+
+function getConfigValue<T>(key: string): T | undefined {
+  return vscode.workspace.getConfiguration(KONVEYOR_CONFIG_KEY)?.get<T>(key);
+}
+
+export function getConfigAnalyzerPath(): string {
+  return getConfigValue<string>("analyzerPath") || "";
+}
+
+export function getConfigKaiRpcServerPath(): string {
+  return getConfigValue<string>("kaiRpcServerPath") || "";
+}
+
+export function getConfigLogLevel(): string {
+  return getConfigValue<string>("logLevel") || "debug";
+}
+
+export function getConfigIncidentLimit(): number {
+  return getConfigValue<number>("analysis.incidentLimit") || 10000;
+}
+
+export function getConfigContextLines(): number {
+  return getConfigValue<number>("analysis.contextLines") || 10;
+}
+
+export function getConfigCodeSnipLimit(): number {
+  return getConfigValue<number>("analysis.codeSnipLimit") || 10;
+}
+
+export function getConfigUseDefaultRulesets(): boolean {
+  return getConfigValue<boolean>("analysis.useDefaultRulesets") || true;
+}
+
+export function getConfigCustomRules(): string[] {
+  return getConfigValue<string[]>("analysis.customRules") || [];
+}
+
+export function getConfigLabelSelector(): string {
+  return getConfigValue<string>("analysis.labelSelector") || "discovery";
+}
+
+export function getConfigAnalyzeKnownLibraries(): boolean {
+  return getConfigValue<boolean>("analysis.analyzeKnownLibraries") || false;
+}
+
+export function getConfigAnalyzeDependencies(): boolean {
+  return getConfigValue<boolean>("analysis.analyzeDependencies") || true;
+}
+
+export function getConfigAnalyzeOnSave(): boolean {
+  return getConfigValue<boolean>("analysis.analyzeOnSave") || true;
+}
+
+export function getConfigDiffEditorType(): string {
+  return getConfigValue<string>("diffEditorType") || "diff";
+}
+
+export function getConfigKaiBackendURL(): string {
+  return getConfigValue<string>("kai.backendURL") || "0.0.0.0:8080";
+}
+
+export function getConfigKaiProviderName(): string {
+  return getConfigValue<string>("kai.providerName") || "ChatIBMGenAI";
+}
+
+export function getConfigKaiProviderModel(): string {
+  return getConfigValue<string>("kai.providerModel") || "meta-llama/llama-3-1-70b-instruct";
+}
+
+export function getConfigKaiProviderParameters(): object {
+  return getConfigValue<object>("kai.providerParameters") || {};
+}
+
+async function updateConfigValue<T>(
+  key: string,
+  value: T | undefined,
+  scope: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Workspace,
+): Promise<void> {
+  await vscode.workspace.getConfiguration(KONVEYOR_CONFIG_KEY).update(key, value, scope);
+}
+
+export async function updateAnalyzerPath(value: string | undefined): Promise<void> {
+  await updateConfigValue("analyzerPath", value, vscode.ConfigurationTarget.Workspace);
+}
+
+export async function updateKaiRpcServerPath(value: string | undefined): Promise<void> {
+  await updateConfigValue("kaiRpcServerPath", value, vscode.ConfigurationTarget.Workspace);
+}
+
+export async function updateLogLevel(value: string): Promise<void> {
+  await updateConfigValue("logLevel", value, vscode.ConfigurationTarget.Workspace);
+}
+
+export async function updateIncidentLimit(value: number): Promise<void> {
+  await updateConfigValue("analysis.incidentLimit", value, vscode.ConfigurationTarget.Workspace);
+}
+
+export async function updateContextLines(value: number): Promise<void> {
+  await updateConfigValue("analysis.contextLines", value, vscode.ConfigurationTarget.Workspace);
+}
+
+export async function updateCodeSnipLimit(value: number): Promise<void> {
+  await updateConfigValue("analysis.codeSnipLimit", value, vscode.ConfigurationTarget.Workspace);
+}
+
+export async function updateUseDefaultRulesets(value: boolean): Promise<void> {
+  await updateConfigValue(
+    "analysis.useDefaultRulesets",
+    value,
+    vscode.ConfigurationTarget.Workspace,
+  );
+}
+
+export async function updateCustomRules(value: string[]): Promise<void> {
+  await updateConfigValue("analysis.customRules", value, vscode.ConfigurationTarget.Workspace);
+}
+
+export async function updateLabelSelector(value: string): Promise<void> {
+  await updateConfigValue("analysis.labelSelector", value, vscode.ConfigurationTarget.Workspace);
+}
+
+export async function updateAnalyzeKnownLibraries(value: boolean): Promise<void> {
+  await updateConfigValue(
+    "analysis.analyzeKnownLibraries",
+    value,
+    vscode.ConfigurationTarget.Workspace,
+  );
+}
+
+export async function updateAnalyzeDependencies(value: boolean): Promise<void> {
+  await updateConfigValue(
+    "analysis.analyzeDependencies",
+    value,
+    vscode.ConfigurationTarget.Workspace,
+  );
+}
+
+export async function updateAnalyzeOnSave(value: boolean): Promise<void> {
+  await updateConfigValue("analysis.analyzeOnSave", value, vscode.ConfigurationTarget.Workspace);
+}
+
+export async function updateKaiProviderName(value: string): Promise<void> {
+  await updateConfigValue("kai.providerName", value, vscode.ConfigurationTarget.Workspace);
+}
+
+export async function updateKaiProviderModel(value: string): Promise<void> {
+  await updateConfigValue("kai.providerModel", value, vscode.ConfigurationTarget.Workspace);
+}

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -105,7 +105,7 @@ export async function updateCodeSnipLimit(value: number): Promise<void> {
   await updateConfigValue("analysis.codeSnipLimit", value, vscode.ConfigurationTarget.Workspace);
 }
 
-export async function updateUseDefaultRulesets(value: boolean): Promise<void> {
+export async function updateUseDefaultRuleSets(value: boolean): Promise<void> {
   await updateConfigValue(
     "analysis.useDefaultRulesets",
     value,

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -65,12 +65,8 @@ export function getConfigKaiProviderName(): string {
   return getConfigValue<string>("kai.providerName") || "ChatIBMGenAI";
 }
 
-export function getConfigKaiProviderModel(): string {
-  return getConfigValue<string>("kai.providerModel") || "meta-llama/llama-3-1-70b-instruct";
-}
-
-export function getConfigKaiProviderParameters(): object {
-  return getConfigValue<object>("kai.providerParameters") || {};
+export function getConfigKaiProviderArgs(): object {
+  return getConfigValue<object>("kai.providerArgs") || {};
 }
 
 async function updateConfigValue<T>(

--- a/vscode/src/utilities/constants.ts
+++ b/vscode/src/utilities/constants.ts
@@ -2,3 +2,4 @@ export const KONVEYOR_SCHEME = "konveyorMemFs";
 export const KONVEYOR_READ_ONLY_SCHEME = "konveyorReadOnly";
 export const RULE_SET_DATA_FILE_PREFIX = "analysis";
 export const SOLUTION_DATA_FILE_PREFIX = "solution";
+export const KONVEYOR_CONFIG_KEY = "konveyor";

--- a/vscode/src/utilities/index.ts
+++ b/vscode/src/utilities/index.ts
@@ -2,3 +2,4 @@ export * from "./constants";
 export * from "./uris";
 export * from "./getNonce";
 export * from "./typeGuards";
+export * from "./configuration";


### PR DESCRIPTION
This PR adds the kai configuration items to our extension's config **AND** attempts to standardize the way we get and update our configuration items.
