### PR TITLE
:bug: Allow override of binaries in workspace & global settings.

### DIFF
--- a/vscode/media/walkthroughs/override-analyzer.md
+++ b/vscode/media/walkthroughs/override-analyzer.md
@@ -1,5 +1,5 @@
 # Override Analyzer Binary
 
-The Konveyor extension comes packaged with default analyzer and Generative AI binaries. However, you may want to use a custom or updated version of these binaries.
+The Konveyor extension comes packaged with default analyzer and rpc server binaries. However, you may want to use a custom or updated version of these binaries.
 
-To override the default analyzer, run the [Konveyor: Override Analyzer Binaries](command:konveyor.overrideAnalyzerBinaries) command, and to override the Generative AI binary, run the [Konveyor: Override Generative AI Binaries](command:konveyor.overrideKaiRpcServerBinaries) command. 
+To override the default analyzer, run the [Konveyor: Override Analyzer Binary](command:konveyor.overrideAnalyzerBinaries) command, and to override the Generative AI binary, run the [Konveyor: Override Kai Rpc Server Binary](command:konveyor.overrideKaiRpcServerBinaries) command.

--- a/vscode/media/walkthroughs/override-analyzer.md
+++ b/vscode/media/walkthroughs/override-analyzer.md
@@ -2,4 +2,4 @@
 
 The Konveyor extension comes packaged with default analyzer and rpc server binaries. However, you may want to use a custom or updated version of these binaries.
 
-To override the default analyzer, run the [Konveyor: Override Analyzer Binary](command:konveyor.overrideAnalyzerBinaries) command, and to override the Generative AI binary, run the [Konveyor: Override Kai Rpc Server Binary](command:konveyor.overrideKaiRpcServerBinaries) command.
+To override the default analyzer, run the [Konveyor: Override Analyzer Binary](command:konveyor.overrideAnalyzerBinaries) command, and to override the Generative AI binary, run the [Konveyor: Override Rpc Server Binary](command:konveyor.overrideKaiRpcServerBinaries) command.

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -84,13 +84,13 @@
       },
       {
         "command": "konveyor.overrideAnalyzerBinaries",
-        "title": "Override Analyzer Binaries",
+        "title": "Override Analyzer Binary",
         "category": "Konveyor",
         "icon": "$(gear)"
       },
       {
         "command": "konveyor.overrideKaiRpcServerBinaries",
-        "title": "Override Generative AI Binaries",
+        "title": "Override Kai Rpc Server Binary",
         "category": "Konveyor",
         "icon": "$(gear)"
       },
@@ -456,14 +456,14 @@
           "type": "string",
           "default": "",
           "description": "Path to the analyzer binary. If not set, the extension will use the bundled binary.",
-          "scope": "machine",
+          "scope": "resource",
           "order": 2
         },
         "konveyor.kaiRpcServerPath": {
           "type": "string",
           "default": "",
           "description": "Path to the rpc-server binary. If not set, the extension will use the bundled binary.",
-          "scope": "machine",
+          "scope": "resource",
           "order": 1
         },
         "konveyor.analysis.useDefaultRulesets": {
@@ -601,7 +601,7 @@
           {
             "id": "override-analyzer",
             "title": "Override Analyzer Binary",
-            "description": "Specify a custom path for the analyzer binary\n[Override Analyzer Binary](command:konveyor.overrideAnalyzerBinaries)\n[Override GenerativeAI Binary](command:konveyor.overrideKaiRpcServerBinaries)",
+            "description": "Specify a custom path for the analyzer binary\n[Override Analyzer Binary](command:konveyor.overrideAnalyzerBinaries)\n[Override Kai Rpc Server Binary](command:konveyor.overrideKaiRpcServerBinaries)",
             "completionEvents": [],
             "media": {
               "markdown": "media/walkthroughs/override-analyzer.md"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -90,7 +90,7 @@
       },
       {
         "command": "konveyor.overrideKaiRpcServerBinaries",
-        "title": "Override Kai Rpc Server Binary",
+        "title": "Override Rpc Server Binary",
         "category": "Konveyor",
         "icon": "$(gear)"
       },
@@ -601,7 +601,7 @@
           {
             "id": "override-analyzer",
             "title": "Override Analyzer Binary",
-            "description": "Specify a custom path for the analyzer binary\n[Override Analyzer Binary](command:konveyor.overrideAnalyzerBinaries)\n[Override Kai Rpc Server Binary](command:konveyor.overrideKaiRpcServerBinaries)",
+            "description": "Specify a custom path for the analyzer binary\n[Override Analyzer Binary](command:konveyor.overrideAnalyzerBinaries)\n[Override Rpc Server Binary](command:konveyor.overrideKaiRpcServerBinaries)",
             "completionEvents": [],
             "media": {
               "markdown": "media/walkthroughs/override-analyzer.md"

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -634,7 +634,7 @@ export class AnalyzerClient {
     const path = getConfigKaiRpcServerPath() || this.assetPaths.kaiRpcServer;
 
     if (!fs.existsSync(path)) {
-      const message = `Kai RPC Server binary doesn't exist at ${path}`;
+      const message = `RPC Server binary doesn't exist at ${path}`;
       this.outputChannel.appendLine(`Error: ${message}`);
       vscode.window.showErrorMessage(message);
       throw new Error(message);

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -35,20 +35,13 @@ import {
 import { runPartialAnalysis } from "./analysis";
 import { fixGroupOfIncidents, IncidentTypeItem } from "./issueView";
 import { paths } from "./paths";
+import { checkIfExecutable } from "./utilities/fileUtils";
 
-// let fullScreenPanel: WebviewPanel | undefined;
-
-// function getFullScreenTab() {
-//   const tabs = window.tabGroups.all.flatMap((tabGroup) => tabGroup.tabs);
-//   return tabs.find((tab) =>
-//     (tab.input as any)?.viewType?.endsWith("konveyor.konveyorAnalysisView"),
-//   );
-// }
+const isWindows = process.platform === "win32";
 
 const commandsMap: (state: ExtensionState) => {
   [command: string]: (...args: any) => any;
 } = (state) => {
-  // const { extensionContext } = state;
   return {
     "konveyor.startServer": async () => {
       const analyzerClient = state.analyzerClient;
@@ -102,16 +95,28 @@ const commandsMap: (state: ExtensionState) => {
     "konveyor.overrideAnalyzerBinaries": async () => {
       const options: OpenDialogOptions = {
         canSelectMany: false,
-        openLabel: "Select Analyzer Binary",
-        filters: {
-          "Executable Files": ["exe", "sh", "bat", ""],
-          "All Files": ["*"],
-        },
+        openLabel: "Select Kai Rpc Server Binary",
+        filters: isWindows
+          ? {
+              "Executable Files": ["exe"],
+              "All Files": ["*"],
+            }
+          : {
+              "All Files": ["*"],
+            },
       };
 
       const fileUri = await window.showOpenDialog(options);
       if (fileUri && fileUri[0]) {
         const filePath = fileUri[0].fsPath;
+
+        const isExecutable = await checkIfExecutable(filePath);
+        if (!isExecutable) {
+          window.showErrorMessage(
+            `The selected file "${filePath}" is not executable. Please select a valid executable file.`,
+          );
+          return;
+        }
 
         // Update the user settings
         await updateAnalyzerPath(filePath);
@@ -126,16 +131,28 @@ const commandsMap: (state: ExtensionState) => {
     "konveyor.overrideKaiRpcServerBinaries": async () => {
       const options: OpenDialogOptions = {
         canSelectMany: false,
-        openLabel: "Select GenAI Binary",
-        filters: {
-          "Executable Files": ["exe", "sh", "bat", ""],
-          "All Files": ["*"],
-        },
+        openLabel: "Select Kai Rpc Server Binary",
+        filters: isWindows
+          ? {
+              "Executable Files": ["exe"],
+              "All Files": ["*"],
+            }
+          : {
+              "All Files": ["*"],
+            },
       };
 
       const fileUri = await window.showOpenDialog(options);
       if (fileUri && fileUri[0]) {
         const filePath = fileUri[0].fsPath;
+
+        const isExecutable = await checkIfExecutable(filePath);
+        if (!isExecutable) {
+          window.showErrorMessage(
+            `The selected file "${filePath}" is not executable. Please select a valid executable file.`,
+          );
+          return;
+        }
 
         // Update the user settings
         await updateKaiRpcServerPath(filePath);

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -95,7 +95,7 @@ const commandsMap: (state: ExtensionState) => {
     "konveyor.overrideAnalyzerBinaries": async () => {
       const options: OpenDialogOptions = {
         canSelectMany: false,
-        openLabel: "Select Kai Rpc Server Binary",
+        openLabel: "Select Analyzer Binary",
         filters: isWindows
           ? {
               "Executable Files": ["exe"],
@@ -131,7 +131,7 @@ const commandsMap: (state: ExtensionState) => {
     "konveyor.overrideKaiRpcServerBinaries": async () => {
       const options: OpenDialogOptions = {
         canSelectMany: false,
-        openLabel: "Select Kai Rpc Server Binary",
+        openLabel: "Select Rpc Server Binary",
         filters: isWindows
           ? {
               "Executable Files": ["exe"],
@@ -157,7 +157,7 @@ const commandsMap: (state: ExtensionState) => {
         // Update the user settings
         await updateKaiRpcServerPath(filePath);
 
-        window.showInformationMessage(`Kai rpc server binary path updated to: ${filePath}`);
+        window.showInformationMessage(`Rpc server binary path updated to: ${filePath}`);
       } else {
         // Reset the setting to undefined or remove it
         await updateKaiRpcServerPath(undefined);

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -108,11 +108,27 @@ async function updateConfigValue<T>(
 }
 
 export async function updateAnalyzerPath(value: string | undefined): Promise<void> {
-  await updateConfigValue("analyzerPath", value, vscode.ConfigurationTarget.Workspace);
+  try {
+    const scope = vscode.workspace.workspaceFolders
+      ? vscode.ConfigurationTarget.Workspace
+      : vscode.ConfigurationTarget.Global;
+    await updateConfigValue("analyzerPath", value, scope);
+    vscode.window.showInformationMessage(`Updated analyzerPath to ${value}`);
+  } catch (error) {
+    console.error("Failed to update analyzerPath:", error);
+  }
 }
 
 export async function updateKaiRpcServerPath(value: string | undefined): Promise<void> {
-  await updateConfigValue("kaiRpcServerPath", value, vscode.ConfigurationTarget.Workspace);
+  try {
+    const scope = vscode.workspace.workspaceFolders
+      ? vscode.ConfigurationTarget.Workspace
+      : vscode.ConfigurationTarget.Global;
+    await updateConfigValue("kaiRpcServerPath", value, scope);
+    vscode.window.showInformationMessage(`Updated kaiRpcServerPath to ${value}`);
+  } catch (error) {
+    console.error("Failed to update kaiRpcServerPath:", error);
+  }
 }
 
 export async function updateLogLevel(value: string): Promise<void> {

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -113,7 +113,6 @@ export async function updateAnalyzerPath(value: string | undefined): Promise<voi
       ? vscode.ConfigurationTarget.Workspace
       : vscode.ConfigurationTarget.Global;
     await updateConfigValue("analyzerPath", value, scope);
-    vscode.window.showInformationMessage(`Updated analyzerPath to ${value}`);
   } catch (error) {
     console.error("Failed to update analyzerPath:", error);
   }
@@ -125,7 +124,6 @@ export async function updateKaiRpcServerPath(value: string | undefined): Promise
       ? vscode.ConfigurationTarget.Workspace
       : vscode.ConfigurationTarget.Global;
     await updateConfigValue("kaiRpcServerPath", value, scope);
-    vscode.window.showInformationMessage(`Updated kaiRpcServerPath to ${value}`);
   } catch (error) {
     console.error("Failed to update kaiRpcServerPath:", error);
   }

--- a/vscode/src/utilities/fileUtils.ts
+++ b/vscode/src/utilities/fileUtils.ts
@@ -1,0 +1,34 @@
+import path from "path";
+import fs from "fs";
+import { access } from "node:fs/promises";
+import { platform } from "node:process";
+
+const isWindows = platform === "win32";
+
+export const checkIfExecutable = async (filePath: string): Promise<boolean> => {
+  try {
+    // Normalize the path for cross-platform compatibility
+    const normalizedPath = path.normalize(filePath);
+
+    if (isWindows) {
+      // On Windows, check if the file has a valid executable extension
+      const executableExtensions = [".exe"];
+      const fileExtension = path.extname(normalizedPath).toLowerCase();
+
+      if (!executableExtensions.includes(fileExtension)) {
+        console.warn(`File does not have a valid Windows executable extension: ${normalizedPath}`);
+        return false;
+      }
+    } else {
+      // On Unix systems, check for execute permissions
+      await access(normalizedPath, fs.constants.X_OK);
+    }
+
+    // Check if the file exists
+    await access(normalizedPath, fs.constants.F_OK);
+    return true;
+  } catch (err) {
+    console.error("Error checking if file is executable:", err);
+    return false;
+  }
+};


### PR DESCRIPTION
Resolves #224 
Resolves #218 

- This PR allows for ease of binary override by using the custom methods available in the walkthrough or command palette. Previously the override was silently failing when trying to write paths to the user settings. Changed the scope to allow workspace / global settings. Also, enabled selection of all file extension types and included an executable check post selection. Improved error message & success messaging when path operations succeed or fail. 
