### PR TITLE
:bug: Remove sm size to restore button alignment

### DIFF
--- a/webview-ui/src/components/GetSolutionDropdown.tsx
+++ b/webview-ui/src/components/GetSolutionDropdown.tsx
@@ -41,7 +41,6 @@ const GetSolutionDropdown: React.FC<GetSolutionDropdownProps> = ({ incidents }) 
   const menuToggle = (
     <MenuToggle
       variant="plain"
-      size="sm"
       isDisabled={isButtonDisabled}
       splitButtonOptions={{
         items: [


### PR DESCRIPTION
Resolves https://github.com/konveyor/editor-extensions/issues/397

When using the plain button variant, we don't need to use "sm" size. This was originally added to create space between button backgrounds in table view. 
![Screenshot 2025-02-27 at 12 04 40 PM](https://github.com/user-attachments/assets/73ebdf19-2fdb-44bf-8c63-2eab539eb230)
