### PR TITLE
:seedling: release 0.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "editor-extensions",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "editor-extensions",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -14290,7 +14290,7 @@
     },
     "shared": {
       "name": "@editor-extensions/shared",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "devDependencies": {
         "vite": "^5.4.9",
         "vite-plugin-checker": "^0.8.0"
@@ -14298,7 +14298,7 @@
     },
     "vscode": {
       "name": "konveyor-ai",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/jsesc": "^3.0.3",
@@ -14326,7 +14326,7 @@
     },
     "webview-ui": {
       "name": "@editor-extensions/webview-ui",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "dependencies": {
         "@patternfly/patternfly": "6.0.0-prerelease.15",
         "@patternfly/react-code-editor": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editor-extensions",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "displayName": "Konveyor",
   "description": "VSCode Extension for Konveyor to assist in migrating and modernizing applications.",

--- a/scripts/collect-assets.js
+++ b/scripts/collect-assets.js
@@ -43,7 +43,7 @@ if (process.env.WORKFLOW && process.env.WORKFLOW !== "False") {
     metaFile: join(DOWNLOAD_DIR, "kai", "collect.json"),
     org: "konveyor",
     repo: "kai",
-    releaseTag: "v0.0.7",
+    releaseTag: "v0.0.8",
     /*
       Release asset filenames and nodejs equivalent platform/arch
       platform: https://nodejs.org/docs/latest-v22.x/api/process.html#processplatform

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editor-extensions/shared",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -5,7 +5,7 @@
   "author": "Konveyor",
   "icon": "resources/konveyor-icon-color.png",
   "license": "Apache-2.0",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "./out/extension.js",
   "publisher": "konveyor",
   "repository": {

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editor-extensions/webview-ui",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
