### PR TITLE
:bug: Fix wrapping on markdown messages

### DIFF
--- a/webview-ui/src/components/ResolutionsPage/ChatMessageComponent.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ChatMessageComponent.tsx
@@ -9,6 +9,7 @@ import rehypeSanitize from "rehype-sanitize";
 // css for markdown and plugins
 import "github-markdown-css/github-markdown.css";
 import "highlight.js/styles/github.min.css";
+import "./chatMessageComponent.css";
 
 interface RenderMessageProps {
   value: ChatMessage["value"];

--- a/webview-ui/src/components/ResolutionsPage/chatMessageComponent.css
+++ b/webview-ui/src/components/ResolutionsPage/chatMessageComponent.css
@@ -1,6 +1,6 @@
 .chat-message {
   white-space: normal;
 }
-.chat-message > details {
+.chat-message > details > summary {
   cursor: pointer;
 }

--- a/webview-ui/src/components/ResolutionsPage/chatMessageComponent.css
+++ b/webview-ui/src/components/ResolutionsPage/chatMessageComponent.css
@@ -1,0 +1,3 @@
+.chat-message {
+  white-space: normal;
+}

--- a/webview-ui/src/components/ResolutionsPage/chatMessageComponent.css
+++ b/webview-ui/src/components/ResolutionsPage/chatMessageComponent.css
@@ -1,3 +1,6 @@
 .chat-message {
   white-space: normal;
 }
+.chat-message > details {
+  cursor: pointer;
+}


### PR DESCRIPTION
Signed-off-by: Ian Bolton <ibolton@redhat.com>

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
