### PR TITLE
:book: Update 01-configuration_and_runtime_support.md

### DIFF
--- a/docs/roadmap/stories/01-configuration_and_runtime_support.md
+++ b/docs/roadmap/stories/01-configuration_and_runtime_support.md
@@ -1,7 +1,7 @@
 # Configuration and runtime support
 
 ## Story highlights
-  - Configuration of the analysis/Kia runtime can be on User or Workspace level
+  - Configuration of the analysis/Kai runtime can be on User or Workspace level
 
   - Select the runtime to setup and configure, options should support:
     - deployed with the extension itself _(as the default)_
@@ -10,8 +10,8 @@
 
   - Configure the runtime server
     - Standard configuration view pattern is ok
-    - Support storing secretes needed by the runtime
-      - Support logging in to services (e.g. login to LLM proxy)
+    - Support storing secrets needed by the runtime
+      - Support logging into services (e.g. login to LLM proxy)
       - Support storing already known / manually generated API keys
     - __Concern__: In a large corporate environment, developers are unlikely to have keys to directly access a model or even understand what a model is. A guided login to some kind of llm provider at a known URL is preferred.
 
@@ -19,7 +19,7 @@
 
   - Use [Walkthroughs](https://code.visualstudio.com/api/ux-guidelines/walkthroughs) as a root for configuration user flows
 
-  - After initial install / start of the extension,open the walkthrough to make it obvious that initial configurations need to be chosen and verified before the extension can operate properly.
+  - After initial install / start of the extension, open the walkthrough to make it obvious that initial configurations need to be chosen and verified before the extension can operate properly.
 
 
 ## Walkthrough for configuration points


### PR DESCRIPTION
Small typo updates

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
