### PR TITLE
:seedling: Add ability to trace the jsonrpc MessageConnection

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -651,6 +651,12 @@
           "description": "Should the analyzer analyze project dependencies?",
           "scope": "window",
           "order": 99
+        },
+        "konveyor.logging.traceMessageConnection": {
+          "type": "boolean",
+          "default": false,
+          "description": "Trace the jsonrpc calls between the extension and the kai server?",
+          "order": 100
         }
       }
     },

--- a/vscode/src/client/tracer.ts
+++ b/vscode/src/client/tracer.ts
@@ -1,0 +1,65 @@
+// Modified from https://github.com/microsoft/vscode-languageserver-node/blob/main/client/src/common/client.ts
+
+import * as vscode from "vscode";
+import { Logger, ResponseError, Tracer } from "vscode-jsonrpc/node";
+
+function isString(value: any): value is string {
+  return typeof value === "string" || value instanceof String;
+}
+
+function data2String(data: object): string {
+  if (data instanceof ResponseError) {
+    const responseError = data as ResponseError<any>;
+    return `  Message: ${responseError.message}\n  Code: ${responseError.code} ${responseError.data ? "\n" + responseError.data.toString() : ""}`;
+  }
+  if (data instanceof Error) {
+    if (isString(data.stack)) {
+      return data.stack;
+    }
+    return (data as Error).message;
+  }
+  if (isString(data)) {
+    return data;
+  }
+  return data.toString();
+}
+
+const tracerToLogOutputChannel = (channel: vscode.LogOutputChannel): Tracer => {
+  const logTrace = (message: string, data?: any) => {
+    channel.info(message);
+    if (data) {
+      channel.info(data2String(data));
+    }
+  };
+
+  const logObjectTrace = (data: any) => {
+    if (data) {
+      channel.info(JSON.stringify(data, null, 2));
+    }
+  };
+
+  const log = (messageOrDataObject: string | any, data?: string) => {
+    if (isString(messageOrDataObject)) {
+      logTrace(messageOrDataObject, data);
+    } else {
+      logObjectTrace(messageOrDataObject);
+    }
+  };
+
+  return { log };
+};
+
+/** Enable a `MessageConnection` to trace comms to a `LogOutputChannel`. */
+export const tracer = (channelName: string): Tracer => {
+  const traceLogChannel = vscode.window.createOutputChannel(channelName, {
+    log: true,
+  });
+  return tracerToLogOutputChannel(traceLogChannel);
+};
+
+export const logger = (channel: vscode.LogOutputChannel): Logger => ({
+  error: (message: string) => channel.error(message),
+  warn: (message: string) => channel.warn(message),
+  info: (message: string) => channel.info(message),
+  log: (message: string) => channel.debug(message),
+});

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -18,6 +18,10 @@ export function getConfigLogLevel(): ServerLogLevels {
   return getConfigValue<ServerLogLevels>("logLevel") || "DEBUG";
 }
 
+export function getConfigLoggingTraceMessageConnection(): boolean {
+  return getConfigValue<boolean>("logging.traceMessageConnection") ?? false;
+}
+
 export function getConfigIncidentLimit(): number {
   return getConfigValue<number>("analysis.incidentLimit") || 10000;
 }


### PR DESCRIPTION
To make it easier to work between the jsonrpc server and the extension client, add the ability to trace the messaging to an output channel.

Details:
  - The output channel's name is of the form: `${basename(kai-rpc-server)} message trace`

  - The trace output channel is created when the server is first started, and is independent from the `Konveyor-Analyzer` channel

  - Tracing is controlled by the configuration key `konveyor.logging.traceMessageConnection`. It is `false` by default.

Note: Supports #315