### PR TITLE
:seedling: Fix vsce packaging warning

### DIFF
--- a/scripts/copy-dist.js
+++ b/scripts/copy-dist.js
@@ -41,6 +41,7 @@ await copy({
     {
       context: "vscode",
       src: [
+        ".vscodeignore",
         "LICENSE.md",
         "README.md",
         "CHANGELOG.md",

--- a/vscode/.vscodeignore
+++ b/vscode/.vscodeignore
@@ -1,36 +1,10 @@
-.vscode/**
-.vscode-test/**
-test_out/**
-node_modules/**
-src/**
-.gitignore
-.yarnrc
-webpack.config.js
-vsc-extension-quickstart.md
-**/tsconfig.json
-**/eslint.config.mjs
-**/*.map
-**/*.ts
-**/.vscode-test.*
-test_out/*
-
-# Exclude all unnecessary files and directories
-.git/
-node_modules/
-*.log
+# development paths and files
 .vscode/
-README.md
-CHANGELOG.md
-.vscodeignore
-.prettierignore
-.nvmrc
-*.lock
-.github/
-bin/
-assets/
-
-.husky/
-package-lock.json
+node_modules/
+src/
+.vscode-test.mjs
+.gitignore
+tsconfig.*
 
 # Don't include ANY file or directory that includes "../" in its name
 ../


### PR DESCRIPTION
Since `vsce` was complaining about a missing `.vscodeignore`, that file has been cleaned up and included in the copy-dist file list.  The warning is gone, and nothing changes with respect to the packaged contents.