### PR TITLE
:sparkles: Add issue tree view

### DIFF
--- a/shared/src/types/types.ts
+++ b/shared/src/types/types.ts
@@ -1,5 +1,7 @@
 import { Uri } from "vscode";
 
+export type WebviewType = "sidebar" | "resolution";
+
 export type Severity = "High" | "Medium" | "Low";
 
 export interface Incident {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -41,6 +41,24 @@
         "icon": "$(book)"
       },
       {
+        "command": "konveyor.expandAllIssues",
+        "title": "Expand All",
+        "category": "Konveyor",
+        "icon": "$(expand-all)"
+      },
+      {
+        "command": "konveyor.expandSingleIssue",
+        "title": "Expand All",
+        "category": "Konveyor",
+        "icon": "$(expand-all)"
+      },
+      {
+        "command": "konveyor.openAnalysisDetails",
+        "title": "Open Details",
+        "category": "Konveyor",
+        "icon": "$(book)"
+      },
+      {
         "command": "konveyor.overrideAnalyzerBinaries",
         "title": "Override Analyzer Binaries",
         "category": "Konveyor",
@@ -239,6 +257,11 @@
           "when": "view == konveyor.issueView"
         },
         {
+          "command": "konveyor.expandAllIssues",
+          "group": "navigation@2",
+          "when": "view == konveyor.issueView"
+        },
+        {
           "command": "konveyor.applyAll",
           "group": "navigation@1",
           "when": "view == konveyor.diffView"
@@ -255,6 +278,16 @@
         }
       ],
       "view/item/context": [
+        {
+          "command": "konveyor.expandSingleIssue",
+          "group": "inline@2",
+          "when": "view == konveyor.issueView && viewItem == incident-type-item"
+        },
+        {
+          "command": "konveyor.openAnalysisDetails",
+          "group": "inline@1",
+          "when": "view == konveyor.issueView && viewItem == incident-type-item"
+        },
         {
           "command": "konveyor.applyFile",
           "group": "inline",
@@ -318,6 +351,10 @@
       ],
       "konveyor.submenu": [],
       "commandPalette": [
+        {
+          "command": "konveyor.expandSingleIssue",
+          "when": "never"
+        },
         {
           "command": "konveyor.loadRuleSets",
           "when": "never"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -35,10 +35,10 @@
         "icon": "$(key)"
       },
       {
-        "command": "konveyor.toggleFullScreen",
-        "title": "Toggle Fullscreen",
+        "command": "konveyor.showAnalysisPanel",
+        "title": "Open Konveyor Analysis View",
         "category": "Konveyor",
-        "icon": "$(fullscreen)"
+        "icon": "$(book)"
       },
       {
         "command": "konveyor.overrideAnalyzerBinaries",
@@ -226,12 +226,6 @@
           "name": "Konveyor Issues"
         },
         {
-          "type": "webview",
-          "id": "konveyor.konveyorAnalysisView",
-          "name": "Konveyor Analysis View",
-          "visibility": "visible"
-        },
-        {
           "id": "konveyor.diffView",
           "name": "Konveyor Resolutions"
         }
@@ -240,9 +234,9 @@
     "menus": {
       "view/title": [
         {
-          "command": "konveyor.toggleFullScreen",
+          "command": "konveyor.showAnalysisPanel",
           "group": "navigation@1",
-          "when": "view == konveyor.konveyorAnalysisView"
+          "when": "view == konveyor.issueView"
         },
         {
           "command": "konveyor.applyAll",
@@ -290,13 +284,6 @@
           "command": "konveyor.copyPath",
           "group": "2@2",
           "when": "view == konveyor.diffView && viewItem == file-item"
-        }
-      ],
-      "editor/title": [
-        {
-          "command": "konveyor.toggleFullScreen",
-          "group": "navigation@1",
-          "when": "activeWebviewPanelId == konveyor.konveyorAnalysisView"
         }
       ],
       "diffEditor/gutter/selection": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -222,6 +222,10 @@
     "views": {
       "konveyor": [
         {
+          "id": "konveyor.issueView",
+          "name": "Konveyor Issues"
+        },
+        {
           "type": "webview",
           "id": "konveyor.konveyorAnalysisView",
           "name": "Konveyor Analysis View",

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -1,7 +1,6 @@
-import { setupWebviewMessageListener } from "./webviewMessageHandler";
 import { ExtensionState } from "./extensionState";
 import { sourceOptions, targetOptions } from "./config/labels";
-import { WebviewPanel, window, commands, Uri, OpenDialogOptions, ViewColumn } from "vscode";
+import { WebviewPanel, window, commands, Uri, OpenDialogOptions } from "vscode";
 import {
   cleanRuleSets,
   loadResultsFromDataFolder,
@@ -46,7 +45,6 @@ const commandsMap: (state: ExtensionState) => {
   [command: string]: (...args: any) => any;
 } = (state) => {
   const { extensionContext } = state;
-  const sidebarProvider = state.webviewProviders?.get("sidebar");
   return {
     "konveyor.startServer": async () => {
       const analyzerClient = state.analyzerClient;
@@ -106,64 +104,52 @@ const commandsMap: (state: ExtensionState) => {
       //   window.showErrorMessage("No webview available to run analysis!");
       // }
     },
-    "konveyor.focusKonveyorInput": async () => {
-      const fullScreenTab = getFullScreenTab();
-      if (!fullScreenTab) {
-        commands.executeCommand("konveyor.konveyorAnalysisView.focus");
-      } else {
-        fullScreenPanel?.reveal();
-      }
-      // sidebar.webviewProtocol?.request("focusInput", undefined);
-      // await addHighlightedCodeToContext(sidebar.webviewProtocol);
-    },
     "konveyor.toggleFullScreen": () => {
-      // TODO: refactor this to use showWebviewPanel
-      // Check if full screen is already open by checking open tabs
-      const fullScreenTab = getFullScreenTab();
-
-      // Check if the active editor is the GUI View
-      if (fullScreenTab && fullScreenTab.isActive) {
-        //Full screen open and focused - close it
-        commands.executeCommand("workbench.action.closeActiveEditor"); //this will trigger the onDidDispose listener below
-        return;
-      }
-
-      if (fullScreenTab && fullScreenPanel) {
-        //Full screen open, but not focused - focus it
-        fullScreenPanel.reveal();
-        return;
-      }
-
-      //create the full screen panel
-      const panel = window.createWebviewPanel(
-        "konveyor.konveyorFullScreenView",
-        "Konveyor",
-        ViewColumn.One,
-        {
-          retainContextWhenHidden: true,
-          enableScripts: true,
-          localResourceRoots: [
-            Uri.joinPath(extensionContext.extensionUri, "media"),
-            Uri.joinPath(extensionContext.extensionUri, "out"),
-          ],
-        },
-      );
-      fullScreenPanel = panel;
-      if (sidebarProvider) {
-        panel.webview.html = sidebarProvider.getHtmlForWebview(panel.webview);
-        setupWebviewMessageListener(panel.webview, state);
-        commands.executeCommand("workbench.action.closeSidebar");
-        //When panel closes, reset the webview and focus
-        panel.onDidDispose(
-          () => {
-            state.webviewProviders.delete("sidebar");
-            fullScreenPanel = undefined;
-            commands.executeCommand("konveyor.focusKonveyorInput");
-          },
-          null,
-          extensionContext.subscriptions,
-        );
-      }
+      // // TODO: refactor this to use showWebviewPanel
+      // // Check if full screen is already open by checking open tabs
+      // const fullScreenTab = getFullScreenTab();
+      // // Check if the active editor is the GUI View
+      // if (fullScreenTab && fullScreenTab.isActive) {
+      //   //Full screen open and focused - close it
+      //   commands.executeCommand("workbench.action.closeActiveEditor"); //this will trigger the onDidDispose listener below
+      //   return;
+      // }
+      // if (fullScreenTab && fullScreenPanel) {
+      //   //Full screen open, but not focused - focus it
+      //   fullScreenPanel.reveal();
+      //   return;
+      // }
+      // //create the full screen panel
+      // const panel = window.createWebviewPanel(
+      //   "konveyor.konveyorFullScreenView",
+      //   "Konveyor",
+      //   ViewColumn.One,
+      //   {
+      //     retainContextWhenHidden: true,
+      //     enableScripts: true,
+      //     localResourceRoots: [
+      //       Uri.joinPath(extensionContext.extensionUri, "media"),
+      //       Uri.joinPath(extensionContext.extensionUri, "out"),
+      //     ],
+      //   },
+      // );
+      // fullScreenPanel = panel;
+      // const sidebarProvider = state.webviewProviders?.get("sidebar");
+      // if (sidebarProvider) {
+      // panel.webview.html = sidebarProvider.getHtmlForWebview(panel.webview);
+      // setupWebviewMessageListener(panel.webview, state);
+      //   commands.executeCommand("workbench.action.closeSidebar");
+      //   //When panel closes, reset the webview and focus
+      //   panel.onDidDispose(
+      //     () => {
+      //       state.webviewProviders.delete("sidebar");
+      //       fullScreenPanel = undefined;
+      //       commands.executeCommand("konveyor.focusKonveyorInput");
+      //     },
+      //     null,
+      //     extensionContext.subscriptions,
+      //   );
+      // }
     },
     "konveyor.overrideAnalyzerBinaries": async () => {
       const options: OpenDialogOptions = {
@@ -398,6 +384,10 @@ const commandsMap: (state: ExtensionState) => {
     "konveyor.discardFile": async (item: FileItem | Uri) => discardFile(item, state),
     "konveyor.showResolutionPanel": () => {
       const resolutionProvider = state.webviewProviders?.get("resolution");
+      resolutionProvider?.showWebviewPanel();
+    },
+    "konveyor.showAnalysisPanel": () => {
+      const resolutionProvider = state.webviewProviders?.get("sidebar");
       resolutionProvider?.showWebviewPanel();
     },
     "konveyor.reloadLastResolutions": async () => reloadLastResolutions(state),

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -31,6 +31,7 @@ import {
   updateGenAiKey,
 } from "./utilities/configuration";
 import { runPartialAnalysis } from "./analysis";
+import { IncidentTypeItem } from "./issueView";
 
 let fullScreenPanel: WebviewPanel | undefined;
 
@@ -387,6 +388,12 @@ const commandsMap: (state: ExtensionState) => {
       resolutionProvider?.showWebviewPanel();
     },
     "konveyor.showAnalysisPanel": () => {
+      const resolutionProvider = state.webviewProviders?.get("sidebar");
+      resolutionProvider?.showWebviewPanel();
+    },
+    "konveyor.openAnalysisDetails": async (item: IncidentTypeItem) => {
+      //TODO: pass the item to webview and move the focus
+      console.log("Open details for ", item);
       const resolutionProvider = state.webviewProviders?.get("sidebar");
       resolutionProvider?.showWebviewPanel();
     },

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -9,6 +9,7 @@ import { registerDiffView, KonveyorFileModel } from "./diffView";
 import { MemFS } from "./data";
 import { Immutable, produce } from "immer";
 import { partialAnalysisTrigger } from "./analysis";
+import { IssuesModel, registerIssueView } from "./issueView";
 
 class VsCodeExtension {
   private state: ExtensionState;
@@ -50,6 +51,7 @@ class VsCodeExtension {
       diagnosticCollection: vscode.languages.createDiagnosticCollection("konveyor"),
       memFs: new MemFS(),
       fileModel: new KonveyorFileModel(),
+      issueModel: new IssuesModel(),
       get data() {
         return getData();
       },
@@ -64,6 +66,7 @@ class VsCodeExtension {
       this.checkWorkspace();
       this.registerWebviewProvider(context);
       this.listeners.push(this.onDidChangeData(registerDiffView(this.state)));
+      this.listeners.push(this.onDidChangeData(registerIssueView(this.state)));
       this.registerCommands();
       this.registerLanguageProviders(context);
       this.listeners.push(vscode.workspace.onDidSaveTextDocument(partialAnalysisTrigger));

--- a/vscode/src/extensionState.ts
+++ b/vscode/src/extensionState.ts
@@ -5,6 +5,7 @@ import { KonveyorGUIWebviewViewProvider } from "./KonveyorGUIWebviewViewProvider
 import * as vscode from "vscode";
 import { ExtensionData } from "@editor-extensions/shared";
 import { Immutable } from "immer";
+import { IssuesModel } from "./issueView";
 
 export interface ExtensionState {
   analyzerClient: AnalyzerClient;
@@ -13,6 +14,7 @@ export interface ExtensionState {
   diagnosticCollection: vscode.DiagnosticCollection;
   memFs: MemFS;
   fileModel: KonveyorFileModel;
+  issueModel: IssuesModel;
   data: Immutable<ExtensionData>;
   mutateData: (recipe: (draft: ExtensionData) => void) => Immutable<ExtensionData>;
 }

--- a/vscode/src/issueView/expandCommands.ts
+++ b/vscode/src/issueView/expandCommands.ts
@@ -1,0 +1,18 @@
+import { TreeView } from "vscode";
+import { IncidentTypeItem, IssuesModel, ReferenceItem, FileItem } from "./issueModel";
+
+export const expandAll = async (
+  model: IssuesModel,
+  treeView: TreeView<IncidentTypeItem | FileItem | ReferenceItem>,
+) => {
+  for (const item of model.items.reverse()) {
+    await treeView.reveal(item, { select: false, focus: false, expand: 2 });
+  }
+};
+
+export const expandChildren = (
+  item: IncidentTypeItem | FileItem | ReferenceItem,
+  treeView: TreeView<IncidentTypeItem | FileItem | ReferenceItem>,
+) => {
+  treeView.reveal(item, { select: false, focus: false, expand: 2 });
+};

--- a/vscode/src/issueView/index.ts
+++ b/vscode/src/issueView/index.ts
@@ -1,2 +1,3 @@
 export * from "./issueModel";
 export * from "./register";
+export * from "./transformation";

--- a/vscode/src/issueView/index.ts
+++ b/vscode/src/issueView/index.ts
@@ -1,0 +1,2 @@
+export * from "./issueModel";
+export * from "./register";

--- a/vscode/src/issueView/issueModel.ts
+++ b/vscode/src/issueView/issueModel.ts
@@ -1,0 +1,339 @@
+/*---------------------------------------------------------------------------------------------
+ *  Contains substantial parts of: https://github.com/microsoft/vscode/blob/e1e29b63e245d9564f6acaafa53645ca4ca62f96/extensions/references-view/src/references/model.ts#L1
+ *
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License.
+ *
+ *  MIT License
+ *
+ *  Copyright (c) 2015 - present Microsoft Corporation
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Incident, RuleSet } from "@editor-extensions/shared";
+import { Immutable } from "immer";
+import * as vscode from "vscode";
+
+export class IssuesModel {
+  private _onDidChange = new vscode.EventEmitter<
+    IncidentTypeItem | FileItem | ReferenceItem | undefined
+  >();
+  readonly onDidChangeTreeData = this._onDidChange.event;
+
+  readonly items: IncidentTypeItem[] = [];
+
+  constructor() {}
+
+  findIncidentType(msg: string) {
+    return this.items.find((it) => it.msg === msg);
+  }
+  findFileItem(incidentMsg: string, fileUri: string) {
+    return this.findIncidentType(incidentMsg)?.files.find((it) => it.uri === fileUri);
+  }
+
+  updateIssues(ruleSets: Immutable<RuleSet[]>) {
+    const allIncidents: Incident[] = ruleSets
+      .flatMap((r) => Object.values(r.violations ?? {}))
+      .flatMap((v) => v?.incidents ?? [])
+      // ensure basic properties are valid
+      .filter(
+        (it) =>
+          // allow empty messages (they will be grouped together)
+          typeof it.message === "string" &&
+          typeof it.uri === "string" &&
+          Number.isInteger(it.lineNumber) &&
+          // expect non-empty path in format file:///some/file.ext
+          it.uri &&
+          // expect 1-based numbering (vscode.Position is zero-based)
+          it.lineNumber > 0,
+      );
+
+    const incidentsByMsg: { [msg: string]: [string, Incident][] } = allIncidents
+      .map((it): [string, string, Incident] => [it.message, it.uri, it])
+      .reduce(
+        (acc, [msg, uri, incident]) => {
+          if (!acc[msg]) {
+            acc[msg] = [];
+          }
+          acc[msg].push([uri, incident]);
+          return acc;
+        },
+        {} as { [msg: string]: [string, Incident][] },
+      );
+
+    // entries [msg, incidentsByFile]
+    const treeItemsAsEntries: [string, { [uri: string]: Incident[] }][] = Object.entries(
+      incidentsByMsg,
+    ).map(([msg, incidents]) => [
+      msg,
+      incidents.reduce(
+        (acc, [uri, incident]) => {
+          if (!acc[uri]) {
+            acc[uri] = [];
+          }
+          acc[uri].push(incident);
+          return acc;
+        },
+        {} as { [uri: string]: Incident[] },
+      ),
+    ]);
+
+    const items = treeItemsAsEntries
+      .map(([msg, incidentsByFile]): [string, [string, Incident[]][]] => [
+        msg,
+        Object.entries(incidentsByFile),
+      ])
+      .map(([msg, incidentsByFileAsEntries]): [string, FileItem[]] => [
+        msg,
+        incidentsByFileAsEntries.map(
+          ([uri, incidents]) =>
+            new FileItem(
+              uri,
+              incidents
+                .map((it) => new ReferenceItem(it, uri, this))
+                .toSorted((a, b) => a.incident.lineNumber - b.incident.lineNumber),
+              msg,
+              this,
+            ),
+        ),
+      ])
+      .map(
+        ([msg, fileItems]) =>
+          new IncidentTypeItem(
+            msg,
+            fileItems.toSorted((a, b) => a.uri.localeCompare(b.uri)),
+            this,
+          ),
+      );
+
+    this.items.splice(0, this.items.length);
+    this.items.push(...items);
+    this._onDidChange.fire(undefined);
+  }
+
+  // --- adapter
+
+  get message() {
+    if (this.items.length === 0) {
+      return vscode.l10n.t("No results.");
+    }
+    //unique files
+    const files = this.items.reduce(
+      (prev, cur) => new Set([...cur.files.map((it) => it.uri), ...Array.from(prev)]),
+      new Set(),
+    ).size;
+    const total = this.items.length;
+    if (total === 1 && files === 1) {
+      return vscode.l10n.t("{0} result in {1} file", total, files);
+    } else if (total === 1) {
+      return vscode.l10n.t("{0} result in {1} files", total, files);
+    } else if (files === 1) {
+      return vscode.l10n.t("{0} results in {1} file", total, files);
+    } else {
+      return vscode.l10n.t("{0} results in {1} files", total, files);
+    }
+  }
+
+  location(item: IncidentTypeItem | FileItem | ReferenceItem) {
+    if (item instanceof ReferenceItem) {
+      return item.location;
+    }
+    if (item instanceof FileItem) {
+      return item.references[0]?.location ?? item.location;
+    }
+    return undefined;
+  }
+
+  remove(item: IncidentTypeItem | FileItem | ReferenceItem) {
+    // TODO not implemented
+  }
+}
+
+export class IssuesTreeDataProvider
+  implements vscode.TreeDataProvider<IncidentTypeItem | FileItem | ReferenceItem>
+{
+  private readonly _listener: vscode.Disposable;
+  private readonly _onDidChange = new vscode.EventEmitter<
+    IncidentTypeItem | FileItem | ReferenceItem | undefined
+  >();
+
+  readonly onDidChangeTreeData = this._onDidChange.event;
+
+  constructor(private readonly _model: IssuesModel) {
+    this._listener = _model.onDidChangeTreeData(() => this._onDidChange.fire(undefined));
+  }
+
+  dispose(): void {
+    this._onDidChange.dispose();
+    this._listener.dispose();
+  }
+
+  async getTreeItem(element: IncidentTypeItem | FileItem | ReferenceItem) {
+    if (element instanceof FileItem) {
+      // files
+      const result = new vscode.TreeItem(element.location.uri);
+      result.contextValue = "file-item";
+      result.description = true;
+      result.iconPath = vscode.ThemeIcon.File;
+      result.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+      return result;
+    } else if (element instanceof ReferenceItem) {
+      // references
+      const { range } = element.location;
+      const doc = await element.getDocument();
+      const preview = getPreviewChunks(doc, range);
+
+      // use fixed padding
+      // TODO: retrieve max line number to determine pad count at runtime
+      const lineNumber = (element.incident?.lineNumber?.toString() ?? " ").padStart(3);
+      const label: vscode.TreeItemLabel = {
+        label: `${lineNumber}  ${preview}`,
+        // highlight line number
+        highlights: [[0, 3]],
+      };
+
+      const result = new vscode.TreeItem(label);
+      result.collapsibleState = vscode.TreeItemCollapsibleState.None;
+      result.contextValue = "reference-item";
+      result.command = {
+        command: "vscode.open",
+        title: vscode.l10n.t("Open Reference"),
+        arguments: [
+          element.location.uri,
+          { selection: range.with({ end: range.start }) } satisfies vscode.TextDocumentShowOptions,
+        ],
+      };
+      return result;
+    } else {
+      // IncidentTypeItem
+      const result = new vscode.TreeItem(element.msg);
+      result.contextValue = "incident-type-item";
+      result.description = true;
+      result.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+      return result;
+    }
+  }
+
+  async getChildren(element?: IncidentTypeItem | FileItem | ReferenceItem) {
+    if (!element) {
+      return this._model.items;
+    }
+    if (element instanceof IncidentTypeItem) {
+      return element.files;
+    }
+    if (element instanceof FileItem) {
+      return element.references;
+    }
+    return undefined;
+  }
+
+  getParent(element: IncidentTypeItem | FileItem | ReferenceItem) {
+    if (element instanceof IncidentTypeItem) {
+      return undefined;
+    }
+    if (element instanceof FileItem) {
+      return element.getParent();
+    }
+    if (element instanceof ReferenceItem) {
+      return element.getParent();
+    }
+    return undefined;
+  }
+}
+
+export class IncidentTypeItem {
+  constructor(
+    readonly msg: string,
+    readonly files: Array<FileItem>,
+    readonly model: IssuesModel,
+  ) {}
+}
+
+export class FileItem {
+  readonly location: vscode.Location;
+  constructor(
+    readonly uri: string,
+    readonly references: Array<ReferenceItem>,
+    readonly incidentMsg: string,
+    readonly model: IssuesModel,
+  ) {
+    this.location = new vscode.Location(
+      vscode.Uri.parse(uri),
+      new vscode.Position(0, Number.MAX_SAFE_INTEGER),
+    );
+  }
+
+  getParent() {
+    return this.model.findIncidentType(this.incidentMsg);
+  }
+  // --- adapter
+
+  remove(): void {
+    // TODO not implemented
+  }
+}
+
+export class ReferenceItem {
+  private _document: Thenable<vscode.TextDocument> | undefined;
+  readonly location: vscode.Location;
+
+  constructor(
+    readonly incident: Incident,
+    readonly fileUri: string,
+    readonly model: IssuesModel,
+  ) {
+    const safeLineNumber = Math.max((incident.lineNumber ?? 0) - 1, 0);
+    this.location = new vscode.Location(
+      vscode.Uri.parse(fileUri),
+      new vscode.Range(
+        new vscode.Position(safeLineNumber, 0),
+        new vscode.Position(safeLineNumber, Number.MAX_SAFE_INTEGER),
+      ),
+    );
+  }
+
+  async getDocument() {
+    if (!this._document) {
+      this._document = vscode.workspace.openTextDocument(this.location.uri);
+    }
+    return this._document;
+  }
+
+  getParent() {
+    return this.model.findFileItem(this.incident.message, this.fileUri);
+  }
+
+  // --- adapter
+
+  remove(): void {
+    // TODO not implemented
+  }
+}
+
+/* preview modified to handle full-lines only
+ */
+export function getPreviewChunks(
+  doc: vscode.TextDocument,
+  range: vscode.Range,
+  trim: boolean = true,
+) {
+  const inside = doc.getText(new vscode.Range(range.start, range.start.translate(0, 331)));
+  return trim ? inside.replace(/^\s*/g, "") : inside;
+}

--- a/vscode/src/issueView/issueModel.ts
+++ b/vscode/src/issueView/issueModel.ts
@@ -62,7 +62,7 @@ export class IssuesModel {
           // expect non-empty path in format file:///some/file.ext
           it.uri &&
           // expect 1-based numbering (vscode.Position is zero-based)
-          it.lineNumber > 0,
+          it.lineNumber! > 0,
       );
 
     const incidentsByMsg: { [msg: string]: [string, Incident][] } = allIncidents
@@ -108,7 +108,7 @@ export class IssuesModel {
               uri,
               incidents
                 .map((it) => new ReferenceItem(it, uri, this))
-                .toSorted((a, b) => a.incident.lineNumber - b.incident.lineNumber),
+                .toSorted((a, b) => a.incident.lineNumber! - b.incident.lineNumber!),
               msg,
               this,
             ),

--- a/vscode/src/issueView/issueModel.ts
+++ b/vscode/src/issueView/issueModel.ts
@@ -139,15 +139,18 @@ export class IssuesModel {
       (prev, cur) => new Set([...cur.files.map((it) => it.uri), ...Array.from(prev)]),
       new Set(),
     ).size;
-    const total = this.items.length;
-    if (total === 1 && files === 1) {
-      return vscode.l10n.t("{0} result in {1} file", total, files);
-    } else if (total === 1) {
-      return vscode.l10n.t("{0} result in {1} files", total, files);
+    const totalIncidents = this.items.reduce(
+      (sum, it) => sum + it.files.reduce((sum, fileItem) => sum + fileItem.references.length, 0),
+      0,
+    );
+    if (totalIncidents === 1 && files === 1) {
+      return vscode.l10n.t("{0} result in {1} file", totalIncidents, files);
+    } else if (totalIncidents === 1) {
+      return vscode.l10n.t("{0} result in {1} files", totalIncidents, files);
     } else if (files === 1) {
-      return vscode.l10n.t("{0} results in {1} file", total, files);
+      return vscode.l10n.t("{0} results in {1} file", totalIncidents, files);
     } else {
-      return vscode.l10n.t("{0} results in {1} files", total, files);
+      return vscode.l10n.t("{0} results in {1} files", totalIncidents, files);
     }
   }
 

--- a/vscode/src/issueView/register.ts
+++ b/vscode/src/issueView/register.ts
@@ -22,12 +22,19 @@ export function registerIssueView({
     treeView.message = model.message;
   });
 
+  let firstLoad = true;
   let lastRuleSets: Immutable<RuleSet[]> = [];
   return (data: Immutable<ExtensionData>) => {
     // by-reference comparison assumes immutable state object
     if (lastRuleSets !== data.ruleSets) {
       model.updateIssues(data.ruleSets);
       lastRuleSets = data.ruleSets;
+    }
+    if (firstLoad) {
+      firstLoad = false;
+      // TODO: re-implement to be explicitly part of the extension lifecycle
+      // current code relies on the side effects
+      vscode.commands.executeCommand("konveyor.showAnalysisPanel");
     }
   };
 }

--- a/vscode/src/issueView/register.ts
+++ b/vscode/src/issueView/register.ts
@@ -1,0 +1,33 @@
+import { ExtensionState } from "src/extensionState";
+import * as vscode from "vscode";
+import { IssuesTreeDataProvider } from "./issueModel";
+import { Immutable } from "immer";
+import { ExtensionData, RuleSet } from "@editor-extensions/shared";
+
+export function registerIssueView({
+  extensionContext: context,
+  issueModel: model,
+}: ExtensionState): (data: Immutable<ExtensionData>) => void {
+  const provider = new IssuesTreeDataProvider(model);
+  vscode.window.registerTreeDataProvider("konveyor.issueView", provider);
+  const treeView = vscode.window.createTreeView<unknown>("konveyor.issueView", {
+    treeDataProvider: provider,
+    showCollapseAll: true,
+  });
+
+  treeView.message = model.message;
+  context.subscriptions.push(treeView);
+
+  provider.onDidChangeTreeData(() => {
+    treeView.message = model.message;
+  });
+
+  let lastRuleSets: Immutable<RuleSet[]> = [];
+  return (data: Immutable<ExtensionData>) => {
+    // by-reference comparison assumes immutable state object
+    if (lastRuleSets !== data.ruleSets) {
+      model.updateIssues(data.ruleSets);
+      lastRuleSets = data.ruleSets;
+    }
+  };
+}

--- a/vscode/src/issueView/register.ts
+++ b/vscode/src/issueView/register.ts
@@ -1,8 +1,9 @@
 import { ExtensionState } from "src/extensionState";
 import * as vscode from "vscode";
-import { IssuesTreeDataProvider } from "./issueModel";
+import { FileItem, IncidentTypeItem, IssuesTreeDataProvider, ReferenceItem } from "./issueModel";
 import { Immutable } from "immer";
 import { ExtensionData, RuleSet } from "@editor-extensions/shared";
+import { expandAll, expandChildren } from "./expandCommands";
 
 export function registerIssueView({
   extensionContext: context,
@@ -10,17 +11,34 @@ export function registerIssueView({
 }: ExtensionState): (data: Immutable<ExtensionData>) => void {
   const provider = new IssuesTreeDataProvider(model);
   vscode.window.registerTreeDataProvider("konveyor.issueView", provider);
-  const treeView = vscode.window.createTreeView<unknown>("konveyor.issueView", {
-    treeDataProvider: provider,
-    showCollapseAll: true,
-  });
+  const treeView = vscode.window.createTreeView<IncidentTypeItem | FileItem | ReferenceItem>(
+    "konveyor.issueView",
+    {
+      treeDataProvider: provider,
+      showCollapseAll: true,
+    },
+  );
 
   treeView.message = model.message;
+  treeView.badge = model.badge;
   context.subscriptions.push(treeView);
-
   provider.onDidChangeTreeData(() => {
     treeView.message = model.message;
+    treeView.badge = model.badge;
   });
+  // auto-expand nodes with only one child
+  treeView.onDidExpandElement((event) => {
+    const element = event.element;
+    if (element.hasOneChild()) {
+      treeView.reveal(element, { select: false, focus: false, expand: 2 });
+    }
+  });
+
+  vscode.commands.registerCommand("konveyor.expandAllIssues", () => expandAll(model, treeView));
+  vscode.commands.registerCommand(
+    "konveyor.expandSingleIssue",
+    (item: IncidentTypeItem | FileItem | ReferenceItem) => expandChildren(item, treeView),
+  );
 
   let firstLoad = true;
   let lastRuleSets: Immutable<RuleSet[]> = [];
@@ -30,6 +48,7 @@ export function registerIssueView({
       model.updateIssues(data.ruleSets);
       lastRuleSets = data.ruleSets;
     }
+
     if (firstLoad) {
       firstLoad = false;
       // TODO: re-implement to be explicitly part of the extension lifecycle

--- a/vscode/src/issueView/transformation.ts
+++ b/vscode/src/issueView/transformation.ts
@@ -1,0 +1,19 @@
+import { Incident, RuleSet } from "@editor-extensions/shared";
+import { Immutable } from "immer";
+
+export const allIncidents = (ruleSets: Immutable<RuleSet[]>): Incident[] =>
+  ruleSets
+    .flatMap((r) => Object.values(r.violations ?? {}))
+    .flatMap((v) => v?.incidents ?? [])
+    // ensure basic properties are valid
+    .filter(
+      (it) =>
+        // allow empty messages (they will be grouped together)
+        typeof it.message === "string" &&
+        typeof it.uri === "string" &&
+        Number.isInteger(it.lineNumber) &&
+        // expect non-empty path in format file:///some/file.ext
+        it.uri &&
+        // expect 1-based numbering (vscode.Position is zero-based)
+        it.lineNumber! > 0,
+    );

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -3,9 +3,10 @@ import React, { useState, useEffect } from "react";
 import { viewType } from "./utils/vscode";
 import AnalysisPage from "./components/AnalysisPage/AnalysisPage";
 import ResolutionPage from "./components/ResolutionsPage";
+import { WebviewType } from "@editor-extensions/shared";
 
 const App: React.FC = () => {
-  const [currentView, setCurrentView] = useState<string>(viewType);
+  const [currentView, setCurrentView] = useState<WebviewType>(viewType);
 
   useEffect(() => {
     // Update the view when viewType changes

--- a/webview-ui/src/hooks/useExtensionState.ts
+++ b/webview-ui/src/hooks/useExtensionState.ts
@@ -14,15 +14,23 @@ const defaultState: ExtensionData = {
   solutionScope: undefined,
 };
 
+const windowState =
+  typeof window["konveyorInitialData"] === "object"
+    ? (window["konveyorInitialData"] as ExtensionData)
+    : defaultState;
+
 export function useExtensionState(): [
   ExtensionData,
   (message: WebviewAction<WebviewActionType, unknown>) => void,
 ] {
-  const [state, setState] = useState<ExtensionData>(defaultState);
+  const [state, setState] = useState<ExtensionData>(windowState);
 
   useEffect(() => {
-    const handleMessage = (event: MessageEvent<ExtensionData>) => setState(event.data);
-
+    const handleMessage = (event: MessageEvent<ExtensionData>) => {
+      console.warn("useExtensionState - handleMessage", event);
+      setState(event.data);
+    };
+    console.warn("useExtensionState - useEffect");
     window.addEventListener("message", handleMessage);
 
     return () => {

--- a/webview-ui/src/hooks/useExtensionState.ts
+++ b/webview-ui/src/hooks/useExtensionState.ts
@@ -27,10 +27,8 @@ export function useExtensionState(): [
 
   useEffect(() => {
     const handleMessage = (event: MessageEvent<ExtensionData>) => {
-      console.warn("useExtensionState - handleMessage", event);
       setState(event.data);
     };
-    console.warn("useExtensionState - useEffect");
     window.addEventListener("message", handleMessage);
 
     return () => {

--- a/webview-ui/src/utils/vscode.ts
+++ b/webview-ui/src/utils/vscode.ts
@@ -1,3 +1,5 @@
+import { WebviewType } from "@editor-extensions/shared";
+
 // vscode.ts
 export interface VscodeApi {
   postMessage(message: any): void;
@@ -8,7 +10,7 @@ export interface VscodeApi {
 declare global {
   interface Window {
     vscode: VscodeApi;
-    viewType: "sidebar" | "resolution"; // Declare the expected types for viewType
+    viewType: WebviewType; // Declare the expected types for viewType
   }
 }
 
@@ -16,4 +18,4 @@ declare global {
 export const vscode: VscodeApi = window.vscode;
 
 // export const viewType: string = "sidebar" | "resolution";
-export const viewType: "sidebar" | "resolution" = window.viewType || "sidebar"; // Default to "sidebar" if not set
+export const viewType: WebviewType = window.viewType || "sidebar"; // Default to "sidebar" if not set


### PR DESCRIPTION
Layout:
1. group incidents by message (top level) and file (2nd level)
2. within message group the files are sorted based on the entire path
3. within file group the incidents are sorted based on line number

Actions:
1. top bar
     1. open Analysis webview 
     2. expand all nodes 
2. context:
     1. open details in Analysis webview (currently just opens the webview) 
     2. expand all child nodes
3. one-click expand for nodes with only one child 
4. open Analysis webview when extension is loaded (first time the perspective is accessed)

Refactorings:
1. move Analysis web view to the editor section (similar to Resolution webview)
2. disable full screen toggling for Analysis webview
3. embed initial state data in the HTML to ensure that first message won't be missed

Reference-Url: https://github.com/konveyor/editor-extensions/issues/140
