### PR TITLE
:sparkles: make the incident list sortable

### DIFF
--- a/shared/src/types/types.ts
+++ b/shared/src/types/types.ts
@@ -2,12 +2,9 @@ import { Uri } from "vscode";
 
 export type WebviewType = "sidebar" | "resolution";
 
-export type Severity = "High" | "Medium" | "Low";
-
 export interface Incident {
   uri: string;
   lineNumber?: number;
-  severity?: Severity;
   message: string;
   codeSnip?: string;
 }
@@ -38,7 +35,6 @@ export interface EnhancedIncident extends Incident {
   violationId: string;
   uri: string;
   message: string;
-  severity?: Severity;
   ruleset_name?: string;
   ruleset_description?: string;
   violation_name?: string;

--- a/vscode/src/data/loadResults.ts
+++ b/vscode/src/data/loadResults.ts
@@ -89,7 +89,6 @@ function enhanceIncidentsFromRuleSets(ruleSets: RuleSet[]): EnhancedIncident[] {
         violationId,
         uri: incident.uri,
         message: incident.message,
-        severity: incident.severity,
       })),
     ),
   );

--- a/webview-ui/src/components/ViolationCard.tsx
+++ b/webview-ui/src/components/ViolationCard.tsx
@@ -64,7 +64,7 @@ export const ViolationCard: React.FC<ViolationCardProps> = ({ incident, violatio
                 >
                   {incident.codeSnip}
                 </Content> */}
-                <Label color="blue">{incident.severity || "Low"}</Label>
+                <Label color="blue">{violation.category || "potential"}</Label>
               </FlexItem>
               <Divider />
             </>


### PR DESCRIPTION
* Make the list of incidents sort ascending/descending based on the grouping (issues | files)
* Add new toggle for the sort
* Swap severity filter for category filter that actually exist on incidents.

Fixes #358 
Fixes #369
