### PR TITLE
:bug: Only run partial analysis if a file was changed

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -8,7 +8,7 @@ import { AnalyzerClient } from "./client/analyzerClient";
 import { registerDiffView, KonveyorFileModel } from "./diffView";
 import { MemFS } from "./data";
 import { Immutable, produce } from "immer";
-import { partialAnalysisTrigger } from "./analysis";
+import { registerAnalysisTrigger } from "./analysis";
 import { IssuesModel, registerIssueView } from "./issueView";
 import { ensurePaths, ExtensionPaths } from "./paths";
 import { copySampleProviderSettings } from "./utilities/fileUtils";
@@ -79,7 +79,9 @@ class VsCodeExtension {
       this.listeners.push(this.onDidChangeData(registerIssueView(this.state)));
       this.registerCommands();
       this.registerLanguageProviders();
-      this.listeners.push(vscode.workspace.onDidSaveTextDocument(partialAnalysisTrigger));
+
+      registerAnalysisTrigger(this.listeners);
+
       this.listeners.push(
         vscode.workspace.onDidChangeConfiguration((event) => {
           console.log("Configuration modified!");


### PR DESCRIPTION
Resolves: #344

Only send a document that has been saved to partial analysis if the document was actually changed.  Just hooking the `onDidSaveTextDocument()` event is not enough to determine if a change was actually made to a document being saved. Track document changes by file uri and check that list on save.
