### PR TITLE
:sparkles: Enhance server process and status handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "editor-extensions",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "editor-extensions",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -12119,7 +12119,7 @@
     },
     "vscode": {
       "name": "editor-extensions-vscode",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "dependencies": {
         "@types/jsesc": "^3.0.3",
         "diff": "^7.0.0",

--- a/shared/src/types/types.ts
+++ b/shared/src/types/types.ts
@@ -128,7 +128,10 @@ export interface ExtensionData {
 
 export type ServerState =
   | "initial"
+  | "configurationNeeded"
+  | "configurationReady"
   | "starting"
+  | "readyToInitialize"
   | "startFailed"
   | "running"
   | "stopping"

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -1,6 +1,6 @@
 import { ExtensionState } from "./extensionState";
 import { sourceOptions, targetOptions } from "./config/labels";
-import { WebviewPanel, window, commands, Uri, OpenDialogOptions } from "vscode";
+import { window, commands, Uri, OpenDialogOptions } from "vscode";
 import {
   cleanRuleSets,
   loadResultsFromDataFolder,
@@ -36,19 +36,19 @@ import {
 import { runPartialAnalysis } from "./analysis";
 import { IncidentTypeItem } from "./issueView";
 
-let fullScreenPanel: WebviewPanel | undefined;
+// let fullScreenPanel: WebviewPanel | undefined;
 
-function getFullScreenTab() {
-  const tabs = window.tabGroups.all.flatMap((tabGroup) => tabGroup.tabs);
-  return tabs.find((tab) =>
-    (tab.input as any)?.viewType?.endsWith("konveyor.konveyorAnalysisView"),
-  );
-}
+// function getFullScreenTab() {
+//   const tabs = window.tabGroups.all.flatMap((tabGroup) => tabGroup.tabs);
+//   return tabs.find((tab) =>
+//     (tab.input as any)?.viewType?.endsWith("konveyor.konveyorAnalysisView"),
+//   );
+// }
 
 const commandsMap: (state: ExtensionState) => {
   [command: string]: (...args: any) => any;
 } = (state) => {
-  const { extensionContext } = state;
+  // const { extensionContext } = state;
   return {
     "konveyor.startServer": async () => {
       const analyzerClient = state.analyzerClient;
@@ -65,7 +65,6 @@ const commandsMap: (state: ExtensionState) => {
     "konveyor.stopServer": async () => {
       const analyzerClient = state.analyzerClient;
       try {
-        await analyzerClient.shutdown();
         await analyzerClient.stop();
       } catch (e) {
         console.error("Could not shutdown and stop the server", e);
@@ -75,7 +74,6 @@ const commandsMap: (state: ExtensionState) => {
       const analyzerClient = state.analyzerClient;
       try {
         if (analyzerClient.isServerRunning()) {
-          await analyzerClient.shutdown();
           await analyzerClient.stop();
         }
 


### PR DESCRIPTION
Resolves: #133
Resolves: #135

Use additional child_process eventing to keep track of the server process itself.  This lets the extension time the initialize call better, and be able to "cleanly" shutdown the `kai-rpc-server``.  If the `kai-rpc-server` is killed or terminated externally, it will be noticed and the extension will understand the server is stopped.
