### PR TITLE
:ghost: Add logging of the rpc server init request

### DIFF
--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -303,7 +303,9 @@ export class AnalyzerClient {
         cancellable: false,
       },
       async (progress) => {
-        this.outputChannel.appendLine("Sending 'initialize' request.");
+        this.outputChannel.appendLine(
+          `Sending 'initialize' request: ${JSON.stringify(initializeParams)}`,
+        );
         progress.report({
           message: "Sending 'initialize' request to RPC Server",
         });


### PR DESCRIPTION
Logging of the rpc server init request got dropped in recent changes.  Adding the logging back to the output channel for easier debugging.