### PR TITLE
:bug: respect isReadOnly for solution dropdown

### DIFF
--- a/webview-ui/src/components/GetSolutionDropdown.tsx
+++ b/webview-ui/src/components/GetSolutionDropdown.tsx
@@ -33,9 +33,14 @@ const GetSolutionDropdown: React.FC<GetSolutionDropdownProps> = ({ incidents }) 
   const isButtonDisabled =
     state.isFetchingSolution || state.isAnalyzing || state.serverState !== "running";
 
+  // The disabled plain button looks terrible, just return undefined
+  if (isButtonDisabled) {
+    return undefined;
+  }
+
   const menuToggle = (
     <MenuToggle
-      variant="primary"
+      variant="plain"
       size="sm"
       isDisabled={isButtonDisabled}
       splitButtonOptions={{

--- a/webview-ui/src/components/IncidentTable/IncidentTable.tsx
+++ b/webview-ui/src/components/IncidentTable/IncidentTable.tsx
@@ -38,6 +38,7 @@ export const IncidentTable: FC<IncidentTableProps> = ({
   const ISSUE = "Issue";
   const LOCATION = "Location";
   const FOLDER = "Folder";
+
   return (
     <>
       <Card isPlain>
@@ -60,9 +61,8 @@ export const IncidentTable: FC<IncidentTableProps> = ({
                 <Tr>
                   {isReadOnly ? (
                     <>
-                      <Th width={15}>{ISSUE}</Th>
-                      <Th width={60}>{FOLDER}</Th>
-                      <Th width={25}>{LOCATION}</Th>
+                      <Th width={60}>{ISSUE}</Th>
+                      <Th width={40}>{LOCATION}</Th>
                     </>
                   ) : (
                     <>
@@ -77,7 +77,7 @@ export const IncidentTable: FC<IncidentTableProps> = ({
               <Tbody>
                 {incidents.map((it) => (
                   <Tr key={uniqueId(it)}>
-                    <Td dataLabel={ISSUE} width={isReadOnly ? 15 : 30}>
+                    <Td dataLabel={ISSUE} width={isReadOnly ? 60 : 30}>
                       <TableText tooltip={it.uri} tooltipProps={tooltipProps}>
                         <Button
                           component="a"
@@ -89,16 +89,18 @@ export const IncidentTable: FC<IncidentTableProps> = ({
                         </Button>
                       </TableText>
                     </Td>
-                    <Td dataLabel={FOLDER} width={isReadOnly ? 60 : 40}>
-                      <TableText
-                        wrapModifier="truncate"
-                        tooltip={relativeDirname(it)}
-                        tooltipProps={tooltipProps}
-                      >
-                        <i>{relativeDirname(it)}</i>
-                      </TableText>
-                    </Td>
-                    <Td dataLabel={LOCATION} width={isReadOnly ? 25 : 20}>
+                    {!isReadOnly && (
+                      <Td dataLabel={FOLDER} width={40}>
+                        <TableText
+                          wrapModifier="truncate"
+                          tooltip={relativeDirname(it)}
+                          tooltipProps={tooltipProps}
+                        >
+                          <i>{relativeDirname(it)}</i>
+                        </TableText>
+                      </Td>
+                    )}
+                    <Td dataLabel={LOCATION} width={isReadOnly ? 40 : 20}>
                       <TableText wrapModifier="nowrap">
                         <Content component="p">
                           {it.lineNumber !== undefined ? `Line ${it.lineNumber}` : "No line number"}

--- a/webview-ui/src/components/IncidentTable/IncidentTable.tsx
+++ b/webview-ui/src/components/IncidentTable/IncidentTable.tsx
@@ -3,9 +3,8 @@ import React, { FC, useCallback } from "react";
 import { Content, Button, Card, CardBody, CardHeader } from "@patternfly/react-core";
 import { EnhancedIncident, Incident } from "@editor-extensions/shared";
 import { Table, Thead, Tr, Th, Tbody, Td, TableText } from "@patternfly/react-table";
-import * as path from "path-browserify";
 import Markdown from "react-markdown";
-import { getIncidentRelativeDir } from "../../utils/incident";
+import { getIncidentFile, getIncidentRelativeDir } from "../../utils/incident";
 import { useExtensionStateContext } from "../../context/ExtensionStateContext";
 import GetSolutionDropdown from "../GetSolutionDropdown";
 
@@ -19,11 +18,10 @@ export interface IncidentTableProps {
 export const IncidentTable: FC<IncidentTableProps> = ({
   incidents,
   message,
-  isReadOnly,
+  isReadOnly = false,
   onIncidentSelect,
 }) => {
   const { state } = useExtensionStateContext();
-  const fileName = (incident: Incident) => path.basename(incident.uri);
   const relativeDirname = useCallback(
     (incident: Incident) => {
       return getIncidentRelativeDir(incident, state.workspaceRoot);
@@ -44,7 +42,13 @@ export const IncidentTable: FC<IncidentTableProps> = ({
     <>
       <Card isPlain>
         <CardHeader
-          actions={{ actions: <GetSolutionDropdown incidents={incidents} scope="in-between" /> }}
+          actions={
+            isReadOnly
+              ? undefined
+              : {
+                  actions: <GetSolutionDropdown incidents={incidents} scope="in-between" />,
+                }
+          }
         >
           <Markdown>{message}</Markdown>
         </CardHeader>
@@ -54,23 +58,38 @@ export const IncidentTable: FC<IncidentTableProps> = ({
             <Table aria-label="Incidents" variant="compact">
               <Thead>
                 <Tr>
-                  <Th>{ISSUE}</Th>
-                  <Th width={50}>{FOLDER}</Th>
-                  <Th>{LOCATION}</Th>
-                  <Th />
+                  {isReadOnly ? (
+                    <>
+                      <Th width={15}>{ISSUE}</Th>
+                      <Th width={60}>{FOLDER}</Th>
+                      <Th width={25}>{LOCATION}</Th>
+                    </>
+                  ) : (
+                    <>
+                      <Th width={30}>{ISSUE}</Th>
+                      <Th width={40}>{FOLDER}</Th>
+                      <Th width={20}>{LOCATION}</Th>
+                      <Th width={10} />
+                    </>
+                  )}
                 </Tr>
               </Thead>
               <Tbody>
                 {incidents.map((it) => (
                   <Tr key={uniqueId(it)}>
-                    <Td dataLabel={ISSUE}>
+                    <Td dataLabel={ISSUE} width={isReadOnly ? 15 : 30}>
                       <TableText tooltip={it.uri} tooltipProps={tooltipProps}>
-                        <Button component="a" variant="link" onClick={() => onIncidentSelect(it)}>
-                          <b>{fileName(it)}</b>
+                        <Button
+                          component="a"
+                          variant="link"
+                          isInline
+                          onClick={() => onIncidentSelect(it)}
+                        >
+                          <b>{getIncidentFile(it)}</b>
                         </Button>
                       </TableText>
                     </Td>
-                    <Td dataLabel={FOLDER}>
+                    <Td dataLabel={FOLDER} width={isReadOnly ? 60 : 40}>
                       <TableText
                         wrapModifier="truncate"
                         tooltip={relativeDirname(it)}
@@ -79,18 +98,18 @@ export const IncidentTable: FC<IncidentTableProps> = ({
                         <i>{relativeDirname(it)}</i>
                       </TableText>
                     </Td>
-                    <Td dataLabel={LOCATION}>
+                    <Td dataLabel={LOCATION} width={isReadOnly ? 25 : 20}>
                       <TableText wrapModifier="nowrap">
                         <Content component="p">
                           {it.lineNumber !== undefined ? `Line ${it.lineNumber}` : "No line number"}
                         </Content>
                       </TableText>
                     </Td>
-                    <Td isActionCell>
-                      {isReadOnly ? null : (
+                    {!isReadOnly && (
+                      <Td width={10}>
                         <GetSolutionDropdown incidents={[it]} scope="incident" />
-                      )}
-                    </Td>
+                      </Td>
+                    )}
                   </Tr>
                 ))}
               </Tbody>

--- a/webview-ui/src/components/ViolationIncidentsList.tsx
+++ b/webview-ui/src/components/ViolationIncidentsList.tsx
@@ -35,9 +35,9 @@ import {
   FilterIcon,
 } from "@patternfly/react-icons";
 import { IncidentTableGroup } from "./IncidentTable";
-import * as path from "path-browserify";
 import { EnhancedIncident, Incident, Category } from "@editor-extensions/shared";
 import GetSolutionDropdown from "./GetSolutionDropdown";
+import { getIncidentFile } from "../utils/incident";
 
 type GroupByOption = "none" | "file" | "violation";
 
@@ -163,7 +163,7 @@ const ViolationIncidentsList = ({
       switch (filters.groupBy) {
         case "file":
           key = incident.uri;
-          label = path.basename(incident.uri);
+          label = getIncidentFile(incident);
           break;
         case "violation":
           key = incident.violationId;
@@ -286,7 +286,6 @@ const ViolationIncidentsList = ({
             <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="md">
               {toggleGroupItems}
             </ToolbarToggleGroup>
-            <ToolbarItem variant="separator" />
             <ToolbarItem align={{ default: "alignEnd" }}>
               <GetSolutionDropdown
                 incidents={groupedIncidents.flatMap((group) => group.incidents)}

--- a/webview-ui/src/utils/__tests__/incidentPath.test.ts
+++ b/webview-ui/src/utils/__tests__/incidentPath.test.ts
@@ -1,0 +1,56 @@
+import { getIncidentFile } from "../incident";
+import { Incident } from "@editor-extensions/shared";
+import { expect } from "expect";
+
+describe("getIncidentFile", () => {
+  // Base incident to modify in each test
+  const baseIncident: Incident = {
+    uri: "",
+    message: "Test message",
+  };
+
+  it("correctly extracts file name (POSIX)", () => {
+    const incident = { ...baseIncident, uri: "file:///home/user/project/src/file.ts" };
+    expect(getIncidentFile(incident)).toBe("file.ts");
+  });
+
+  it("correctly extracts file name (Windows)", () => {
+    const incident = { ...baseIncident, uri: "file:///C:/Users/John/project/src/file.ts" };
+    expect(getIncidentFile(incident)).toBe("file.ts");
+  });
+
+  it("handles Windows paths with backslashes", () => {
+    const incident = { ...baseIncident, uri: "file:///C:\\Users\\John\\project\\src\\file.ts" };
+    expect(getIncidentFile(incident)).toBe("file.ts");
+  });
+
+  it("handles file in root directory (POSIX)", () => {
+    const incident = { ...baseIncident, uri: "file:///home/user/project/rootfile.txt" };
+    expect(getIncidentFile(incident)).toBe("rootfile.txt");
+  });
+
+  it("handles file in root directory (Windows)", () => {
+    const incident = { ...baseIncident, uri: "file:///C:/Users/John/rootfile.txt" };
+    expect(getIncidentFile(incident)).toBe("rootfile.txt");
+  });
+
+  it("handles file with special characters", () => {
+    const incident = { ...baseIncident, uri: "file:///home/user/project/some file (1).txt" };
+    expect(getIncidentFile(incident)).toBe("some file (1).txt");
+  });
+
+  it("handles Windows UNC paths", () => {
+    const incident = { ...baseIncident, uri: "file://server/share/folder/file.txt" };
+    expect(getIncidentFile(incident)).toBe("file.txt");
+  });
+
+  it("handles file with no extension", () => {
+    const incident = { ...baseIncident, uri: "file:///home/user/project/README" };
+    expect(getIncidentFile(incident)).toBe("README");
+  });
+
+  it("handles deeply nested paths", () => {
+    const incident = { ...baseIncident, uri: "file:///home/user/project/a/b/c/d/file.log" };
+    expect(getIncidentFile(incident)).toBe("file.log");
+  });
+});

--- a/webview-ui/src/utils/__tests__/incidentRelativeDir.test.ts
+++ b/webview-ui/src/utils/__tests__/incidentRelativeDir.test.ts
@@ -43,4 +43,53 @@ describe("getIncidentRelativeDir", () => {
 
     expect(getIncidentRelativeDir(incident, workspaceRoot)).toBe("src");
   });
+
+  it("correctly computes relative path for root file (pom.xml)", () => {
+    const incident = { ...baseIncident, uri: "file:///home/user/project/pom.xml" };
+    const workspaceRoot = "file:///home/user/project";
+
+    expect(getIncidentRelativeDir(incident, workspaceRoot)).toBe(""); // Should return empty string
+  });
+
+  it("correctly computes relative path for root file (Windows pom.xml)", () => {
+    const incident = { ...baseIncident, uri: "file:///C:/Users/John/project/pom.xml" };
+    const workspaceRoot = "file:///C:/Users/John/project";
+
+    expect(getIncidentRelativeDir(incident, workspaceRoot)).toBe(""); // Should return empty string
+  });
+
+  it("handles workspace root with trailing slash", () => {
+    const incident = { ...baseIncident, uri: "file:///home/user/project/src/file.ts" };
+    const workspaceRoot = "file:///home/user/project/";
+
+    expect(getIncidentRelativeDir(incident, workspaceRoot)).toBe("src");
+  });
+
+  it("handles workspace root without trailing slash", () => {
+    const incident = { ...baseIncident, uri: "file:///home/user/project/src/file.ts" };
+    const workspaceRoot = "file:///home/user/project";
+
+    expect(getIncidentRelativeDir(incident, workspaceRoot)).toBe("src");
+  });
+
+  it("handles Windows workspace root with trailing slash", () => {
+    const incident = { ...baseIncident, uri: "file:///C:/Users/John/project/src/file.ts" };
+    const workspaceRoot = "file:///C:/Users/John/project/";
+
+    expect(getIncidentRelativeDir(incident, workspaceRoot)).toBe("src");
+  });
+
+  it("handles Windows workspace root without trailing slash", () => {
+    const incident = { ...baseIncident, uri: "file:///C:/Users/John/project/src/file.ts" };
+    const workspaceRoot = "file:///C:/Users/John/project";
+
+    expect(getIncidentRelativeDir(incident, workspaceRoot)).toBe("src");
+  });
+
+  it("handles Windows root file with trailing slash in workspace root", () => {
+    const incident = { ...baseIncident, uri: "file:///C:/Users/John/project/pom.xml" };
+    const workspaceRoot = "file:///C:/Users/John/project/";
+
+    expect(getIncidentRelativeDir(incident, workspaceRoot)).toBe(""); // Should return empty string
+  });
 });

--- a/webview-ui/src/utils/incident.ts
+++ b/webview-ui/src/utils/incident.ts
@@ -1,9 +1,18 @@
 import path from "path-browserify";
 import { Incident } from "@editor-extensions/shared";
 
+export function getIncidentFile(incident: Incident): string {
+  return path.basename(incident.uri.replace(/\\/g, "/"));
+}
+
 // The assumption baked into this function is that both incident.uri and workspaceRoot have
-// a `file://` prefix. This function simply returns the dirname relative tot he workspace root.
+// a `file://` prefix. This function simply returns the dirname relative to the workspace root.
 export function getIncidentRelativeDir(incident: Incident, workspaceRoot: string): string {
-  const dir = path.dirname(incident.uri.replace(/\\/g, "/"));
-  return dir.toLocaleLowerCase().replace(workspaceRoot.toLocaleLowerCase() + "/", "");
+  const normalizedRoot = workspaceRoot.toLocaleLowerCase().replace(/\/$/, "");
+  const dir = path.dirname(incident.uri.replace(/\\/g, "/")).toLocaleLowerCase();
+
+  if (normalizedRoot === dir) {
+    return "";
+  }
+  return dir.replace(normalizedRoot + "/", "");
 }


### PR DESCRIPTION
This PR fixes problems with rendering the incident table(s).
* When isReadOnly, we shouldn't be rendering the solution dropdown
* When isReadOnly, we don't actually need to full rendered path because it gets cluttered
* We need to handle windows paths with care, not just for relative paths but when computing the filename from the incident.uri
* Some other minor tweaks to the look and feel of the table and solution dropdown
 
Fixes #398
Fixes #400 