### PR TITLE
:bug: Add initialization state tracking to prevent spawning duplicate 

### DIFF
--- a/shared/src/types/types.ts
+++ b/shared/src/types/types.ts
@@ -95,6 +95,7 @@ export interface ExtensionData {
   isAnalyzing: boolean;
   isFetchingSolution: boolean;
   isStartingServer: boolean;
+  isInitializingServer: boolean;
   serverState: ServerState;
   solutionState: SolutionState;
   solutionData?: Solution;
@@ -108,6 +109,7 @@ export type ServerState =
   | "configurationReady"
   | "starting"
   | "readyToInitialize"
+  | "initializing"
   | "startFailed"
   | "running"
   | "stopping"

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -31,6 +31,7 @@ class VsCodeExtension {
         isAnalyzing: false,
         isFetchingSolution: false,
         isStartingServer: false,
+        isInitializingServer: false,
         solutionData: undefined,
         serverState: "initial",
         solutionScope: undefined,

--- a/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
+++ b/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
@@ -46,6 +46,7 @@ const AnalysisPage: React.FC = () => {
   const {
     isAnalyzing,
     isStartingServer,
+    isInitializingServer,
     isFetchingSolution: isWaitingForSolution,
     ruleSets: analysisResults,
     workspaceRoot,
@@ -112,6 +113,7 @@ const AnalysisPage: React.FC = () => {
                     <ServerStatusToggle
                       isRunning={serverRunning}
                       isStarting={isStartingServer}
+                      isInitializing={isInitializingServer}
                       onToggle={handleServerToggle}
                     />
                   </ToolbarItem>

--- a/webview-ui/src/components/ResolutionsPage.tsx
+++ b/webview-ui/src/components/ResolutionsPage.tsx
@@ -30,6 +30,7 @@ const ResolutionPage: React.FC = () => {
     solutionState,
     workspaceRoot,
   } = state;
+
   const getRemainingFiles = () => {
     if (!resolution) {
       return [];
@@ -56,17 +57,6 @@ const ResolutionPage: React.FC = () => {
   const handleIncidentClick = (incident: Incident) => {
     dispatch(openFile(incident.uri, incident.lineNumber ?? 0));
   };
-
-  console.log("Resolution view state:", {
-    state,
-    isResolved,
-    isTriggeredByUser,
-    isHistorySolution,
-    hasResponseWithErrors,
-    hasResponse,
-    hasEmptyResponse,
-    hasNothingToView,
-  });
 
   return (
     <Page

--- a/webview-ui/src/components/ServerStatusToggle/ServerStatusToggle.tsx
+++ b/webview-ui/src/components/ServerStatusToggle/ServerStatusToggle.tsx
@@ -6,10 +6,16 @@ import "./styles.css";
 interface ServerStatusToggleProps {
   isRunning: boolean;
   isStarting: boolean;
+  isInitializing: boolean;
   onToggle: () => void;
 }
 
-export function ServerStatusToggle({ isRunning, isStarting, onToggle }: ServerStatusToggleProps) {
+export function ServerStatusToggle({
+  isRunning,
+  isStarting,
+  isInitializing,
+  onToggle,
+}: ServerStatusToggleProps) {
   return (
     <div className="server-status-container">
       <div className="server-status-wrapper">
@@ -20,12 +26,12 @@ export function ServerStatusToggle({ isRunning, isStarting, onToggle }: ServerSt
         <div className="vertical-divider" />
         <Button
           variant="plain"
-          icon={isStarting ? <Spinner size="sm" /> : <OnIcon />}
+          icon={isStarting || isInitializing ? <Spinner size="sm" /> : <OnIcon />}
           onClick={onToggle}
-          isDisabled={isStarting}
+          isDisabled={isStarting || isInitializing}
           className="server-action-button"
         >
-          {isStarting ? "" : isRunning ? "Stop" : "Start"}
+          {isStarting || isInitializing ? "" : isRunning ? "Stop" : "Start"}
         </Button>
       </div>
     </div>

--- a/webview-ui/src/hooks/useExtensionState.ts
+++ b/webview-ui/src/hooks/useExtensionState.ts
@@ -9,6 +9,7 @@ const defaultState: ExtensionData = {
   isAnalyzing: false,
   isFetchingSolution: false,
   isStartingServer: false,
+  isInitializingServer: false,
   solutionData: undefined,
   serverState: "initial",
   solutionScope: undefined,


### PR DESCRIPTION
Resolves https://github.com/konveyor/editor-extensions/issues/187

- Update fireStateChange -> fireServerStateChange for clarity
- Add additional server state for initialization. This is purely to handle the unhandled started but not initialized case that can arise for now. 
TODO: Handle readyToInitialize case. Comment out the fire state event until this is ready to be handled. 