### PR TITLE
:seedling: Use kai binaries from release v0.0.3

### DIFF
--- a/scripts/_download.js
+++ b/scripts/_download.js
@@ -133,7 +133,7 @@ export async function downloadGitHubRelease({
     };
 
     for (const { name, platform, arch, chmod } of assets) {
-      const releaseAsset = releaseAssets.find((a) => a.name === name);
+      const releaseAsset = releaseAssets.find((a) => a.name.toLowerCase() === name.toLowerCase());
       if (releaseAsset) {
         try {
           console.group(yellow(releaseAsset.name));

--- a/scripts/collect-assets.js
+++ b/scripts/collect-assets.js
@@ -17,7 +17,7 @@ await downloadGitHubRelease({
 
   org: "konveyor",
   repo: "kai",
-  releaseTag: "v0.0.2",
+  releaseTag: "v0.0.3",
 
   /*
     Release asset filenames and nodejs equivalent platform/arch
@@ -26,9 +26,11 @@ await downloadGitHubRelease({
   */
   assets: [
     { name: "kai-rpc-server.linux-x86_64.zip", platform: "linux", arch: "x64", chmod: true },
-    { name: "kai-rpc-server.macos-arm64.zip", platform: "darwin", arch: "arm64", chmod: true },
+    { name: "kai-rpc-server.linux-aarch64.zip", platform: "linux", arch: "arm64", chmod: true },
     { name: "kai-rpc-server.macos-x86_64.zip", platform: "darwin", arch: "x64", chmod: true },
-    { name: "kai-rpc-server.windows-x86_64.zip", platform: "win32", arch: "x64" },
+    { name: "kai-rpc-server.macos-arm64.zip", platform: "darwin", arch: "arm64", chmod: true },
+    { name: "kai-rpc-server.windows-x64.zip", platform: "win32", arch: "x64" },
+    { name: "kai-rpc-server.windows-arm64.zip", platform: "win32", arch: "arm64" },
   ],
 });
 


### PR DESCRIPTION
- Use release v0.0.3

- Adjust `collect-assets.js` to use the "new" asset names

- Use case insensitive asset name matching between release
  assets and the configurations

- Add linux and windows arm64 builds