### PR TITLE
:seedling: Fix typing on `Array.filter(Boolean)` for the project

### DIFF
--- a/extra-types/array-filter-Boolean.d.ts
+++ b/extra-types/array-filter-Boolean.d.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/**
+ * Fixes https://github.com/microsoft/TypeScript/issues/16655 for `Array.prototype.filter()`
+ * For example, using the fix the type of `bar` is `string[]` in the below snippet as it should be.
+ *
+ *  const foo: (string | null | undefined)[] = [];
+ *  const bar = foo.filter(Boolean);
+ *
+ * For related definitions, see https://github.com/microsoft/TypeScript/blob/master/src/lib/es5.d.ts
+ *
+ * Original licenses apply, see
+ *  - https://github.com/microsoft/TypeScript/blob/master/LICENSE.txt
+ *  - https://stackoverflow.com/help/licensing
+ */
+
+/** See https://stackoverflow.com/a/51390763/1470607  */
+type Falsy = false | 0 | "" | null | undefined;
+
+interface Array<T> {
+  /**
+   * Returns the elements of an array that meet the condition specified in a callback function.
+   * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
+   * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
+   */
+  filter<S extends T>(predicate: BooleanConstructor, thisArg?: any): Exclude<S, Falsy>[];
+}

--- a/extra-types/index.d.ts
+++ b/extra-types/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./array-filter-Boolean.d.ts";

--- a/extra-types/package.json
+++ b/extra-types/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@types/extra-types",
+  "version": "0.0.1",
+  "description": "TypeScript definitions useful for our project",
+  "main": "",
+  "types": "index.d.ts",
+  "scripts": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
+        "extra-types",
         "shared",
         "webview-ui",
         "vscode"
@@ -58,6 +59,10 @@
         "npm": "^9.5.0 || ^10.5.2",
         "vscode": "^1.93.0"
       }
+    },
+    "extra-types": {
+      "name": "@types/extra-types",
+      "version": "0.0.1"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -2122,6 +2127,10 @@
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/extra-types": {
+      "resolved": "extra-types",
+      "link": true
     },
     "node_modules/@types/fs-extra": {
       "version": "11.0.4",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "Analyze"
   ],
   "workspaces": [
+    "extra-types",
     "shared",
     "webview-ui",
     "vscode"

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -651,6 +651,6 @@ export class AnalyzerClient {
     return [
       getConfigUseDefaultRulesets() && this.assetPaths.rulesets,
       ...getConfigCustomRules(),
-    ].filter(Boolean) as string[];
+    ].filter(Boolean);
   }
 }


### PR DESCRIPTION
Use a new workspace project `extra-types` that installs to `@types/extra-types` as a way to make `Array.filter(boolean)` have the correct typing across all of the ts projects in the repo.  Typescript "makes visible" all typing from packages installed under `node_modules/@types`.  Put our override there and no extra configurations needed.  Magic.
