### PR TITLE
:bug: Fix Analysis and Resolution file paths relative to workspaceRoot

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -35,7 +35,7 @@ class VsCodeExtension {
         solutionData: undefined,
         serverState: "initial",
         solutionScope: undefined,
-        workspaceRoot: paths.workspaceRepo.fsPath,
+        workspaceRoot: paths.workspaceRepo.toString(),
         solutionMessages: [],
         solutionState: "none",
       },


### PR DESCRIPTION
Incident file path information changed to use Uri values.  Since the `workspaceRoot` being handed to the webviews was fsPath based, the full Uris were being rendered.  Pass the workspaceRoot as a Uri string and get the `relativeDirname()` function working properly again.

Resolves: #252 
