### PR TITLE
:bug: At extension startup, reload analysis result but do not reload solutions

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -181,12 +181,6 @@
         "icon": "$(check)"
       },
       {
-        "command": "konveyor.reloadLastResolutions",
-        "title": "Reload Last Resolutions",
-        "icon": "$(history)",
-        "category": "Konveyor"
-      },
-      {
         "command": "konveyor.discardAll",
         "title": "Discard All",
         "category": "Konveyor",
@@ -312,11 +306,6 @@
         {
           "command": "konveyor.discardAll",
           "group": "navigation@2",
-          "when": "view == konveyor.diffView"
-        },
-        {
-          "command": "konveyor.reloadLastResolutions",
-          "group": "navigation@3",
           "when": "view == konveyor.diffView"
         }
       ],

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -7,7 +7,6 @@ import {
   loadRuleSets,
   loadSolution,
   loadStaticResults,
-  reloadLastResolutions,
 } from "./data";
 import { EnhancedIncident, RuleSet, Scope, Solution } from "@editor-extensions/shared";
 import {
@@ -342,7 +341,6 @@ const commandsMap: (state: ExtensionState) => {
     },
     "konveyor.fixGroupOfIncidents": fixGroupOfIncidents,
     "konveyor.fixIncident": fixGroupOfIncidents,
-    "konveyor.reloadLastResolutions": async () => reloadLastResolutions(state),
     "konveyor.diffView.applyBlock": applyBlock,
     "konveyor.diffView.applyBlockInline": applyBlock,
     "konveyor.diffView.applySelection": applyBlock,

--- a/vscode/src/data/loadResults.ts
+++ b/vscode/src/data/loadResults.ts
@@ -11,7 +11,6 @@ import { processIncidents } from "./analyzerResults";
 import { ExtensionState } from "src/extensionState";
 import { writeDataFile } from "./storage";
 import { toLocalChanges, writeSolutionsToMemFs } from "./virtualStorage";
-import { window } from "vscode";
 import {
   KONVEYOR_SCHEME,
   RULE_SET_DATA_FILE_PREFIX,
@@ -47,17 +46,6 @@ export const loadSolution = async (state: ExtensionState, solution: Solution, sc
     solution,
     scope ?? (solution as GetSolutionResult).scope,
   );
-};
-
-export const reloadLastResolutions = async (state: ExtensionState) => {
-  await doLoadSolution(
-    state,
-    state.data.localChanges.map((it) => ({ ...it })),
-    state.data.solutionData,
-    state.data.solutionScope,
-  );
-
-  window.showInformationMessage(`Loaded last available resolutions`);
 };
 
 const doLoadSolution = async (

--- a/vscode/src/data/loadResults.ts
+++ b/vscode/src/data/loadResults.ts
@@ -52,7 +52,7 @@ export const loadSolution = async (state: ExtensionState, solution: Solution, sc
 export const reloadLastResolutions = async (state: ExtensionState) => {
   await doLoadSolution(
     state,
-    state.data.localChanges.map((it) => ({ ...it, state: "pending" })),
+    state.data.localChanges.map((it) => ({ ...it })),
     state.data.solutionData,
     state.data.solutionScope,
   );

--- a/vscode/src/data/loadStaticResults.ts
+++ b/vscode/src/data/loadStaticResults.ts
@@ -50,11 +50,8 @@ const filePathsCorrect = (ruleSets: RuleSet[]) =>
     );
 
 export const loadResultsFromDataFolder = async () => {
-  const [analysisResults, solution] = await loadStateFromDataFolder();
+  const [analysisResults] = await loadStateFromDataFolder();
   if (analysisResults) {
     vscode.commands.executeCommand("konveyor.loadRuleSets", analysisResults);
-  }
-  if (solution) {
-    vscode.commands.executeCommand("konveyor.loadSolution", solution);
   }
 };

--- a/vscode/src/data/loadStaticResults.ts
+++ b/vscode/src/data/loadStaticResults.ts
@@ -33,6 +33,7 @@ export const loadStaticResults = async () => {
     }
   }
   if (solution) {
+    vscode.commands.executeCommand("konveyor.diffView.focus");
     vscode.commands.executeCommand("konveyor.loadSolution", solution);
     vscode.window.showInformationMessage("Successfully loaded the solutions");
   }

--- a/vscode/src/data/virtualStorage.ts
+++ b/vscode/src/data/virtualStorage.ts
@@ -75,8 +75,7 @@ export const writeSolutionsToMemFs = async (
     memFs.createDirectoriesIfNeeded(modifiedUri, KONVEYOR_SCHEME),
   );
 
-  const writeDiff = async (change: LocalChange) => {
-    const { originalUri, modifiedUri, diff, state } = change;
+  const writeDiff = async ({ diff, originalUri, modifiedUri }: LocalChange) => {
     const content = await applyDiff(originalUri, diff);
     memFs.writeFile(modifiedUri, Buffer.from(content), {
       create: true,

--- a/vscode/src/data/virtualStorage.ts
+++ b/vscode/src/data/virtualStorage.ts
@@ -75,12 +75,19 @@ export const writeSolutionsToMemFs = async (
     memFs.createDirectoriesIfNeeded(modifiedUri, KONVEYOR_SCHEME),
   );
 
-  const writeDiff = async ({ diff, originalUri, modifiedUri }: LocalChange) => {
-    const content = await applyDiff(originalUri, diff);
-    memFs.writeFile(modifiedUri, Buffer.from(content), {
-      create: true,
-      overwrite: true,
-    });
+  const writeDiff = async (change: LocalChange) => {
+    const { originalUri, modifiedUri, diff, state } = change;
+    if (state === "applied") {
+      const msg = `Already applied solution for ${originalUri.path}.`;
+      window.showErrorMessage(msg);
+      return;
+    } else {
+      const content = await applyDiff(originalUri, diff);
+      memFs.writeFile(modifiedUri, Buffer.from(content), {
+        create: true,
+        overwrite: true,
+      });
+    }
   };
   // write the content asynchronously (reading original file via VS Code is async)
   await Promise.all(localChanges.map((change) => writeDiff(change)));

--- a/vscode/src/data/virtualStorage.ts
+++ b/vscode/src/data/virtualStorage.ts
@@ -77,17 +77,11 @@ export const writeSolutionsToMemFs = async (
 
   const writeDiff = async (change: LocalChange) => {
     const { originalUri, modifiedUri, diff, state } = change;
-    if (state === "applied") {
-      const msg = `Already applied solution for ${originalUri.path}.`;
-      window.showErrorMessage(msg);
-      return;
-    } else {
-      const content = await applyDiff(originalUri, diff);
-      memFs.writeFile(modifiedUri, Buffer.from(content), {
-        create: true,
-        overwrite: true,
-      });
-    }
+    const content = await applyDiff(originalUri, diff);
+    memFs.writeFile(modifiedUri, Buffer.from(content), {
+      create: true,
+      overwrite: true,
+    });
   };
   // write the content asynchronously (reading original file via VS Code is async)
   await Promise.all(localChanges.map((change) => writeDiff(change)));


### PR DESCRIPTION
Resolves https://github.com/konveyor/editor-extensions/issues/336

- Remove the default solution load behavior on startup
- Remove the reload last solution button from the diff view
- Update to display the diff view when you hard load a solution from a file using the "Load Results from File" command. 
<img width="724" alt="Screenshot 2025-02-20 at 3 45 18 PM" src="https://github.com/user-attachments/assets/d123aed9-47e5-4e1a-9f31-6ff40184243b" />
