### PR TITLE
:bug: Fix errant resolution details message on second resolution request

### DIFF
--- a/webview-ui/src/components/ResolutionsPage.tsx
+++ b/webview-ui/src/components/ResolutionsPage.tsx
@@ -40,7 +40,8 @@ const ResolutionPage: React.FC = () => {
   const isTriggeredByUser = !!solutionScope?.incidents?.length;
   const isHistorySolution = !isTriggeredByUser && !!localChanges.length;
 
-  const isResolved = localChanges.length !== 0 && getRemainingFiles().length === 0;
+  const isResolved =
+    solutionState === "received" && localChanges.length !== 0 && getRemainingFiles().length === 0;
   const hasResponseWithErrors =
     solutionState === "received" && !!resolution?.encountered_errors?.length;
   const hasResponse =


### PR DESCRIPTION
Resolves: #255

Resolution details should only show the "All resolutions have been applied" message when a resolution has been received.
