### PR TITLE
:bug: Redirect user to analysis page at the end of the konveyor walkthrough

### DIFF
--- a/vscode/media/walkthroughs/open-analysis-panel.md
+++ b/vscode/media/walkthroughs/open-analysis-panel.md
@@ -1,6 +1,6 @@
-# Start Server
+# Open Analysis Panel
 
-Start kai server. Under the hood it is using the rules-based analysis engine.
+Open the analysis panel to view and manage your analysis tasks. Under the hood, it utilizes the rules-based analysis engine.
 
 Remember to configure your analysis settings beforehand for the best results:
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -661,12 +661,12 @@
             }
           },
           {
-            "id": "start-server",
+            "id": "open-analysis-panel",
             "title": "Open Analysis Panel",
-            "description": "Open the Konveyor Analysis Panel to manage the server and view its status.\n[Open Analysis Panel](command:konveyor.showAnalysisPanel)",
+            "description": "Open the Konveyor Analysis Panel to manage and monitor your analysis tasks. The Kai server processes analysis requests, so ensure it is started before running any analysis tasks.\n[Open Analysis Panel](command:konveyor.showAnalysisPanel)",
             "completionEvents": [],
             "media": {
-              "markdown": "media/walkthroughs/start-server.md"
+              "markdown": "media/walkthroughs/open-analysis-panel.md"
             }
           }
         ]

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -662,8 +662,8 @@
           },
           {
             "id": "start-server",
-            "title": "Start Server",
-            "description": "Start the analyzer\n[Start Analyzer](command:konveyor.startServer)",
+            "title": "Open Analysis Panel",
+            "description": "Open the Konveyor Analysis Panel to manage the server and view its status.\n[Open Analysis Panel](command:konveyor.showAnalysisPanel)",
             "completionEvents": [],
             "media": {
               "markdown": "media/walkthroughs/start-server.md"


### PR DESCRIPTION
- Addresses the comment from 
[@Pranav](https://redhat-internal.slack.com/team/UJVF3G38W) on https://github.com/konveyor/editor-extensions/issues/425 - the walkthrough button isn’t stateful so we were able to start the server but there were no notifications or button state on the walkthrough that let us know that the server was starting/initializing. You could click it a bunch of times and kick off several instances of the server. The fix in PR 433 just ushers the user to the analysis page and encourages the user to start the server from there.


<img width="1447" alt="Screenshot 2025-03-07 at 2 31 35 PM" src="https://github.com/user-attachments/assets/ca975d14-6e10-4911-b2fb-f0cb2e40fade" />
