### PR TITLE
:bug: deduplicate encountered errors in chat view

### DIFF
--- a/webview-ui/src/components/ResolutionsPage/ResolutionsPage.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ResolutionsPage.tsx
@@ -135,8 +135,15 @@ const ResolutionPage: React.FC = () => {
                 <ReceivedMessage>Response contains errors:</ReceivedMessage>
                 <ReceivedMessage>
                   <ul>
-                    {resolution.encountered_errors.map((error, index) => (
-                      <li key={index}>{error}</li>
+                    {Object.entries(
+                      resolution.encountered_errors.reduce<Record<string, number>>((acc, error) => {
+                        acc[error] = (acc[error] || 0) + 1;
+                        return acc;
+                      }, {}),
+                    ).map(([errorText, count], index) => (
+                      <li key={index}>
+                        {errorText} {count > 1 && `(x${count})`}
+                      </li>
                     ))}
                   </ul>
                 </ReceivedMessage>


### PR DESCRIPTION
This is related to https://github.com/konveyor/kai/issues/697

We sometimes see same error messages in responses from different attempts of fixing an issue. This PR merges same messages into one line and appends the no of times the error was seen to that line. 

<img width="860" alt="Screenshot 2025-02-27 at 9 14 24 PM" src="https://github.com/user-attachments/assets/8cc9d473-fb4b-4f38-a4d7-5e50289db6cf" />
