### PR TITLE
:sparkles: add config options for cache_dir and trace

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -600,6 +600,23 @@
           "scope": "window",
           "order": 50
         },
+        "konveyor.kai.cacheDir": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Path to a directory containing cached responses",
+          "scope": "window",
+          "order": 50
+        },
+        "konveyor.kai.traceEnabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to create traces of the communication with the model",
+          "scope": "window",
+          "order": 50
+        },
         "konveyor.analysis.incidentLimit": {
           "type": "number",
           "default": 10000,

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -33,6 +33,8 @@ import {
   getConfigUseDefaultRulesets,
   getConfigCustomRules,
   isAnalysisResponse,
+  getCacheDir,
+  getTraceEnabled,
 } from "../utilities";
 import { allIncidents } from "../issueView";
 import { Immutable } from "immer";
@@ -263,6 +265,8 @@ export class AnalyzerClient {
       },
 
       demoMode: this.isDemoMode(),
+      cacheDir: getCacheDir(),
+      traceEnabled: getTraceEnabled(),
 
       // Paths to the Analyzer and jdt.ls
       analyzerLspRpcPath: this.getAnalyzerPath(),

--- a/vscode/src/client/types.ts
+++ b/vscode/src/client/types.ts
@@ -54,6 +54,7 @@ export interface KaiRpcApplicationConfig {
   demoMode?: boolean; // defaults to `false`
   cacheDir?: string; // defaults to `None`
   enableReflection?: boolean; // defaults to `true`
+  traceEnabled?: boolean; // defaults to `false`
 
   analyzerLspLspPath: string;
   analyzerLspRpcPath: string;

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -62,6 +62,14 @@ export function getConfigKaiProviderName(): string {
   return getConfigValue<string>("kai.providerName") || "ChatIBMGenAI";
 }
 
+export function getCacheDir(): string | undefined {
+  return getConfigValue<string>("kai.cacheDir");
+}
+
+export function getTraceEnabled(): boolean {
+  return getConfigValue<boolean>("kai.traceEnabled") || false;
+}
+
 export function getConfigKaiProviderArgs(): object | undefined {
   const config = vscode.workspace.getConfiguration("konveyor.kai");
   const providerArgsConfig = config.inspect<object>("providerArgs");


### PR DESCRIPTION
This adds the ability for users to generate new cached data and also adds an option to generate the LLM traces.