### PR TITLE
:seedling: collect-assets refactored to use GitHub API with auth

### DIFF
--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -92,6 +92,19 @@ jobs:
         run: |
           npm ci
 
+      #
+      # TODO: To run a proper test, the Kai assets need to be downloaded for the proper place
+      # TODO: For example, this would be nice...
+      # - name: Collect assets needed to run Kai on the current runtime's platform/arch
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     npm run collect-assets \
+      #       --workflow \
+      #       --branch=main \
+      #       --platform=runtime \
+      #       --arch=runtime
+
       # Run tests on Linux
       - name: Run tests (Linux)
         if: matrix.arch == 'linux'
@@ -134,6 +147,8 @@ jobs:
           npm ci
 
       - name: Build the project and generate the .vsix
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm run build
           npm run collect-assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,23 +15,24 @@ on:
         required: true
         type: boolean
         default: false
+
 # https://typicode.github.io/husky/how-to.html#ci-server-and-docker
 env:
   HUSKY: 0
 
 jobs:
-  release_prereq:
-    name: Build, Test, and Package (${{ matrix.arch }})
+  test_build_package:
+    name: Build, Test, and Package (${{ matrix.platform }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
           - os: ubuntu-latest
-            arch: linux
+            platform: linux
           - os: macos-latest
-            arch: macos
+            platform: macos
           - os: windows-latest
-            arch: windows
+            platform: windows
       max-parallel: 3
     outputs:
       tag_name: ${{ steps.determine_tag.outputs.tag_name }}
@@ -60,15 +61,15 @@ jobs:
 
       # Run tests on different OSes
       - name: Run tests (Linux)
-        if: matrix.arch == 'linux'
+        if: matrix.platform == 'linux'
         run: xvfb-run -a npm run test
 
       - name: Run tests (macOS)
-        if: matrix.arch == 'macos'
+        if: matrix.platform == 'macos'
         run: npm test
 
       - name: Run tests (Windows)
-        if: matrix.arch == 'windows'
+        if: matrix.platform == 'windows'
         shell: cmd
         run: npm test
 
@@ -80,6 +81,8 @@ jobs:
 
       # Collect assets
       - name: Collect assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run collect-assets
 
       # Copy files to dist folder
@@ -90,20 +93,20 @@ jobs:
       - name: Build VSIX package
         run: npm run package
 
-      # Upload VSIX artifact (linux )
+      # Upload VSIX artifact (linux)
       - name: Upload VSIX artifact
-        if: matrix.arch == 'linux'
+        if: matrix.platform == 'linux'
         uses: actions/upload-artifact@v4
         with:
-          name: vscode-extension-${{ matrix.arch }}
+          name: vscode-extension-${{ matrix.platform }}
           path: ./dist/*.vsix
 
   generate_changelog:
     name: Generate Changelog
-    needs: release_prereq
+    needs: test_build_package
     uses: konveyor/release-tools/.github/workflows/generate-changelog.yml@main
     with:
-      version: ${{ needs.release_prereq.outputs.tag_name }}
+      version: ${{ needs.test_build_package.outputs.tag_name }}
       prev_version: $(gh api repos/${{ github.repository }}/releases/latest | jq -r '.tag_name')
       repository: ${{ github.repository }}
       ref: ${{ github.sha }}
@@ -113,7 +116,7 @@ jobs:
   release:
     name: Final Release
     runs-on: ubuntu-latest
-    needs: [release_prereq, generate_changelog]
+    needs: [test_build_package, generate_changelog]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -141,12 +144,12 @@ jobs:
 
       - name: Rename VSIX Packages
         run: |
-          mv ./artifacts/vscode-extension-linux/*.vsix ./artifacts/konveyor-${{ needs.release_prereq.outputs.tag_name }}.vsix
+          mv ./artifacts/vscode-extension-linux/*.vsix ./artifacts/konveyor-${{ needs.test_build_package.outputs.tag_name }}.vsix
 
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ needs.release_prereq.outputs.tag_name }}
+          tag: ${{ needs.test_build_package.outputs.tag_name }}
           commit: ${{ github.sha }}
           bodyFile: ./artifacts/release.md
           artifacts: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.11.1",
+        "@octokit/core": "^6.1.3",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@types/fs-extra": "^11.0.4",
         "@types/js-yaml": "^4.0.9",
@@ -1576,6 +1577,111 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
+      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.3.tgz",
+      "integrity": "sha512-z+j7DixNnfpdToYsOutStDgeRzJSMnbj8T1C/oQjB6Aa+kRfNjs/Fn7W6c8bmlt6mfy3FkgeKBRnDjxQow5dow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.1.2",
+        "@octokit/request": "^9.1.4",
+        "@octokit/request-error": "^6.1.6",
+        "@octokit/types": "^13.6.2",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.2.tgz",
+      "integrity": "sha512-XybpFv9Ms4hX5OCHMZqyODYqGTZ3H6K6Vva+M9LR7ib/xr1y1ZnlChYv9H680y77Vd/i/k+thXApeRASBQkzhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.6.2",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.2.tgz",
+      "integrity": "sha512-bdlj/CJVjpaz06NBpfHhp4kGJaRZfz7AzC+6EwUImRtrwIw8dIgJ63Xg0OzV9pRn3rIzrt5c2sa++BL0JJ8GLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^9.1.4",
+        "@octokit/types": "^13.6.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.0.tgz",
+      "integrity": "sha512-kXLfcxhC4ozCnAXy2ff+cSxpcF0A1UqxjvYMqNuPIeOAzJbVWQ+dy5G2fTylofB/gTbObT8O6JORab+5XtA1Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^10.0.0",
+        "@octokit/request-error": "^6.0.1",
+        "@octokit/types": "^13.6.2",
+        "fast-content-type-parse": "^2.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.6.tgz",
+      "integrity": "sha512-pqnVKYo/at0NuOjinrgcQYpEbv4snvP3bKMRqHaD9kIsk9u1LCpb2smHZi8/qJfgeNqLo5hNW4Z7FezNdEo0xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.6.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
+      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^23.0.1"
       }
     },
     "node_modules/@patternfly/patternfly": {
@@ -3810,6 +3916,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/before-after-hook": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -5866,6 +5979,23 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -12641,6 +12771,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",
+    "@octokit/core": "^6.1.3",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@types/fs-extra": "^11.0.4",
     "@types/js-yaml": "^4.0.9",

--- a/scripts/_github.js
+++ b/scripts/_github.js
@@ -1,99 +1,92 @@
+/** @import { Octokit } from "@octokit/core" */
+
+/**
+ * Fetch the JSON metadata for a GitHub repository release.
+ *
+ * @param {Octokit} octokit Octokit configured for auth and the target owner/repo
+ * @param {string} releaseTag The release's tag
+ */
+export async function fetchGitHubReleaseMetadata(octokit, releaseTag) {
+  const response = await octokit.request("GET /repos/{owner}/{repo}/releases/tags/{tag}", {
+    tag: releaseTag,
+  });
+
+  return await response.data;
+}
+
+/**
+ * Fetch the commit sha for a GitHub repository release.
+ *
+ * @param {Octokit} octokit Octokit configured for auth and the target owner/repo
+ * @param {string} releaseTag The release's tag
+ */
+export async function fetchGitHubReleaseTagSha(octokit, releaseTag) {
+  const response = await octokit.request("GET /repos/{owner}/{repo}/commits/{tag}", {
+    tag: releaseTag,
+  });
+
+  return await response.data.sha;
+}
+
 /**
  * Fetch the most recent successful workflow run for the branch head.
  *
- * @param {string} org - GitHub organization or user.
- * @param {string} repo - GitHub repository name.
- * @param {string} workflowFile - Name of the workflow file.
+ * @param {Octokit} octokit Octokit configured for auth and the target owner/repo
+ * @param {string} branch Name of the brach to check
+ * @param {string} workflowFile Name of the workflow file to check
  * @returns {Promise<{runId: string, headSha: string} | null>} - Object containing the workflow run ID and head SHA, or null if not found.
  */
-export async function fetchFirstSuccessfulRun(org, repo, workflowFile) {
-  try {
-    console.log(`Fetching head commit SHA for branch: main`);
-    const res = await fetch(`https://api.github.com/repos/${org}/${repo}/branches/main`, {
-      headers: {
-        Accept: "application/vnd.github.v3+json",
-      },
-    });
+export async function fetchFirstSuccessfulRun(octokit, branch, workflowFile) {
+  const branchInfo = await octokit.request("GET /repos/{owner}/{repo}/branches/{branch}", {
+    branch,
+  });
+  const headSha = branchInfo.data.commit.sha;
 
-    if (!res.ok) {
-      throw new Error(`Failed to fetch branch head SHA: ${res.statusText}`);
-    }
+  const workflowRunInfo = await octokit.request(
+    "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs{?head_sha,per_page}",
+    {
+      workflow_id: workflowFile,
+      head_sha: headSha,
+      per_page: 1,
+    },
+  );
 
-    const data = await res.json();
-    const headSha = data.commit.sha;
-    console.log(`Head commit SHA: ${headSha}`);
-
-    console.log(`Fetching workflow runs for head SHA: ${headSha}`);
-    const workflowResponse = await fetch(
-      `https://api.github.com/repos/${org}/${repo}/actions/workflows/${workflowFile}/runs?head_sha=${headSha}&per_page=1`,
-      {
-        headers: {
-          Accept: "application/vnd.github.v3+json",
-        },
-      },
-    );
-
-    if (!workflowResponse.ok) {
-      throw new Error(`Failed to fetch workflow runs: ${workflowResponse.statusText}`);
-    }
-
-    const workflowData = await workflowResponse.json();
-    if (workflowData.workflow_runs.length === 0) {
-      console.log("No successful workflow runs found for the head commit.");
-      return null;
-    }
-
-    const workflowRun = workflowData.workflow_runs[0];
-    if (workflowRun.status !== "completed" || workflowRun.conclusion !== "success") {
-      console.log(
-        `Workflow run for head commit is not successful: Status = ${workflowRun.status}, Conclusion = ${workflowRun.conclusion}`,
-      );
-      return null;
-    }
-
-    console.log(`First Successful Workflow Run ID for head commit: ${workflowRun.id}`);
-    return {
-      workflowRunId: workflowRun.id,
-      headSha: headSha,
-    };
-  } catch (error) {
-    console.error("Error fetching workflow runs:", error.message);
-    return null;
+  if (workflowRunInfo.data.workflow_runs.length === 0) {
+    console.error("No workflow runs found for the commit.");
+    return {};
   }
+
+  const workflowRun = workflowRunInfo.data.workflow_runs[0];
+  if (workflowRun.status !== "completed" || workflowRun.conclusion !== "success") {
+    console.error(
+      `Workflow run ${workflowRun.id} for HEAD commit on ${branch} is not successful. status: ${workflowRun.status}, conclusion: ${workflowRun.conclusion}`,
+    );
+    return {};
+  }
+
+  return {
+    workflowRunId: workflowRun.id,
+    workflowRunUrl: workflowRun.url,
+    headSha: headSha,
+  };
 }
 
 /**
  * Fetch artifacts for a specific workflow run.
  *
- * @param {string} org - GitHub organization or user.
- * @param {string} repo - GitHub repository name.
+ * @param {Octokit} octokit Octokit configured for auth and the target owner/repo
  * @param {string} runId - ID of the workflow run.
- * @returns {Promise<Array>} - List of artifacts with download URLs.
+ * @returns {Promise<Array<{ name, url }>} - List of artifacts with download URLs.
  */
-export async function fetchArtifactsForRun(org, repo, runId) {
-  try {
-    const response = await fetch(
-      `https://api.github.com/repos/${org}/${repo}/actions/runs/${runId}/artifacts`,
-      {
-        headers: {
-          Accept: "application/vnd.github.v3+json",
-        },
-      },
-    );
+export async function fetchArtifactsForRun(octokit, runId) {
+  const r = await octokit.request("GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts", {
+    run_id: runId,
+  });
 
-    if (!response.ok) {
-      throw new Error(`Failed to fetch artifacts: ${response.statusText}`);
-    }
-
-    const data = await response.json();
-    const downloadUrls = data.artifacts.map((artifact) => ({
-      name: artifact.name,
-      url: artifact.archive_download_url,
-    }));
-    console.log("Artifact Download URLs:", downloadUrls);
-    return downloadUrls;
-  } catch (error) {
-    console.error("Error fetching artifacts:", error.message);
-    return [];
-  }
+  const data = r.data;
+  const downloadUrls = data.artifacts.map((artifact) => ({
+    name: artifact.name,
+    url: artifact.archive_download_url,
+  }));
+  return downloadUrls;
 }

--- a/scripts/collect-assets.js
+++ b/scripts/collect-assets.js
@@ -23,6 +23,7 @@ if (process.env.WORKFLOW && process.env.WORKFLOW !== "False") {
     metaFile: join(DOWNLOAD_DIR, "kai", "collect.json"),
     org: "konveyor",
     repo: "kai",
+    branch: "main",
     workflow: "build-and-push-binaries.yml",
     assets: [
       { name: "java-deps.zip", chmod: false },
@@ -59,6 +60,7 @@ if (process.env.WORKFLOW && process.env.WORKFLOW !== "False") {
     ],
   });
 }
+
 // Download jdt.ls
 // Base release url: https://download.eclipse.org/jdtls/milestones/1.38.0/
 await downloadAndExtractTarGz({


### PR DESCRIPTION
Refactor the `collect-assets` scripts so every call to the GitHub API can be authorized with the GITHUB_TOKEN envvar.  This will help prevent rate limiting encountered by CI and Release actions.

Summary:
  - Setup `GITHUB_TOKEN` in actions as needed
  - Use `@octokit/core` for GitHub API access as it can default auth and it has lots of nice typing and rich information if errors are encountered
  - GitHub fetch functions are now all in `_github.js`
  - try/catch blocks moved as high as possible, any `await function` call that fails will be passed up
