### PR TITLE
:bug: Ensure konveyor file system resources are resolved during session restore

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -32,6 +32,10 @@
     "node": ">=22.9.0",
     "npm": "^9.5.0 || ^10.5.0"
   },
+  "activationEvents": [
+    "onFileSystem:konveyorMemFs",
+    "onFileSystem:konveyorReadOnly"
+  ],
   "contributes": {
     "commands": [
       {


### PR DESCRIPTION
Resolves https://github.com/konveyor/editor-extensions/issues/185

When a user closes VS Code with open tabs that reference resources from our custom file system (konveyorMemFs or konveyorReadOnly), those tabs fail to load on the next startup. This is because our extension does not activate automatically on VS Code startup or when restoring those resources. Instead, the extension only activates when the user interacts with the sidebar, leading to errors such as:

"The editor could not be opened due to an unexpected error: Unable to resolve resource konveyorReadOnly:/path/to/resource"

Fix:

We added activationEvents to package.json to ensure the extension activates automatically when resources using our custom schemes (konveyorMemFs and konveyorReadOnly) are accessed. This ensures that the file system provider is registered and available before VS Code attempts to restore such resources.