### PR TITLE
:sparkles: Trigger partial analysis after save

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,7 @@ const baseConfig = {
     globals: {
       ...globals.es2023,
       ...globals.node,
+      ...globals.mocha,
     },
   },
   rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -585,6 +585,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -1329,6 +1353,80 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -1896,6 +1994,13 @@
         "win32"
       ]
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
@@ -1907,6 +2012,34 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1953,23 +2086,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/chai": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.0.1.tgz",
-      "integrity": "sha512-5T8ajsg3M/FOncpLYW7sdOcD6yf4+722sze/tc4KQV0P8Z2rAr3SAuHCIkYmYpt8VbcQlnz8SxlOlPQYefe4cA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/deep-eql": "*"
-      }
-    },
-    "node_modules/@types/deep-eql": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/diff": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-6.0.0.tgz",
@@ -2012,6 +2128,26 @@
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
     },
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
@@ -2072,6 +2208,13 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
@@ -2090,6 +2233,23 @@
       "version": "1.57.5",
       "resolved": "https://registry.npmjs.org/@types/vscode-webview/-/vscode-webview-1.57.5.tgz",
       "integrity": "sha512-iBAUYNYkz+uk1kdsq05fEcoh8gJmwT3lqqFPN7MGyjQ3HVloViMdo7ZJ8DFIP8WOK74PjOEilosqAyxV2iUFUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3005,6 +3165,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
@@ -3156,6 +3329,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3297,16 +3477,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -3635,23 +3805,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chai": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
-      "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/chalk": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
@@ -3663,16 +3816,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/cheerio": {
@@ -3773,6 +3916,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cli-cursor": {
@@ -4101,6 +4260,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
@@ -4321,16 +4487,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -4423,6 +4579,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/doctrine": {
@@ -5301,6 +5467,23 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -6783,6 +6966,217 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-util/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -7336,13 +7730,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/loupe": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
-      "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -7365,6 +7752,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/markdown-it": {
       "version": "14.1.0",
@@ -8435,16 +8829,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pathval": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
-      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -8742,6 +9126,41 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -9766,6 +10185,29 @@
       "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
       "dev": true
     },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
@@ -10497,6 +10939,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -10835,6 +11331,13 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -11561,6 +12064,16 @@
         "buffer-crc32": "~0.2.3"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -11585,19 +12098,19 @@
         "diff": "^7.0.0"
       },
       "devDependencies": {
-        "@types/chai": "^5.0.0",
         "@types/diff": "^6.0.0",
         "@types/mocha": "^10.0.9",
         "@types/uuid": "^10.0.0",
         "@types/vscode": "^1.93.0",
         "@vscode/test-cli": "^0.0.10",
         "@vscode/test-electron": "^2.4.1",
-        "chai": "^5.1.1",
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^7.1.2",
+        "expect": "^29.7.0",
         "mocha": "^10.7.3",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.5.1",
+        "ts-node": "10.9.2",
         "webpack": "^5.94.0",
         "webpack-cli": "^5.1.4"
       },

--- a/shared/src/types/types.ts
+++ b/shared/src/types/types.ts
@@ -1,11 +1,13 @@
 import { Uri } from "vscode";
 
+export type Severity = "High" | "Medium" | "Low";
+
 export interface Incident {
   uri: string;
-  lineNumber: number;
-  severity: "High" | "Medium" | "Low";
+  lineNumber?: number;
+  severity?: Severity;
   message: string;
-  codeSnip: string;
+  codeSnip?: string;
 }
 
 export interface Link {
@@ -13,11 +15,7 @@ export interface Link {
   title?: string;
 }
 
-export enum Category {
-  Potential = "potential",
-  Optional = "optional",
-  Mandatory = "mandatory",
-}
+export type Category = "potential" | "optional" | "mandatory";
 
 export interface Violation {
   description: string;

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -547,26 +547,27 @@
     "compile": "tsc -b && webpack --mode production",
     "dev": "npm run watch",
     "watch": "webpack --watch --mode development",
-    "test": "npm run compile && vscode-test"
+    "test:local": "mocha --require ts-node/register src/**/__tests__/*test.ts",
+    "test": "npm run test:local && npm run compile && vscode-test"
   },
   "lint-staged": {
     "*.{js,cjs,mjs,ts,cts,mts}": "eslint --fix",
     "*.{css,json,md,yaml,yml}": "prettier --write"
   },
   "devDependencies": {
-    "@types/chai": "^5.0.0",
     "@types/diff": "^6.0.0",
     "@types/mocha": "^10.0.9",
     "@types/uuid": "^10.0.0",
     "@types/vscode": "^1.93.0",
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.4.1",
-    "chai": "^5.1.1",
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^7.1.2",
+    "expect": "^29.7.0",
     "mocha": "^10.7.3",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.5.1",
+    "ts-node": "10.9.2",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4"
   },

--- a/vscode/src/analysis/__tests__/data.ts
+++ b/vscode/src/analysis/__tests__/data.ts
@@ -1,0 +1,111 @@
+import { RuleSet } from "@editor-extensions/shared";
+export const FOO: RuleSet = {
+  name: "test/foo",
+  description: "foo top description",
+  violations: {
+    "foo-01": {
+      description: "foo-01 description",
+      category: "mandatory",
+      labels: ["konveyor.io/target=foo", "konveyor.io/target=bar"],
+      incidents: [
+        {
+          uri: "file:///src/Foo.java",
+          message: "foo-01 message",
+          codeSnip: "Foo",
+          lineNumber: 57,
+        },
+        {
+          uri: "file:///src/Bar.java",
+          message: "foo-01 message",
+          codeSnip: "Bar",
+          lineNumber: 60,
+        },
+      ],
+      effort: 1,
+    },
+  },
+  errors: {
+    "foo-02": "unable to ask for Konveyor rule entry",
+    "foo-03": "could not run grep with provided pattern exit status 2",
+  },
+  unmatched: ["foo-04", "foo-05"],
+  skipped: ["foo-06", "foo-07"],
+};
+export const BAR: RuleSet = {
+  name: "test/bar",
+  description: "bar top description",
+  violations: {
+    "bar-01": {
+      description: "bar-01 description",
+      category: "mandatory",
+      labels: ["konveyor.io/target=foo", "konveyor.io/target=bar"],
+      incidents: [
+        {
+          uri: "file:///src/Foo.java",
+          message: "bar-01 message A",
+          codeSnip: "Foo",
+          lineNumber: 57,
+        },
+        {
+          uri: "file:///FooBar.java",
+          message: "bar-01 message B",
+          codeSnip: "FooBar",
+          lineNumber: 60,
+        },
+      ],
+      effort: 1,
+    },
+    "bar-02": {
+      description: "bar-02 description",
+      category: "mandatory",
+      labels: ["konveyor.io/target=foo", "konveyor.io/target=bar"],
+      incidents: [
+        {
+          uri: "file:///src/Bar.java",
+          message: "bar-02 message A",
+          codeSnip: "Bar",
+          lineNumber: 57,
+        },
+        {
+          uri: "file:///FooBar.java",
+          message: "bar-02 message B",
+          codeSnip: "FooBar",
+          lineNumber: 60,
+        },
+      ],
+      effort: 1,
+    },
+  },
+  errors: {},
+  unmatched: [],
+  skipped: [],
+};
+export const DISCOVERY: RuleSet = {
+  name: "discovery",
+  tags: ["Java Source"],
+  insights: {
+    "discover-java-files": {
+      description: "Java source files",
+      labels: [
+        "konveyor.io/include=always",
+        "konveyor.io/target=discovery",
+        "discovery",
+        "tag=Java Source",
+      ],
+      incidents: [
+        {
+          uri: "file:///src/Foo.java",
+          message: "",
+        },
+        {
+          uri: "file:///src/Bar.java",
+          message: "",
+        },
+        {
+          uri: "file:///src/FooBar.java",
+          message: "",
+        },
+      ],
+    },
+  },
+};

--- a/vscode/src/analysis/__tests__/mergeRuleSets.test.ts
+++ b/vscode/src/analysis/__tests__/mergeRuleSets.test.ts
@@ -1,0 +1,76 @@
+import { RuleSet } from "@editor-extensions/shared";
+import { produce } from "immer";
+import { mergeRuleSets } from "../mergeRuleSets";
+import expect from "expect";
+import { FOO, BAR, DISCOVERY } from "./data";
+
+const BASE_STATE: RuleSet[] = [FOO, BAR, DISCOVERY];
+
+const PARTIAL_NO_INCIDENTS: RuleSet[] = [
+  produce(FOO, (draft: RuleSet) => {
+    draft.violations!["foo-01"].incidents = [];
+  }),
+  produce(BAR, (draft: RuleSet) => {
+    draft.violations!["bar-01"].incidents = [];
+    draft.violations!["bar-02"].incidents = [];
+  }),
+  produce(DISCOVERY, (draft: RuleSet) => {
+    draft.insights!["discover-java-files"].incidents.pop();
+  }),
+];
+
+const PARTIAL_SINGLE_INCIDENT: RuleSet[] = [
+  produce(FOO, (draft: RuleSet) => {
+    draft.violations!["foo-01"].incidents = [
+      {
+        uri: "file:///src/Foo.java",
+        message: "new message",
+        codeSnip: "Foo",
+        lineNumber: 57,
+      },
+    ];
+  }),
+];
+
+const EMPTY_PARTIAL: RuleSet[] = [];
+const SAVED_FILES: string[] = ["file:///src/Foo.java", "file:///src/Bar.java"];
+
+describe("mergeRuleSets() removes old violations/incidents in the chosen files", () => {
+  it("handles empty response", () => {
+    const merged: RuleSet[] = produce(BASE_STATE, (draft) =>
+      mergeRuleSets(draft, EMPTY_PARTIAL, SAVED_FILES),
+    );
+    expect(merged).toHaveLength(3);
+    const [foo, bar, discovery] = merged;
+
+    expect(foo.violations?.["foo-01"].incidents).toHaveLength(0);
+    expect(bar.violations?.["bar-01"].incidents).toHaveLength(1);
+    expect(bar.violations?.["bar-02"].incidents).toHaveLength(1);
+    expect(discovery.insights?.["discover-java-files"].incidents).toHaveLength(3);
+  });
+  it("handles response with no incidents", () => {
+    const merged: RuleSet[] = produce(BASE_STATE, (draft) =>
+      mergeRuleSets(draft, PARTIAL_NO_INCIDENTS, SAVED_FILES),
+    );
+    expect(merged).toHaveLength(3);
+    const [foo, bar, discovery] = merged;
+
+    expect(foo.violations?.["foo-01"].incidents).toHaveLength(0);
+    expect(bar.violations?.["bar-01"].incidents).toHaveLength(1);
+    expect(bar.violations?.["bar-02"].incidents).toHaveLength(1);
+    expect(discovery.insights?.["discover-java-files"].incidents).toHaveLength(3);
+  });
+});
+
+describe("mergeRuleSets() adds new violations/incidents in the chosen files", () => {
+  it("adds an incident", () => {
+    const merged: RuleSet[] = produce(BASE_STATE, (draft) =>
+      mergeRuleSets(draft, PARTIAL_SINGLE_INCIDENT, SAVED_FILES),
+    );
+    expect(merged).toHaveLength(3);
+    const [foo] = merged;
+
+    expect(foo.violations?.["foo-01"].incidents).toHaveLength(1);
+    expect(foo.violations?.["foo-01"].incidents[0].message).toBe("new message");
+  });
+});

--- a/vscode/src/analysis/index.ts
+++ b/vscode/src/analysis/index.ts
@@ -1,0 +1,2 @@
+export * from "./runAnalysis";
+export * from "./mergeRuleSets";

--- a/vscode/src/analysis/mergeRuleSets.ts
+++ b/vscode/src/analysis/mergeRuleSets.ts
@@ -1,0 +1,59 @@
+import { RuleSet, Violation } from "@editor-extensions/shared";
+
+export const mergeRuleSets = (
+  draft: RuleSet[],
+  received: RuleSet[],
+  filePaths: string[],
+): RuleSet[] => {
+  // remove old incidents in the files included in the partial analysis
+  draft
+    .flatMap((it) => [...Object.values(it.violations ?? {})])
+    .filter((v) => v.incidents?.some((incident) => filePaths.includes(incident.uri)))
+    .forEach(
+      (v) => (v.incidents = v.incidents.filter((incident) => !filePaths.includes(incident.uri))),
+    );
+
+  // filter out empty rule sets
+  received
+    .map((it): [string, [string, Violation][]] => [
+      it.name ?? "",
+      Object.entries(it.violations ?? {}),
+    ])
+    .map(([name, violations]): [string, [string, Violation][]] => [
+      name,
+      violations.filter(([, violation]) => violation.incidents?.length),
+    ])
+    .filter(([, violations]) => violations.length)
+    // remaining violations contain incidents
+    .forEach(([name, violations]) => {
+      const current = draft.find((r) => r.name === name);
+      if (!current) {
+        // console.error("Missing current", draft);
+        return;
+      }
+
+      violations.forEach(([name, violation]) => {
+        if (!current.violations) {
+          current.violations = { [name]: violation };
+          return;
+        }
+
+        if (!current.violations[name]) {
+          current.violations[name] = violation;
+          // console.error("Missing target name", name, violation);
+          return;
+        }
+
+        if (!current.violations[name].incidents) {
+          current.violations[name].incidents = violation.incidents;
+          // console.error("Missing target incident", name, violation.incidents);
+          return;
+        }
+
+        current.violations[name].incidents.push(...violation.incidents);
+        // console.error("Pushed", current.violations[name].incidents, violation.incidents);
+      });
+    });
+
+  return draft;
+};

--- a/vscode/src/analysis/runAnalysis.ts
+++ b/vscode/src/analysis/runAnalysis.ts
@@ -1,0 +1,20 @@
+import { getConfigAnalyzeOnSave } from "../utilities";
+import { ExtensionState } from "../extensionState";
+import { TextDocument, commands, window } from "vscode";
+
+export const partialAnalysisTrigger = (textDoc: TextDocument) => {
+  commands.executeCommand("konveyor.partialAnalysis", [textDoc.fileName]);
+};
+
+export const runPartialAnalysis = async (state: ExtensionState, filePaths: string[]) => {
+  if (!getConfigAnalyzeOnSave()) {
+    return;
+  }
+
+  const analyzerClient = state.analyzerClient;
+  if (!analyzerClient || !analyzerClient.canAnalyze()) {
+    window.showErrorMessage("Analyzer must be started and configured before run!");
+    return;
+  }
+  analyzerClient.runAnalysis(filePaths);
+};

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -226,7 +226,7 @@ export class AnalyzerClient {
     return !!this.kaiRpcServer && !this.kaiRpcServer.killed;
   }
 
-  public async runAnalysis(): Promise<any> {
+  public async runAnalysis(filePaths?: string[]): Promise<any> {
     if (!this.rpcConnection) {
       vscode.window.showErrorMessage("RPC connection is not established.");
       return;
@@ -245,6 +245,7 @@ export class AnalyzerClient {
 
           const requestParams = {
             label_selector: getConfigLabelSelector(),
+            included_paths: filePaths,
           };
 
           this.outputChannel.appendLine(
@@ -268,7 +269,7 @@ export class AnalyzerClient {
             return;
           }
 
-          vscode.commands.executeCommand("konveyor.loadRuleSets", rulesets);
+          vscode.commands.executeCommand("konveyor.loadRuleSets", rulesets, filePaths);
           progress.report({ message: "Results processed!" });
           vscode.window.showInformationMessage("Analysis completed successfully!");
         } catch (err: any) {

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -30,6 +30,7 @@ import {
   getConfigLabelSelector,
   updateLabelSelector,
 } from "./utilities/configuration";
+import { runPartialAnalysis } from "./analysis";
 
 let fullScreenPanel: WebviewPanel | undefined;
 
@@ -362,6 +363,7 @@ const commandsMap: (state: ExtensionState) => {
     "konveyor.diffView.applyBlockInline": applyBlock,
     "konveyor.diffView.applySelection": applyBlock,
     "konveyor.diffView.applySelectionInline": applyBlock,
+    "konveyor.partialAnalysis": async (filePaths: string[]) => runPartialAnalysis(state, filePaths),
   };
 };
 

--- a/vscode/src/data/analyzerResults.ts
+++ b/vscode/src/data/analyzerResults.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import * as fs from "fs";
 import * as yaml from "js-yaml";
 import { RuleSet, Category, Incident } from "@editor-extensions/shared";
+import { Immutable } from "immer";
 
 //Assuming that output is in form of yaml
 export function readYamlFile(filePath: string): RuleSet[] | undefined {
@@ -22,11 +23,11 @@ export function readYamlFile(filePath: string): RuleSet[] | undefined {
 
 function getSeverityFromCategory(category: Category | undefined): vscode.DiagnosticSeverity {
   switch (category) {
-    case Category.Mandatory:
+    case "mandatory":
       return vscode.DiagnosticSeverity.Error;
-    case Category.Optional:
+    case "optional":
       return vscode.DiagnosticSeverity.Warning;
-    case Category.Potential:
+    case "potential":
       return vscode.DiagnosticSeverity.Hint;
     default:
       return vscode.DiagnosticSeverity.Information;
@@ -34,7 +35,7 @@ function getSeverityFromCategory(category: Category | undefined): vscode.Diagnos
 }
 
 export const processIncidents = (
-  ruleSets: RuleSet[],
+  ruleSets: Immutable<RuleSet[]>,
 ): ReadonlyArray<[vscode.Uri, vscode.Diagnostic[] | undefined]> =>
   ruleSets
     .flatMap((ruleSet) => Object.values(ruleSet.violations ?? {}))

--- a/vscode/src/extensionState.ts
+++ b/vscode/src/extensionState.ts
@@ -14,5 +14,5 @@ export interface ExtensionState {
   memFs: MemFS;
   fileModel: KonveyorFileModel;
   data: Immutable<ExtensionData>;
-  mutateData: (recipe: (draft: ExtensionData) => void) => void;
+  mutateData: (recipe: (draft: ExtensionData) => void) => Immutable<ExtensionData>;
 }

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -30,7 +30,7 @@ export function getConfigCodeSnipLimit(): number {
 }
 
 export function getConfigUseDefaultRulesets(): boolean {
-  return getConfigValue<boolean>("analysis.useDefaultRulesets") || true;
+  return getConfigValue<boolean>("analysis.useDefaultRulesets") ?? true;
 }
 
 export function getConfigCustomRules(): string[] {
@@ -42,15 +42,15 @@ export function getConfigLabelSelector(): string {
 }
 
 export function getConfigAnalyzeKnownLibraries(): boolean {
-  return getConfigValue<boolean>("analysis.analyzeKnownLibraries") || false;
+  return getConfigValue<boolean>("analysis.analyzeKnownLibraries") ?? false;
 }
 
 export function getConfigAnalyzeDependencies(): boolean {
-  return getConfigValue<boolean>("analysis.analyzeDependencies") || true;
+  return getConfigValue<boolean>("analysis.analyzeDependencies") ?? true;
 }
 
 export function getConfigAnalyzeOnSave(): boolean {
-  return getConfigValue<boolean>("analysis.analyzeOnSave") || true;
+  return getConfigValue<boolean>("analysis.analyzeOnSave") ?? true;
 }
 
 export function getConfigDiffEditorType(): string {

--- a/vscode/src/utilities/constants.ts
+++ b/vscode/src/utilities/constants.ts
@@ -1,5 +1,7 @@
 export const KONVEYOR_SCHEME = "konveyorMemFs";
 export const KONVEYOR_READ_ONLY_SCHEME = "konveyorReadOnly";
 export const RULE_SET_DATA_FILE_PREFIX = "analysis";
+export const PARTIAL_RULE_SET_DATA_FILE_PREFIX = "partial_analysis";
+export const MERGED_RULE_SET_DATA_FILE_PREFIX = "merged_analysis";
 export const SOLUTION_DATA_FILE_PREFIX = "solution";
 export const KONVEYOR_CONFIG_KEY = "konveyor";

--- a/webview-ui/src/components/AnalysisPage.tsx
+++ b/webview-ui/src/components/AnalysisPage.tsx
@@ -46,7 +46,7 @@ const AnalysisPage: React.FC = () => {
 
   const handleIncidentSelect = (incident: Incident) => {
     setFocusedIncident(incident);
-    dispatch(openFile(incident.uri, incident.lineNumber));
+    dispatch(openFile(incident.uri, incident.lineNumber ?? 0));
   };
 
   const runAnalysisRequest = () => dispatch(runAnalysis());

--- a/webview-ui/src/components/ViolationIncidentsList.tsx
+++ b/webview-ui/src/components/ViolationIncidentsList.tsx
@@ -29,7 +29,7 @@ import {
   CardFooter,
 } from "@patternfly/react-core";
 import { SortAmountDownIcon, TimesIcon, FileIcon, LightbulbIcon } from "@patternfly/react-icons";
-import { Incident, Violation } from "@editor-extensions/shared";
+import { Incident, Violation, Severity } from "@editor-extensions/shared";
 
 type SortOption = "description" | "incidentCount" | "severity";
 
@@ -78,12 +78,13 @@ const ViolationIncidentsList: React.FC<ViolationIncidentsListProps> = ({
   );
 
   const getHighestSeverity = (incidents: Incident[]): string => {
-    const severityOrder = { high: 3, medium: 2, low: 1 };
+    const severityOrder: { [key in Severity]: number } = { High: 3, Medium: 2, Low: 1 };
     return incidents.reduce((highest, incident) => {
-      const currentSeverity = severityOrder[incident.severity as keyof typeof severityOrder] || 0;
-      const highestSeverity = severityOrder[highest as keyof typeof severityOrder] || 0;
-      return currentSeverity > highestSeverity ? incident.severity : highest;
-    }, "low");
+      const incidentSeverity = incident.severity ?? "Low";
+      const currentSeverity = severityOrder[incidentSeverity];
+      const highestSeverity = severityOrder[highest];
+      return currentSeverity > highestSeverity ? incidentSeverity : highest;
+    }, "Low" as Severity);
   };
 
   const filteredAndSortedViolations = useMemo(() => {


### PR DESCRIPTION
1. register onDidSaveTextDocument() listener to track save operations
   inside editors and ensure proper clean-up
2. explicitly trigger partial analysis for files modified via apply
   actions
3. send chosen files inside included_paths parameter
4. save received responses with prefix "partial_analaysis" - this prevents
   multiple subsequent requests from overwriting last full analysis
5. save the result of merging the response with current state to files with
   prefix "merged_analysis" - this allows debugging and loading last state
   on IDE start
6. both partial_analysis and merged_analysis files are remove on the next
   full analysis

Test changes:
1. remove unused chai lib - the syntax used for assertions triggers
   eslint errors
2. use assertion from  "expect" lib known from Jest
3. create test:local target for simple tests that do not require VS Code
   runtime

Type changes:
1. replace Category enum with union type - enum is not exported
2. extract Severity type from Incident
3. make properties in Incident optional - this aligns the type with the
   test input where insights["name"].incidents have only uri and empty
   message

Resolves: https://github.com/konveyor/editor-extensions/issues/128
