### PR TITLE
:seedling: Release 0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editor-extensions",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "displayName": "Konveyor",
   "description": "VSCode Extension for Konveyor to assist in migrating and modernizing applications.",

--- a/scripts/collect-assets.js
+++ b/scripts/collect-assets.js
@@ -17,7 +17,7 @@ await downloadGitHubRelease({
 
   org: "konveyor",
   repo: "kai",
-  releaseTag: "v0.0.4",
+  releaseTag: "v0.0.5",
 
   /*
     Release asset filenames and nodejs equivalent platform/arch

--- a/scripts/collect-assets.js
+++ b/scripts/collect-assets.js
@@ -30,7 +30,7 @@ await downloadGitHubRelease({
     { name: "kai-rpc-server.macos-x86_64.zip", platform: "darwin", arch: "x64", chmod: true },
     { name: "kai-rpc-server.macos-arm64.zip", platform: "darwin", arch: "arm64", chmod: true },
     { name: "kai-rpc-server.windows-x64.zip", platform: "win32", arch: "x64" },
-    { name: "kai-rpc-server.windows-arm64.zip", platform: "win32", arch: "arm64" },
+    // { name: "kai-rpc-server.windows-arm64.zip", platform: "win32", arch: "arm64" },
   ],
 });
 

--- a/scripts/copy-dist.js
+++ b/scripts/copy-dist.js
@@ -77,7 +77,7 @@ await copy({
     // seed assets - kai binaries
     {
       context: "downloaded_assets/kai",
-      src: ["**/*", "!**/*.zip"],
+      src: ["kai-rpc-server*/kai*", "!**/*.zip"],
       dest: "dist/assets/kai",
     },
   ],

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editor-extensions/shared",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "private": true,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -5,7 +5,7 @@
   "author": "Konveyor",
   "icon": "resources/konveyor-icon-color.png",
   "license": "Apache-2.0",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "./out/extension.js",
   "publisher": "konveyor",
   "repository": {

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editor-extensions/webview-ui",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Prepare release 0.0.5

  - Bump `collect-assets.js` to use kai 0.0.5

  - Refine the `copy-dist.js` file globs given updated kai asset contents

  - Bump `package.json` versions to 0.0.5
