### PR TITLE
:sparkles: Change default diff editor to `merge`

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -507,7 +507,7 @@
             "diff",
             "merge"
           ],
-          "default": "diff",
+          "default": "merge",
           "description": "Select the editor to use when resolving proposed solutions.",
           "scope": "window",
           "order": 7


### PR DESCRIPTION
The `diff` view requires use of proposed APIs. Swap the default to the one that will both work without special measures and will let the extension be
published to the extension markplace.

Ref: #222

Note: This change does not remove the proposed api use warnings vscode shows at startup.
