### PR TITLE
:seedling: release 0.0.5-1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "editor-extensions",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "editor-extensions",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -13295,11 +13295,11 @@
     },
     "shared": {
       "name": "@editor-extensions/shared",
-      "version": "0.0.1"
+      "version": "0.0.5"
     },
     "vscode": {
       "name": "konveyor-ai",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/jsesc": "^3.0.3",
@@ -13331,7 +13331,7 @@
     },
     "webview-ui": {
       "name": "@editor-extensions/webview-ui",
-      "version": "0.0.1",
+      "version": "0.0.5",
       "dependencies": {
         "@patternfly/patternfly": "6.0.0-prerelease.15",
         "@patternfly/react-code-editor": "^6.0.0",

--- a/scripts/copy-dist.js
+++ b/scripts/copy-dist.js
@@ -77,7 +77,7 @@ await copy({
     // seed assets - kai binaries
     {
       context: "downloaded_assets/kai",
-      src: ["kai-rpc-server*/kai*", "!**/*.zip"],
+      src: ["*/kai*", "!**/*.zip"],
       dest: "dist/assets/kai",
     },
   ],


### PR DESCRIPTION
  - fix dist copy glob for kai binaries
  - updating `package-lock.json` file after version bumps
