### PR TITLE
:sparkles: Set cwd for `kai-rpc-server` to a `.vscode/` path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "vscode"
       ],
       "dependencies": {
+        "fs-extra": "^11.2.0",
         "globby": "^14.0.2",
         "immer": "10.1.1",
         "js-yaml": "^4.1.0",
@@ -25,6 +26,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.11.1",
+        "@types/fs-extra": "^11.0.4",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "22.x",
         "@types/react": "^18.3.11",
@@ -41,7 +43,6 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.14",
         "eslint-plugin-unused-imports": "^4.1.4",
-        "fs-extra": "^11.2.0",
         "globals": "^15.0.0",
         "husky": "^9.1.6",
         "lint-staged": "^15.2.10",
@@ -2122,6 +2123,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2162,6 +2174,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/mocha": {
       "version": "10.0.9",
@@ -5726,7 +5748,6 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",
+    "@types/fs-extra": "^11.0.4",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "22.x",
     "@types/react": "^18.3.11",
@@ -78,7 +79,6 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "eslint-plugin-unused-imports": "^4.1.4",
-    "fs-extra": "^11.2.0",
     "globals": "^15.0.0",
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",
@@ -90,6 +90,7 @@
     "unzipper": "^0.12.3"
   },
   "dependencies": {
+    "fs-extra": "^11.2.0",
     "globby": "^14.0.2",
     "immer": "10.1.1",
     "js-yaml": "^4.1.0",

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -1,7 +1,7 @@
 import { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { setTimeout } from "node:timers/promises";
+import * as fs from "fs-extra";
 import * as vscode from "vscode";
 import * as rpc from "vscode-jsonrpc/node";
 import { Incident, RuleSet, SolutionResponse, Violation } from "@editor-extensions/shared";
@@ -33,6 +33,7 @@ export class AnalyzerClient {
   private outputChannel: vscode.OutputChannel;
   private assetPaths: AssetPaths;
   private kaiDir: string;
+  private kaiRuntimeDir: string;
   private kaiConfigToml: string;
   private fireStateChange: (state: ServerState) => void;
   private fireAnalysisStateChange: (flag: boolean) => void;
@@ -60,7 +61,11 @@ export class AnalyzerClient {
 
     this.assetPaths = buildAssetPaths(extContext);
     this.kaiDir = path.join(buildDataFolderPath()!, "kai");
+    this.kaiRuntimeDir = path.join(buildDataFolderPath()!, "kai-runtime");
     this.kaiConfigToml = path.join(this.kaiDir, "kai-config.toml");
+
+    fs.ensureDirSync(this.kaiDir);
+    fs.ensureDirSync(this.kaiRuntimeDir);
 
     this.outputChannel.appendLine(
       `current asset paths: ${JSON.stringify(this.assetPaths, null, 2)}`,
@@ -77,20 +82,19 @@ export class AnalyzerClient {
       return;
     }
 
-    // TODO: If the server generates files in cwd, we should set this to something else
-    const serverCwd = this.extContext.extensionPath;
+    const serverCwd = this.kaiRuntimeDir;
+    const serverEnv = await this.getKaiRpcServerEnv();
+    const serverPath = this.getKaiRpcServerPath();
+    const serverArgs = this.getKaiRpcServerArgs();
 
     this.fireStateChange("starting");
     this.outputChannel.appendLine(`Starting the kai rpc server ...`);
     this.outputChannel.appendLine(`server cwd: ${serverCwd}`);
-    this.outputChannel.appendLine(`server path: ${this.getKaiRpcServerPath()}`);
+    this.outputChannel.appendLine(`server path: ${serverPath}`);
     this.outputChannel.appendLine(`server args:`);
-    this.getKaiRpcServerArgs().forEach((arg) => this.outputChannel.appendLine(`   ${arg}`));
+    serverArgs.forEach((arg) => this.outputChannel.appendLine(`   ${arg}`));
 
-    // Retrieve the environment variables asynchronously
-    const serverEnv = await this.getKaiRpcServerEnv();
-
-    const kaiRpcServer = spawn(this.getKaiRpcServerPath(), this.getKaiRpcServerArgs(), {
+    const kaiRpcServer = spawn(serverPath, serverArgs, {
       cwd: serverCwd,
       env: serverEnv,
     });
@@ -528,10 +532,6 @@ export class AnalyzerClient {
   }
 
   public getKaiConfigTomlPath(): string {
-    if (!fs.existsSync(this.kaiDir)) {
-      fs.mkdirSync(this.kaiDir, { recursive: true });
-    }
-
     // Ensure the file exists with default content if it doesn't
     // Consider making this more robust, maybe this is an asset we can get from kai?
     if (!fs.existsSync(this.kaiConfigToml)) {


### PR DESCRIPTION
The `kai-rpc-server` processes generate some working directories that are created in the process's given working directory. Set the process's current working directory to a path under the workspace's `.vscode/` directory.  This will ensure that if multiple vscode windows are open, the konveyor runtime binaries will not clash with each other.

The process will run with a cwd of:
   `{{workspace_root}}/.vscode/konveyor/kai-runtime`
