### PR TITLE
:bug: Reclaim webview body padding, page inset

### DIFF
--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -1,3 +1,8 @@
+body {
+  margin: 0;
+  padding: 0;
+}
+
 .pf-v6-c-masthead,
 .pf-v6-c-page,
 .pf-v6-c-page__main-container,
@@ -18,6 +23,10 @@
 #root {
   height: 100vh;
   overflow: hidden;
+}
+
+.pf-v6-c-page {
+  --pf-v6-c-page--inset: 0;
 }
 
 .pf-c-page__main-section {


### PR DESCRIPTION
For some reason, vscode adds a CSS body padding rule of `padding: 0 20px` automatically to every webview.  This is overridden in our CSS to our view can be shown edge-to-edge.

Also remove the page insets to reclaim some additional horizontal margins that don't make sense in the vscode webview.
