### PR TITLE
:seedling: Include dummy `GENAI_KEY` in rpc server env

### DIFF
--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -407,6 +407,7 @@ export class AnalyzerClient {
    */
   public getKaiRpcServerEnv(): NodeJS.ProcessEnv {
     return {
+      GENAI_KEY: "dummy",
       ...process.env,
       // TODO: If/when necessary, add new envvars here from configuration
     };


### PR DESCRIPTION
The kai rpc server needs the `GENAI_KEY` envvar to be set so it can start up.  A valid key is _not_ needed to be able to run analysis.

Update the kai rpc server env function to insert the dummy value but let it be overridden by the value available in vscode's the actual envvars.
