### PR TITLE
:seedling: Update config definitions, base configs and initialize call

### DIFF
--- a/shared/src/types/types.ts
+++ b/shared/src/types/types.ts
@@ -40,33 +40,6 @@ export interface RuleSet {
   skipped?: string[];
 }
 
-// KaiConfigModels type definition
-export interface KaiConfigModels {
-  provider: string;
-  args: Record<string, any>;
-  template?: string;
-  llamaHeader?: boolean;
-  llmRetries: number;
-  llmRetryDelay: number;
-}
-
-// KaiRpcApplicationConfig type definition
-export interface KaiInitializeParams {
-  rootPath: string;
-  modelProvider: KaiConfigModels;
-  kaiBackendUrl: string;
-
-  logLevel: string;
-  stderrLogLevel: string;
-  fileLogLevel?: string;
-  logDirPath?: string;
-
-  analyzerLspLspPath: string;
-  analyzerLspRpcPath: string;
-  analyzerLspRulesPath: string;
-  analyzerLspJavaBundlePath: string;
-}
-
 export interface GetSolutionParams {
   file_path: string;
   incidents: Incident[];

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -409,12 +409,27 @@
       "type": "object",
       "title": "Konveyor",
       "properties": {
+        "konveyor.logLevel": {
+          "type": "string",
+          "enum": [
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR",
+            "CRITICAL"
+          ],
+          "default": "DEBUG",
+          "description": "Log level to use with extension",
+          "scope": "window",
+          "order": 0
+        },
         "konveyor.analyzerPath": {
           "type": "string",
           "default": "",
           "description": "Path to the analyzer binary. If not set, the extension will use the bundled analyzer.",
           "scope": "machine",
-          "order": 0
+          "order": 2
         },
         "konveyor.kaiRpcServerPath": {
           "type": "string",
@@ -423,40 +438,12 @@
           "scope": "machine",
           "order": 1
         },
-        "konveyor.logLevel": {
-          "type": "string",
-          "default": "debug",
-          "description": "Log level to use with extension",
-          "scope": "window",
-          "order": 2
-        },
-        "konveyor.analysis.incidentLimit": {
-          "type": "number",
-          "default": 10000,
-          "description": "Maximum number of incidents to report",
-          "scope": "window",
-          "order": 1
-        },
-        "konveyor.analysis.contextLines": {
-          "type": "number",
-          "default": 10,
-          "description": "Number of lines of context to include in incident reports",
-          "scope": "window",
-          "order": 2
-        },
-        "konveyor.analysis.codeSnipLimit": {
-          "type": "number",
-          "default": 10,
-          "description": "Number of lines of code to include in incident reports",
-          "scope": "window",
-          "order": 3
-        },
         "konveyor.analysis.useDefaultRulesets": {
           "type": "boolean",
           "default": true,
           "description": "Whether analysis should use the default rulesets, included in the extension",
           "scope": "window",
-          "order": 4
+          "order": 3
         },
         "konveyor.analysis.customRules": {
           "type": "array",
@@ -466,53 +453,39 @@
           "default": [],
           "description": "Array of filepaths to additional rules for analysis",
           "scope": "window",
-          "order": 5
+          "order": 4
         },
         "konveyor.analysis.labelSelector": {
           "type": "string",
           "default": "discovery",
           "description": "Expression to select incidents based on custom variables. Example: (!package=io.konveyor.demo.config-utils)",
           "scope": "window",
-          "order": 6
-        },
-        "konveyor.analysis.analyzeKnownLibraries": {
-          "type": "boolean",
-          "default": false,
-          "description": "Whether analysis should include known open-source libraries",
-          "scope": "window",
-          "order": 7
-        },
-        "konveyor.analysis.analyzeDependencies": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether analysis should include dependencies",
-          "scope": "window",
-          "order": 8
+          "order": 5
         },
         "konveyor.analysis.analyzeOnSave": {
           "type": "boolean",
           "default": true,
           "description": "Whether analysis of file should be run when saved",
           "scope": "window",
-          "order": 9
+          "order": 6
         },
         "konveyor.diffEditorType": {
           "type": "string",
+          "enum": [
+            "diff",
+            "merge"
+          ],
           "default": "diff",
           "description": "Diff editor to use when resolving proposed solutions",
-          "scope": "window"
-        },
-        "konveyor.kai.backendURL": {
-          "type": "string",
-          "default": "0.0.0.0:8080",
-          "description": "Kai Backend URL",
-          "scope": "window"
+          "scope": "window",
+          "order": 7
         },
         "konveyor.kai.providerName": {
           "type": "string",
           "default": "ChatIBMGenAI",
           "description": "URL for the Kai solution server",
-          "scope": "window"
+          "scope": "window",
+          "order": 30
         },
         "konveyor.kai.providerArgs": {
           "type": "object",
@@ -523,28 +496,68 @@
             }
           },
           "description": "Kai provider arguments",
-          "scope": "window"
+          "scope": "window",
+          "order": 30
         },
         "konveyor.kai.genAiKey": {
           "type": "string",
           "default": "",
           "description": "Generative AI Key",
-          "scope": "window"
+          "scope": "window",
+          "order": 30
         },
         "konveyor.kai.getSolutionMaxPriority": {
           "type": "number",
           "default": 0,
-          "description": "Maximum priority for the getSolution request"
+          "description": "Maximum priority for the getSolution request",
+          "order": 40
         },
         "konveyor.kai.getSolutionMaxDepth": {
           "type": "number",
           "default": 0,
-          "description": "Max depth for the getSolution request"
+          "description": "Max depth for the getSolution request",
+          "order": 40
         },
         "konveyor.kai.getSolutionMaxIterations": {
           "type": "number",
           "default": 1,
-          "description": "Max iterations for the getSolution request"
+          "description": "Max iterations for the getSolution request",
+          "order": 40
+        },
+        "konveyor.analysis.incidentLimit": {
+          "type": "number",
+          "default": 10000,
+          "description": "Maximum number of incidents to report ??",
+          "scope": "window",
+          "order": 99
+        },
+        "konveyor.analysis.contextLines": {
+          "type": "number",
+          "default": 10,
+          "description": "Number of lines of context to include in incident reports ??",
+          "scope": "window",
+          "order": 99
+        },
+        "konveyor.analysis.codeSnipLimit": {
+          "type": "number",
+          "default": 10,
+          "description": "Number of lines of code to include in incident reports ??",
+          "scope": "window",
+          "order": 99
+        },
+        "konveyor.analysis.analyzeKnownLibraries": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether analysis should include known open-source libraries ??",
+          "scope": "window",
+          "order": 99
+        },
+        "konveyor.analysis.analyzeDependencies": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether analysis should include dependencies ??",
+          "scope": "window",
+          "order": 99
         }
       }
     },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -483,8 +483,7 @@
         "konveyor.kai.providerName": {
           "type": "string",
           "default": "ChatIBMGenAI",
-          "description": "Kai provider name",
-          "deprecationMessage": "Kai configurations will be moved to an extension specific file.",
+          "description": "Kai provider name (Note: Kai configurations will be moved to an extension specific file.",
           "scope": "window",
           "order": 30
         },
@@ -496,16 +495,14 @@
               "max_new_tokens": 2048
             }
           },
-          "description": "Kai provider arguments",
-          "deprecationMessage": "Kai configurations will be moved to an extension specific file.",
+          "description": "Kai provider arguments (Note: Kai configurations will be moved to an extension specific file.",
           "scope": "window",
           "order": 30
         },
         "konveyor.kai.genAiKey": {
           "type": "string",
           "default": "",
-          "description": "Generative AI Key",
-          "deprecationMessage": "Kai configurations will be moved to an extension specific file.",
+          "description": "Generative AI Key (Note: Kai configurations will be moved to an extension specific file.",
           "scope": "window",
           "order": 30
         },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -420,14 +420,14 @@
             "CRITICAL"
           ],
           "default": "DEBUG",
-          "description": "Log level to use with extension",
+          "description": "Logging level used for the server binaries",
           "scope": "window",
           "order": 0
         },
         "konveyor.analyzerPath": {
           "type": "string",
           "default": "",
-          "description": "Path to the analyzer binary. If not set, the extension will use the bundled analyzer.",
+          "description": "Path to the analyzer binary. If not set, the extension will use the bundled binary.",
           "scope": "machine",
           "order": 2
         },
@@ -441,7 +441,7 @@
         "konveyor.analysis.useDefaultRulesets": {
           "type": "boolean",
           "default": true,
-          "description": "Whether analysis should use the default rulesets, included in the extension",
+          "description": "Should the rulesets bundled in the extension be used?",
           "scope": "window",
           "order": 3
         },
@@ -451,7 +451,7 @@
             "type": "string"
           },
           "default": [],
-          "description": "Array of filepaths to additional rules for analysis",
+          "description": "Array of filepaths to additional rules for analysis.",
           "scope": "window",
           "order": 4
         },
@@ -465,7 +465,7 @@
         "konveyor.analysis.analyzeOnSave": {
           "type": "boolean",
           "default": true,
-          "description": "Whether analysis of file should be run when saved",
+          "description": "Should analysis of file be run when it is saved?",
           "scope": "window",
           "order": 6
         },
@@ -476,14 +476,15 @@
             "merge"
           ],
           "default": "diff",
-          "description": "Diff editor to use when resolving proposed solutions",
+          "description": "Select the editor to use when resolving proposed solutions.",
           "scope": "window",
           "order": 7
         },
         "konveyor.kai.providerName": {
           "type": "string",
           "default": "ChatIBMGenAI",
-          "description": "URL for the Kai solution server",
+          "description": "Kai provider name",
+          "deprecationMessage": "Kai configurations will be moved to an extension specific file.",
           "scope": "window",
           "order": 30
         },
@@ -496,6 +497,7 @@
             }
           },
           "description": "Kai provider arguments",
+          "deprecationMessage": "Kai configurations will be moved to an extension specific file.",
           "scope": "window",
           "order": 30
         },
@@ -503,6 +505,7 @@
           "type": "string",
           "default": "",
           "description": "Generative AI Key",
+          "deprecationMessage": "Kai configurations will be moved to an extension specific file.",
           "scope": "window",
           "order": 30
         },
@@ -510,52 +513,55 @@
           "type": "number",
           "default": 0,
           "description": "Maximum priority for the getSolution request",
+          "scope": "window",
           "order": 40
         },
         "konveyor.kai.getSolutionMaxDepth": {
           "type": "number",
           "default": 0,
           "description": "Max depth for the getSolution request",
+          "scope": "window",
           "order": 40
         },
         "konveyor.kai.getSolutionMaxIterations": {
           "type": "number",
           "default": 1,
           "description": "Max iterations for the getSolution request",
+          "scope": "window",
           "order": 40
         },
         "konveyor.analysis.incidentLimit": {
           "type": "number",
           "default": 10000,
-          "description": "Maximum number of incidents to report ??",
+          "description": "Maximum number of incidents to report",
           "scope": "window",
           "order": 99
         },
         "konveyor.analysis.contextLines": {
           "type": "number",
           "default": 10,
-          "description": "Number of lines of context to include in incident reports ??",
+          "description": "Number of lines of context to include in incident reports.",
           "scope": "window",
           "order": 99
         },
         "konveyor.analysis.codeSnipLimit": {
           "type": "number",
           "default": 10,
-          "description": "Number of lines of code to include in incident reports ??",
+          "description": "Number of lines of code to include in incident reports.",
           "scope": "window",
           "order": 99
         },
         "konveyor.analysis.analyzeKnownLibraries": {
           "type": "boolean",
           "default": false,
-          "description": "Whether analysis should include known open-source libraries ??",
+          "description": "Should the analyzer analyze known open-source libraries?",
           "scope": "window",
           "order": 99
         },
         "konveyor.analysis.analyzeDependencies": {
           "type": "boolean",
           "default": true,
-          "description": "Whether analysis should include dependencies ??",
+          "description": "Should the analyzer analyze project dependencies?",
           "scope": "window",
           "order": 99
         }

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -276,6 +276,13 @@ export class AnalyzerClient {
 
       // TODO: Do we need to include `fernFlowerPath` to support the java decompiler?
       // analyzerLspFernFlowerPath: this.assetPaths.fernFlowerPath,
+
+      // TODO: Once konveyor/kai#550 is resolved, analyzer configurations can be supported
+      // analyzerIncidentLimit: getConfigIncidentLimit(),
+      // analyzerContextLines: getConfigContextLines(),
+      // analyzerCodeSnipLimit: getConfigCodeSnipLimit(),
+      // analyzerAnalyzeKnownLibraries: getConfigAnalyzeKnownLibraries(),
+      // analyzerAnalyzeDependencies: getConfigAnalyzeDependencies(),
     };
 
     vscode.window.withProgress(

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -639,7 +639,12 @@ export class AnalyzerClient {
 
   public getKaiRpcServerArgs(): string[] {
     return [
-      // TODO: Pickup configs here from `ServerCliArguments`
+      "--log-level",
+      getConfigLogLevel(),
+      "--file-log-level",
+      getConfigLogLevel(),
+      "--log-dir-path",
+      this.kaiDir,
     ].filter(Boolean);
   }
 

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -4,8 +4,14 @@ import { setTimeout } from "node:timers/promises";
 import * as fs from "fs-extra";
 import * as vscode from "vscode";
 import * as rpc from "vscode-jsonrpc/node";
-import { Incident, RuleSet, SolutionResponse, Violation } from "@editor-extensions/shared";
-import { ExtensionData, ServerState } from "@editor-extensions/shared";
+import {
+  Incident,
+  RuleSet,
+  SolutionResponse,
+  Violation,
+  ExtensionData,
+  ServerState,
+} from "@editor-extensions/shared";
 import { buildDataFolderPath } from "../data";
 import { Extension } from "../helpers/Extension";
 import { ExtensionState } from "../extensionState";
@@ -28,6 +34,7 @@ import {
 import { allIncidents } from "../issueView";
 import { Immutable } from "immer";
 import { countIncidentsOnPaths } from "../analysis";
+import { KaiConfigModels, KaiRpcApplicationConfig } from "./types";
 
 export class AnalyzerClient {
   private kaiRpcServer: ChildProcessWithoutNullStreams | null = null;
@@ -37,7 +44,6 @@ export class AnalyzerClient {
   private assetPaths: AssetPaths;
   private kaiDir: string;
   private kaiRuntimeDir: string;
-  private kaiConfigToml: string;
   private fireStateChange: (state: ServerState) => void;
   private fireAnalysisStateChange: (flag: boolean) => void;
   private fireSolutionStateChange: (flag: boolean) => void;
@@ -67,7 +73,6 @@ export class AnalyzerClient {
     // TODO: Move the directory and file creation to extension init...
     this.kaiDir = path.join(buildDataFolderPath()!, "kai");
     this.kaiRuntimeDir = path.join(buildDataFolderPath()!, "kai-runtime");
-    this.kaiConfigToml = path.join(this.kaiDir, "kai-config.toml");
 
     fs.ensureDirSync(this.kaiDir);
     fs.ensureDirSync(this.kaiRuntimeDir);
@@ -79,7 +84,6 @@ export class AnalyzerClient {
       `current asset paths: ${JSON.stringify(this.assetPaths, null, 2)}`,
     );
     this.outputChannel.appendLine(`Kai directory: ${this.kaiDir}`);
-    this.outputChannel.appendLine(`Kai config toml: ${this.kaiConfigToml}`);
   }
 
   /**
@@ -222,9 +226,9 @@ export class AnalyzerClient {
     const userProviderArgs = getConfigKaiProviderArgs();
     const providerArgs = userProviderArgs || config.get<object>("providerArgs");
 
-    const modelProviderSection = {
+    const modelProviderSection: KaiConfigModels = {
       provider: getConfigKaiProviderName(),
-      args: providerArgs,
+      args: providerArgs as Record<string, any>,
     };
     return modelProviderSection;
   }
@@ -245,27 +249,33 @@ export class AnalyzerClient {
     }
 
     // Define the initialize request parameters
-    const initializeParams = {
-      process_id: null,
-      root_path: vscode.workspace.workspaceFolders![0].uri.fsPath,
-      model_provider: this.buildModelProviderConfig(),
-      log_config: {
-        log_level: getConfigLogLevel(),
-        file_log_level: getConfigLogLevel(),
-        log_dir_path: this.kaiDir,
+    const initializeParams: KaiRpcApplicationConfig = {
+      rootPath: vscode.workspace.workspaceFolders![0].uri.fsPath,
+      modelProvider: this.buildModelProviderConfig(),
+
+      logConfig: {
+        logLevel: getConfigLogLevel(),
+        fileLogLevel: getConfigLogLevel(),
+        logDirPath: this.kaiDir,
       },
-      demo_mode: this.isDemoMode(),
-      cache_dir: null,
-      // Analyzer and jdt.ls parameters
-      analyzer_lsp_lsp_path: this.assetPaths.jdtlsBin,
-      analyzer_lsp_rpc_path: this.getAnalyzerPath(),
-      analyzer_lsp_rules_path: this.getRulesetsPath(),
-      // jdt.ls bundles (comma separated list of paths)
-      analyzer_lsp_java_bundle_path: this.assetPaths.jdtlsBundleJars.join(","),
-      // depOpenSourceLabelsFile
-      analyzer_lsp_dep_labels_path: this.assetPaths.openSourceLabelsFile,
+
+      demoMode: this.isDemoMode(),
+
+      // Paths to the Analyzer and jdt.ls
+      analyzerLspRpcPath: this.getAnalyzerPath(),
+      analyzerLspLspPath: this.assetPaths.jdtlsBin,
+
+      // TODO: With konveyor/kai#509, multiple paths will be accepted
+      analyzerLspRulesPath: this.getRulesetsPath(),
+
+      // TODO: Once konveyor/kai#547 is resolved, multiple bundles can be supported
+      // jdt.ls bundles
+      analyzerLspJavaBundlePath: this.assetPaths.jdtlsBundleJars[0],
+
+      analyzerLspDepLabelsPath: this.assetPaths.openSourceLabelsFile,
+
       // TODO: Do we need to include `fernFlowerPath` to support the java decompiler?
-      // analyzer_lsp_fernflower: this.assetPaths.fernFlowerPath,
+      // analyzerLspFernFlowerPath: this.assetPaths.fernFlowerPath,
     };
 
     vscode.window.withProgress(
@@ -620,10 +630,10 @@ export class AnalyzerClient {
     return path;
   }
 
-  // TODO: With konveyor/kai#526, config.toml will be dropped.  Different cli arguments to configure
-  // TODO: logging levels and directories are expected.
   public getKaiRpcServerArgs(): string[] {
-    return ["--config", this.getKaiConfigTomlPath()];
+    return [
+      // TODO: Pickup configs here from `ServerCliArguments`
+    ].filter(Boolean);
   }
 
   /**
@@ -657,36 +667,5 @@ export class AnalyzerClient {
       return storedRulesets ? JSON.parse(storedRulesets as string) : null;
     }
     return null;
-  }
-
-  // TODO: With konveyor/kai#526, config.toml will be dropped.  This won't be needed after that
-  // TODO: change is released.
-  public getKaiConfigTomlPath(): string {
-    // Ensure the file exists with default content if it doesn't
-    // Consider making this more robust, maybe this is an asset we can get from kai?
-    if (!fs.existsSync(this.kaiConfigToml)) {
-      fs.writeFileSync(this.kaiConfigToml, this.defaultKaiConfigToml(this.kaiDir));
-    }
-
-    return this.kaiConfigToml;
-  }
-
-  // TODO: With konveyor/kai#526, config.toml will be dropped.  This won't be needed after that
-  // TODO: change is released.
-  public defaultKaiConfigToml(log_dir: string) {
-    return `
-log_level = "info"
-file_log_level = "debug"
-log_dir = "${log_dir}"
-
-# These values are needed to start the server but shouldn't be used by the server
-# please ignore
-[models]
-provider = "ChatIBMGenAI"
-
-[models.args]
-model_id = "meta-llama/llama-3-70b-instruct"
-parameters.max_new_tokens = "2048"
-`;
   }
 }

--- a/vscode/src/client/types.ts
+++ b/vscode/src/client/types.ts
@@ -1,0 +1,66 @@
+export type ServerLogLevels = "TRACE" | "DEBUG" | "INFO" | "WARN" | "ERROR" | "CRITICAL";
+
+export interface ServerCliArguments {
+  /** The initial log level for the server. Default: INFO */
+  logLevel?: ServerLogLevels;
+
+  /** The initial stderr log level for the server. Default: TRACE */
+  stderrLogLevel?: ServerLogLevels;
+
+  /** The initial file log level for the server. Default: DEBUG */
+  fileLogLevel?: ServerLogLevels;
+
+  /** The directory path for log files. Default: "./logs" */
+  logDirPath?: string;
+
+  /** The name of the log file. Default: "./kai-rpc-server.log" */
+  logFileName?: string;
+}
+
+/**
+ * Logging configurations on initialization. These match {@link ServerCliArguments} currently
+ * but have slightly different uses.
+ */
+export interface KaiLogConfig {
+  logLevel?: ServerLogLevels; // defaults to "INFO"
+  stderrLogLevel?: ServerLogLevels; // defaults to "TRACE"
+  fileLogLevel?: ServerLogLevels; // defaults to "DEBUG"
+  logDirPath?: string; // defaults to "./logs"
+  logFileName?: string; // defaults to "./kai_server.log"
+}
+
+export interface KaiConfigModels {
+  provider: string;
+  args: Record<string, any>;
+  template?: string;
+  llamaHeader?: boolean;
+  llmRetries?: number;
+  llmRetryDelay?: number;
+}
+
+/**
+ * `initialize` request content as camel case (camelCase and snake_case are both accepted)
+ *
+ * {@link https://github.com/konveyor/kai/blob/78f31fa609a5b53bf66f334803afa72f3849a7e2/kai/rpc_server/server.py#L61}
+ */
+export interface KaiRpcApplicationConfig {
+  processId?: number;
+
+  rootPath: string;
+  modelProvider: KaiConfigModels;
+
+  logConfig: KaiLogConfig;
+
+  demoMode?: boolean; // defaults to `false`
+  cacheDir?: string; // defaults to `None`
+  enableReflection?: boolean; // defaults to `true`
+
+  analyzerLspLspPath: string;
+  analyzerLspRpcPath: string;
+  analyzerLspRulesPath: string; // TODO: See https://github.com/konveyor/kai/issues/509
+  analyzerLspJavaBundlePath: string; // TODO: See https://github.com/konveyor/kai/issues/547
+  analyzerLspDepLabelsPath?: string; // defaults to `None`
+
+  // TODO: Do we need to include `fernFlowerPath` to support the java decompiler?
+  // analyzerLspFernFlowerPath?: string;
+}

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -18,17 +18,14 @@ export function getConfigLogLevel(): ServerLogLevels {
   return getConfigValue<ServerLogLevels>("logLevel") || "DEBUG";
 }
 
-// TODO: Is this used?
 export function getConfigIncidentLimit(): number {
   return getConfigValue<number>("analysis.incidentLimit") || 10000;
 }
 
-// TODO: Is this used?
 export function getConfigContextLines(): number {
   return getConfigValue<number>("analysis.contextLines") || 10;
 }
 
-// TODO: Is this used?
 export function getConfigCodeSnipLimit(): number {
   return getConfigValue<number>("analysis.codeSnipLimit") || 10;
 }
@@ -45,12 +42,10 @@ export function getConfigLabelSelector(): string {
   return getConfigValue<string>("analysis.labelSelector") || "discovery";
 }
 
-// TODO: Is this used?
 export function getConfigAnalyzeKnownLibraries(): boolean {
   return getConfigValue<boolean>("analysis.analyzeKnownLibraries") ?? false;
 }
 
-// TODO: Is this used?
 export function getConfigAnalyzeDependencies(): boolean {
   return getConfigValue<boolean>("analysis.analyzeDependencies") ?? true;
 }
@@ -124,17 +119,14 @@ export async function updateLogLevel(value: string): Promise<void> {
   await updateConfigValue("logLevel", value, vscode.ConfigurationTarget.Workspace);
 }
 
-// TODO: Is this used?
 export async function updateIncidentLimit(value: number): Promise<void> {
   await updateConfigValue("analysis.incidentLimit", value, vscode.ConfigurationTarget.Workspace);
 }
 
-// TODO: Is this used?
 export async function updateContextLines(value: number): Promise<void> {
   await updateConfigValue("analysis.contextLines", value, vscode.ConfigurationTarget.Workspace);
 }
 
-// TODO: Is this used?
 export async function updateCodeSnipLimit(value: number): Promise<void> {
   await updateConfigValue("analysis.codeSnipLimit", value, vscode.ConfigurationTarget.Workspace);
 }
@@ -155,7 +147,6 @@ export async function updateLabelSelector(value: string): Promise<void> {
   await updateConfigValue("analysis.labelSelector", value, vscode.ConfigurationTarget.Workspace);
 }
 
-// TODO: Is this used?
 export async function updateAnalyzeKnownLibraries(value: boolean): Promise<void> {
   await updateConfigValue(
     "analysis.analyzeKnownLibraries",
@@ -164,7 +155,6 @@ export async function updateAnalyzeKnownLibraries(value: boolean): Promise<void>
   );
 }
 
-// TODO: Is this used?
 export async function updateAnalyzeDependencies(value: boolean): Promise<void> {
   await updateConfigValue(
     "analysis.analyzeDependencies",

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -1,5 +1,6 @@
-import { KONVEYOR_CONFIG_KEY } from "./constants";
 import * as vscode from "vscode";
+import { ServerLogLevels } from "../client/types";
+import { KONVEYOR_CONFIG_KEY } from "./constants";
 
 function getConfigValue<T>(key: string): T | undefined {
   return vscode.workspace.getConfiguration(KONVEYOR_CONFIG_KEY)?.get<T>(key);
@@ -13,18 +14,21 @@ export function getConfigKaiRpcServerPath(): string {
   return getConfigValue<string>("kaiRpcServerPath") || "";
 }
 
-export function getConfigLogLevel(): string {
-  return getConfigValue<string>("logLevel") || "debug";
+export function getConfigLogLevel(): ServerLogLevels {
+  return getConfigValue<ServerLogLevels>("logLevel") || "DEBUG";
 }
 
+// TODO: Is this used?
 export function getConfigIncidentLimit(): number {
   return getConfigValue<number>("analysis.incidentLimit") || 10000;
 }
 
+// TODO: Is this used?
 export function getConfigContextLines(): number {
   return getConfigValue<number>("analysis.contextLines") || 10;
 }
 
+// TODO: Is this used?
 export function getConfigCodeSnipLimit(): number {
   return getConfigValue<number>("analysis.codeSnipLimit") || 10;
 }
@@ -41,10 +45,12 @@ export function getConfigLabelSelector(): string {
   return getConfigValue<string>("analysis.labelSelector") || "discovery";
 }
 
+// TODO: Is this used?
 export function getConfigAnalyzeKnownLibraries(): boolean {
   return getConfigValue<boolean>("analysis.analyzeKnownLibraries") ?? false;
 }
 
+// TODO: Is this used?
 export function getConfigAnalyzeDependencies(): boolean {
   return getConfigValue<boolean>("analysis.analyzeDependencies") ?? true;
 }
@@ -54,11 +60,7 @@ export function getConfigAnalyzeOnSave(): boolean {
 }
 
 export function getConfigDiffEditorType(): string {
-  return getConfigValue<string>("diffEditorType") || "diff";
-}
-
-export function getConfigKaiBackendURL(): string {
-  return getConfigValue<string>("kai.backendURL") || "0.0.0.0:8080";
+  return getConfigValue<"diff" | "merge">("diffEditorType") || "diff";
 }
 
 export function getConfigKaiProviderName(): string {
@@ -122,14 +124,17 @@ export async function updateLogLevel(value: string): Promise<void> {
   await updateConfigValue("logLevel", value, vscode.ConfigurationTarget.Workspace);
 }
 
+// TODO: Is this used?
 export async function updateIncidentLimit(value: number): Promise<void> {
   await updateConfigValue("analysis.incidentLimit", value, vscode.ConfigurationTarget.Workspace);
 }
 
+// TODO: Is this used?
 export async function updateContextLines(value: number): Promise<void> {
   await updateConfigValue("analysis.contextLines", value, vscode.ConfigurationTarget.Workspace);
 }
 
+// TODO: Is this used?
 export async function updateCodeSnipLimit(value: number): Promise<void> {
   await updateConfigValue("analysis.codeSnipLimit", value, vscode.ConfigurationTarget.Workspace);
 }
@@ -150,6 +155,7 @@ export async function updateLabelSelector(value: string): Promise<void> {
   await updateConfigValue("analysis.labelSelector", value, vscode.ConfigurationTarget.Workspace);
 }
 
+// TODO: Is this used?
 export async function updateAnalyzeKnownLibraries(value: boolean): Promise<void> {
   await updateConfigValue(
     "analysis.analyzeKnownLibraries",
@@ -158,6 +164,7 @@ export async function updateAnalyzeKnownLibraries(value: boolean): Promise<void>
   );
 }
 
+// TODO: Is this used?
 export async function updateAnalyzeDependencies(value: boolean): Promise<void> {
   await updateConfigValue(
     "analysis.analyzeDependencies",


### PR DESCRIPTION
Based on changes to the kai runtime configurations in https://github.com/konveyor/kai/pull/526, update the CLI arguments and initialize request object to match.

Summary of changes:
  - Reorder the config field definitions

  - Use enum values in config definitions where available

  - Config keys related to analyzer configuration still remain but cannot be passed along to the analyzer, see [kai issue 550](https://github.com/konveyor/kai/issues/550)

  - Aligned CLI arguments and initialize request payload types to the updated Kai configuration keys

  - Dropped config.toml handling since that file is no longer in use

Prerequisite for: #184