### PR TITLE
:sparkles: Remove key text from `sample-provider-settings.yaml`, add a command to reset

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -39,8 +39,14 @@
   "contributes": {
     "commands": [
       {
-        "command": "konveyor.openModelProviderSettings",
+        "command": "konveyor.modelProviderSettingsOpen",
         "title": "Open the GenAI model provider configuration file",
+        "category": "Konveyor",
+        "icon": "$(gear)"
+      },
+      {
+        "command": "konveyor.modelProviderSettingsBackupReset",
+        "title": "Open the default the GenAI model provider configuration file and backup the current file",
         "category": "Konveyor",
         "icon": "$(gear)"
       },

--- a/vscode/resources/sample-provider-settings.yaml
+++ b/vscode/resources/sample-provider-settings.yaml
@@ -10,16 +10,16 @@ environment:
 models:
   OpenAI: &active
     environment:
-      OPENAI_API_KEY: "key"
+      OPENAI_API_KEY: ""
     provider: "ChatOpenAI"
     args:
       model: "gpt-4o"
 
   AmazonBedrock:
     environment:
-      AWS_ACCESS_KEY_ID: "key id"
-      AWS_SECRET_ACCESS_KEY: "secret"
-      AWS_DEFAULT_REGION: "region"
+      AWS_ACCESS_KEY_ID: ""
+      AWS_SECRET_ACCESS_KEY: ""
+      AWS_DEFAULT_REGION: ""
     provider: "ChatBedrock"
     args:
       model_id: "meta.llama3-70b-instruct-v1:0"

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -35,7 +35,7 @@ import {
 import { runPartialAnalysis } from "./analysis";
 import { fixGroupOfIncidents, IncidentTypeItem } from "./issueView";
 import { paths } from "./paths";
-import { checkIfExecutable } from "./utilities/fileUtils";
+import { checkIfExecutable, copySampleProviderSettings } from "./utilities/fileUtils";
 
 const isWindows = process.platform === "win32";
 
@@ -164,7 +164,12 @@ const commandsMap: (state: ExtensionState) => {
         window.showInformationMessage("No Kai rpc-server binary selected.");
       }
     },
-    "konveyor.openModelProviderSettings": async () => {
+    "konveyor.modelProviderSettingsOpen": async () => {
+      const settingsDocument = await workspace.openTextDocument(paths().settingsYaml);
+      window.showTextDocument(settingsDocument);
+    },
+    "konveyor.modelProviderSettingsBackupReset": async () => {
+      await copySampleProviderSettings(true);
       const settingsDocument = await workspace.openTextDocument(paths().settingsYaml);
       window.showTextDocument(settingsDocument);
     },

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -11,6 +11,7 @@ import { Immutable, produce } from "immer";
 import { partialAnalysisTrigger } from "./analysis";
 import { IssuesModel, registerIssueView } from "./issueView";
 import { ensurePaths, ExtensionPaths } from "./paths";
+import { copySampleProviderSettings } from "./utilities/fileUtils";
 
 class VsCodeExtension {
   private state: ExtensionState;
@@ -154,16 +155,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }
 
     const paths = await ensurePaths(context);
-
-    // copy in the sample file if the settings file doesn't exist
-    try {
-      await vscode.workspace.fs.stat(paths.settingsYaml);
-    } catch {
-      await vscode.workspace.fs.copy(
-        vscode.Uri.joinPath(paths.extResources, "sample-provider-settings.yaml"),
-        paths.settingsYaml,
-      );
-    }
+    await copySampleProviderSettings();
 
     extension = new VsCodeExtension(paths, context);
     extension.initialize();


### PR DESCRIPTION
Two changes:
  - Remove the sample key text to shorten any time to fail on solution requests if a user doesn't put the keys in the right place

  - Add a command to allow a user to backup their existing `provider-setting.yaml` file and reset it back to the extension default/sample file

This is a partial fix for #327.
