### PR TITLE
:sparkles: Remove default toml arguments and use settings.json

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -510,7 +510,12 @@
         },
         "konveyor.kai.providerArgs": {
           "type": "object",
-          "default": {},
+          "default": {
+            "model_id": "meta-llama/llama-3-1-70b-instruct",
+            "parameters": {
+              "max_new_tokens": 2048
+            }
+          },
           "description": "Kai provider arguments",
           "scope": "window"
         },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -525,6 +525,12 @@
           "description": "Generative AI Key",
           "scope": "window"
         },
+        "konveyor.kai.demoMode": {
+          "type": "boolean",
+          "default": false,
+          "description": "Demo mode for Kai",
+          "scope": "window"
+        },
         "konveyor.kai.getSolutionMaxPriority": {
           "type": "number",
           "default": 0,

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -525,12 +525,6 @@
           "description": "Generative AI Key",
           "scope": "window"
         },
-        "konveyor.kai.demoMode": {
-          "type": "boolean",
-          "default": false,
-          "description": "Demo mode for Kai",
-          "scope": "window"
-        },
         "konveyor.kai.getSolutionMaxPriority": {
           "type": "number",
           "default": 0,

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -552,14 +552,6 @@ export class AnalyzerClient {
     return `log_level = "info"
 file_log_level = "debug"
 log_dir = "${log_dir}"
-
-[models]
-provider = "ChatIBMGenAI"
-
-[models.args]
-model_id = "meta-llama/llama-3-70b-instruct"
-parameters.max_new_tokens = "2048"
-
 `;
   }
 }

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -11,7 +11,6 @@ import { Extension } from "../helpers/Extension";
 import { ExtensionState } from "../extensionState";
 import { buildAssetPaths, AssetPaths } from "./paths";
 import {
-  KONVEYOR_CONFIG_KEY,
   getConfigKaiBackendURL,
   getConfigLogLevel,
   getConfigKaiProviderName,
@@ -24,6 +23,7 @@ import {
   getConfigMaxDepth,
   getConfigMaxIterations,
   getConfigMaxPriority,
+  getConfigKaiDemoMode,
 } from "../utilities";
 
 export class AnalyzerClient {
@@ -163,19 +163,12 @@ export class AnalyzerClient {
     this.outputChannel.appendLine(`kai rpc server stopped`);
   }
 
-  // This config value is intentionally excluded from package.json
   protected isDemoMode(): boolean {
-    const configDemoMode = vscode.workspace
-      .getConfiguration(KONVEYOR_CONFIG_KEY)
-      ?.get<boolean>("konveyor.kai.demoMode");
+    const configDemoMode = getConfigKaiDemoMode();
 
-    let demoMode: boolean;
-    if (configDemoMode !== undefined) {
-      demoMode = configDemoMode;
-    } else {
-      demoMode = !Extension.getInstance(this.extContext).isProductionMode;
-    }
-    return demoMode;
+    return configDemoMode !== undefined
+      ? configDemoMode
+      : !Extension.getInstance(this.extContext).isProductionMode;
   }
 
   public async initialize(): Promise<void> {

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -69,6 +69,11 @@ export function getConfigKaiProviderArgs(): object {
   return getConfigValue<object>("kai.providerArgs") || {};
 }
 
+export function getConfigKaiDemoMode(): boolean {
+  console.log("getConfigKaiDemoMode inside call", getConfigValue<boolean>("kai.demoMode"));
+  return getConfigValue<boolean>("kai.demoMode") ?? false;
+}
+
 async function updateConfigValue<T>(
   key: string,
   value: T | undefined,

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -70,7 +70,6 @@ export function getConfigKaiProviderArgs(): object {
 }
 
 export function getConfigKaiDemoMode(): boolean {
-  console.log("getConfigKaiDemoMode inside call", getConfigValue<boolean>("kai.demoMode"));
   return getConfigValue<boolean>("kai.demoMode") ?? false;
 }
 


### PR DESCRIPTION
- Toml values overwrite configured settings. Removing these values for now. 
- Add in defaults for providerArgs
- Allow demoMode to be set from settings.json