### PR TITLE
:bug: Rewording notfication for better user experience

### DIFF
--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -479,7 +479,7 @@ export class AnalyzerClient {
             return;
           }
           if (ruleSets.length === 0) {
-            vscode.window.showInformationMessage("Analysis completed, but no RuleSets were found.");
+            vscode.window.showInformationMessage("Analysis completed. No incidents were found.");
             this.fireAnalysisStateChange(false);
             return;
           }


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->

No incidents were detected in this file after reanalysis. It seems the issue has been resolved or is no longer relevant. Rewording notification for clarity. 
<img width="664" alt="Screenshot 2025-01-27 at 1 09 31 PM" src="https://github.com/user-attachments/assets/f468e8e2-cce6-4241-af7f-a3709e14d3c1" />
