### PR TITLE
Get effort level from config

### DIFF
--- a/.vscode/konveyor-logs/kai-rpc-server.log
+++ b/.vscode/konveyor-logs/kai-rpc-server.log
@@ -1,0 +1,27 @@
+INFO - 2025-02-17 09:59:12,830 - kai - MainThread - [logging.py:134 - init_logging()] - We have inited the logger: file_logging: DEBUG console_logging: DEBUG
+INFO - 2025-02-17 09:59:12,831 - kai.kai-rpc-logger - MainThread - [main.py:93 - main()] - using log config: log_level='DEBUG' stderr_log_level='TRACE' file_log_level='DEBUG' log_dir_path=PosixPath('/Users/ibolton/Development/editor-extensions/.vscode/konveyor-logs') log_file_name='kai-rpc-server.log'
+DEBUG - 2025-02-17 09:59:12,831 - kai.kai-rpc-logger - Thread-1 - [core.py:237 - run()] - Server thread started
+DEBUG - 2025-02-17 09:59:12,831 - kai.kai-rpc-logger - Thread-1 - [core.py:240 - run()] - Waiting for message
+INFO - 2025-02-17 09:59:12,831 - kai.kai-rpc-logger - MainThread - [main.py:115 - main()] - Started kai RPC Server
+DEBUG - 2025-02-17 09:59:12,831 - kai.jsonrpc - Thread-1 - [streams.py:109 - recv()] - Waiting for message
+INFO - 2025-02-17 09:59:12,833 - kai.kai.cache - Thread-1 - [cache.py:90 - __init__()] - Using cache dir: /var/folders/ss/srhgsxwn06nbjqy8cgrh_1xc0000gn/T/_MEIyYFMlC/data/llm_cache
+DEBUG - 2025-02-17 09:59:14,499 - kai.kai-rpc-logger - Thread-1 - [core.py:240 - run()] - Waiting for message
+DEBUG - 2025-02-17 09:59:14,499 - kai.jsonrpc - Thread-1 - [streams.py:109 - recv()] - Waiting for message
+DEBUG - 2025-02-17 10:28:32,096 - kai.kai-rpc-logger - Thread-1 - [core.py:240 - run()] - Waiting for message
+DEBUG - 2025-02-17 10:28:32,096 - kai.jsonrpc - Thread-1 - [streams.py:109 - recv()] - Waiting for message
+DEBUG - 2025-02-17 10:31:52,468 - kai.kai-rpc-logger - Thread-1 - [core.py:240 - run()] - Waiting for message
+DEBUG - 2025-02-17 10:31:52,468 - kai.jsonrpc - Thread-1 - [streams.py:109 - recv()] - Waiting for message
+DEBUG - 2025-02-17 10:34:06,219 - kai.kai-rpc-logger - Thread-1 - [core.py:240 - run()] - Waiting for message
+DEBUG - 2025-02-17 10:34:06,219 - kai.jsonrpc - Thread-1 - [streams.py:109 - recv()] - Waiting for message
+DEBUG - 2025-02-17 10:34:45,778 - kai.kai-rpc-logger - Thread-1 - [core.py:240 - run()] - Waiting for message
+DEBUG - 2025-02-17 10:34:45,778 - kai.jsonrpc - Thread-1 - [streams.py:109 - recv()] - Waiting for message
+DEBUG - 2025-02-17 10:39:56,335 - kai.kai-rpc-logger - Thread-1 - [core.py:240 - run()] - Waiting for message
+DEBUG - 2025-02-17 10:39:56,335 - kai.jsonrpc - Thread-1 - [streams.py:109 - recv()] - Waiting for message
+DEBUG - 2025-02-17 10:40:39,460 - kai.kai-rpc-logger - Thread-1 - [core.py:240 - run()] - Waiting for message
+DEBUG - 2025-02-17 10:40:39,460 - kai.jsonrpc - Thread-1 - [streams.py:109 - recv()] - Waiting for message
+DEBUG - 2025-02-17 10:42:56,983 - kai.kai-rpc-logger - Thread-1 - [core.py:240 - run()] - Waiting for message
+DEBUG - 2025-02-17 10:42:56,983 - kai.jsonrpc - Thread-1 - [streams.py:109 - recv()] - Waiting for message
+DEBUG - 2025-02-17 10:48:07,114 - kai.kai-rpc-logger - Thread-1 - [core.py:240 - run()] - Waiting for message
+DEBUG - 2025-02-17 10:48:07,114 - kai.jsonrpc - Thread-1 - [streams.py:109 - recv()] - Waiting for message
+DEBUG - 2025-02-17 10:48:34,574 - kai.kai-rpc-logger - Thread-1 - [core.py:240 - run()] - Waiting for message
+DEBUG - 2025-02-17 10:48:34,574 - kai.jsonrpc - Thread-1 - [streams.py:109 - recv()] - Waiting for message

--- a/shared/src/types/types.ts
+++ b/shared/src/types/types.ts
@@ -116,6 +116,7 @@ export interface ExtensionData {
   solutionData?: Solution;
   solutionScope?: Scope;
   solutionMessages: string[];
+  effortLevel?: number;
 }
 
 export type ServerState =

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -12,6 +12,7 @@ import { partialAnalysisTrigger } from "./analysis";
 import { IssuesModel, registerIssueView } from "./issueView";
 import { ensurePaths, ExtensionPaths } from "./paths";
 import { copySampleProviderSettings } from "./utilities/fileUtils";
+import { getConfigSolutionMaxEffort } from "./utilities/configuration";
 
 class VsCodeExtension {
   private state: ExtensionState;
@@ -79,6 +80,7 @@ class VsCodeExtension {
       this.registerLanguageProviders();
       this.listeners.push(vscode.workspace.onDidSaveTextDocument(partialAnalysisTrigger));
       vscode.commands.executeCommand("konveyor.loadResultsFromDataFolder");
+      this.updateEffortLevelFromConfig();
     } catch (error) {
       console.error("Error initializing extension:", error);
       vscode.window.showErrorMessage(`Failed to initialize Konveyor extension: ${error}`);
@@ -134,6 +136,16 @@ class VsCodeExtension {
         }),
       );
     }
+  }
+
+  private updateEffortLevelFromConfig() {
+    // const config = vscode.workspace.getConfiguration("konveyor");
+    // const effortLevel = config.get<number>("kai.getSolutionMaxEffort");
+    const effortLevel = getConfigSolutionMaxEffort();
+
+    this.state.mutateData((draft) => {
+      draft.effortLevel = effortLevel;
+    });
   }
 
   public async dispose() {

--- a/vscode/src/webviewMessageHandler.ts
+++ b/vscode/src/webviewMessageHandler.ts
@@ -26,6 +26,10 @@ const actions: {
   [WEBVIEW_READY]() {
     console.log("Webview is ready");
   },
+  // [SET_EFFORT](effort: string) {
+  //   vscode.commands.executeCommand("konveyor.setEffort", effort);
+  //TODO: Implement the setEffort command that would update config value
+  // },
   [GET_SOLUTION](scope: Scope) {
     vscode.commands.executeCommand("konveyor.getSolution", scope.incidents, scope.violation);
 


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
