### PR TITLE
:bug: Show analysis panel when KAI extension initialized

### DIFF
--- a/vscode/src/KonveyorGUIWebviewViewProvider.ts
+++ b/vscode/src/KonveyorGUIWebviewViewProvider.ts
@@ -52,6 +52,7 @@ export class KonveyorGUIWebviewViewProvider implements WebviewViewProvider {
 
   public createWebviewPanel(): void {
     if (this._panel) {
+      this._panel.reveal(ViewColumn.One);
       return;
     }
     this._panel = window.createWebviewPanel(

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -81,6 +81,7 @@ class VsCodeExtension {
       this.registerLanguageProviders();
 
       registerAnalysisTrigger(this.listeners);
+      vscode.commands.executeCommand("konveyor.showAnalysisPanel");
 
       this.listeners.push(
         vscode.workspace.onDidChangeConfiguration((event) => {


### PR DESCRIPTION
Resolves https://github.com/konveyor/editor-extensions/issues/425