### PR TITLE
:seedling: Release 0.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "editor-extensions",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "editor-extensions",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -13295,11 +13295,11 @@
     },
     "shared": {
       "name": "@editor-extensions/shared",
-      "version": "0.0.5"
+      "version": "0.0.6"
     },
     "vscode": {
       "name": "konveyor-ai",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/jsesc": "^3.0.3",
@@ -13331,7 +13331,7 @@
     },
     "webview-ui": {
       "name": "@editor-extensions/webview-ui",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@patternfly/patternfly": "6.0.0-prerelease.15",
         "@patternfly/react-code-editor": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editor-extensions",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "displayName": "Konveyor",
   "description": "VSCode Extension for Konveyor to assist in migrating and modernizing applications.",

--- a/scripts/collect-assets.js
+++ b/scripts/collect-assets.js
@@ -17,7 +17,7 @@ await downloadGitHubRelease({
 
   org: "konveyor",
   repo: "kai",
-  releaseTag: "v0.0.5",
+  releaseTag: "v0.0.6",
 
   /*
     Release asset filenames and nodejs equivalent platform/arch

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editor-extensions/shared",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -5,7 +5,7 @@
   "author": "Konveyor",
   "icon": "resources/konveyor-icon-color.png",
   "license": "Apache-2.0",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "./out/extension.js",
   "publisher": "konveyor",
   "repository": {

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editor-extensions/webview-ui",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
