### PR TITLE
:seedling: Update collect-assets scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ out/
 build/
 dist/
 downloaded_assets/
+downloaded_cache/
 *.vsix
 
 # TypeScript build info

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "globby": "^14.0.2",
         "immer": "10.1.1",
         "js-yaml": "^4.1.0",
+        "micromatch": "^4.0.8",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "slash": "^5.1.0",
@@ -8928,6 +8929,8 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "prepare": "husky",
     "postinstall": "npm run build -w shared",
-    "clean": "rimraf ./dist ./downloaded_assets && npm run clean --workspaces --if-present",
+    "clean": "rimraf ./dist ./downloaded_assets ./downloaded_cache && npm run clean --workspaces --if-present",
     "clean:all": "npm run clean && rimraf ./node_modules ./**/node_modules/ ./**/tsconfig.tsbuildinfo",
     "lint": "eslint ./scripts && npm run lint --workspaces --if-present",
     "lint:fix": "npm run lint:fix --workspaces --if-present",
@@ -105,6 +105,7 @@
     "globby": "^14.0.2",
     "immer": "10.1.1",
     "js-yaml": "^4.1.0",
+    "micromatch": "^4.0.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "slash": "^5.1.0",

--- a/scripts/_download.js
+++ b/scripts/_download.js
@@ -1,21 +1,19 @@
-import { join, extname, basename, relative } from "node:path";
+import { join, basename } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { createHash } from "node:crypto";
 import { Octokit } from "@octokit/core";
 import fs from "fs-extra";
-import unzipper from "unzipper";
-import * as tar from "tar";
-import { bold, green, yellow } from "colorette";
-import { globby } from "globby";
+import { blue, bold, green, yellow } from "colorette";
 
-import { chmodOwnerPlusX } from "./_util.js";
+import { fileSha256, isFile } from "./_util.js";
 import {
   fetchGitHubReleaseMetadata,
-  fetchGitHubReleaseTagSha,
+  fetchGitHubTagSha,
   fetchFirstSuccessfulRun,
   fetchArtifactsForRun,
 } from "./_github.js";
+import { unpackAsset, unpackTarGz } from "./_unpack.js";
 
 /**
  * @param {string} targetFile
@@ -35,128 +33,62 @@ async function streamResponseToFile(targetFile, fetchResponse) {
 
   // run them both, reject if either rejects, resolve with the hash
   await Promise.all([pipeToFile, pipeToHash]);
+
+  // push the server side last modified time to the downloaded file for caching purposes
+  const lastModified = fetchResponse.headers.get("Last-Modified");
+  if (lastModified) {
+    await fs.utimes(targetFile, new Date(lastModified), new Date(lastModified));
+  }
   return hash.digest("hex");
 }
 
-export async function downloadAndExtractGitHubReleaseAsset(
-  target,
-  gitHubReleaseAsset,
-  platform,
-  arch,
-  chmod = false,
-  token,
-) {
-  const assetDir = join(target, `${platform}-${arch}`);
-  const assetFileName = join(assetDir, gitHubReleaseAsset.name);
-
-  await fs.ensureDir(assetDir);
-
-  // TODO: Could use ETag/If-None-Match headers to trigger 304s and skip unnecessary
-  // TODO: Could also use If-Modified-Since and the file's GMT timestamp
-
-  console.log(`Downloading asset: ${gitHubReleaseAsset.name}`);
-  const response = await fetch(gitHubReleaseAsset.browser_download_url, {
-    headers: token && { Authorization: `Bearer ${token}` },
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to download ${gitHubReleaseAsset.name}: ${response.statusText}`);
-  }
-  const sha256 = await streamResponseToFile(assetFileName, response);
-
-  console.log(`Asset sha256: ${green(sha256)}`);
-  console.log(`Extracting to: ${assetDir}`);
-  const zipFile = await unzipper.Open.file(assetFileName);
-  await zipFile.extract({ path: assetDir });
-
-  const extractedFiles = await fs.readdir(assetDir);
-  for (const file of extractedFiles) {
-    if (chmod && extname(file) !== ".zip") {
-      chmodOwnerPlusX(join(assetDir, file));
-    }
-  }
-
-  console.log(`Extracted: ${gitHubReleaseAsset.name}`);
-}
-
-export async function downloadGitHubRelease({
-  targetDirectory,
-  metaFile,
-  org,
-  repo,
-  releaseTag,
-  assets,
-}) {
-  const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
-  octokit.request = octokit.request.defaults({ owner: org, repo });
-  console.log(
-    `Fetching GitHub release metadata for ${yellow(`${org}/${repo}`)} release: ${yellow(releaseTag)}`,
-  );
-
-  const releaseData = await fetchGitHubReleaseMetadata(octokit, releaseTag);
-  const commitId = await fetchGitHubReleaseTagSha(octokit, releaseTag);
-  const releaseAssets = releaseData.assets;
-
-  const metadata = {
-    org,
-    repo,
-    releaseTag,
-    commitId,
-    collectedAt: new Date().toISOString(),
-    assets: [],
+export async function downloadUrl({ downloadDirectory, url, targetFileName, sha256, bearerToken }) {
+  const fileName = targetFileName ?? basename(new URL(url).pathname);
+  const targetFile = join(downloadDirectory, fileName);
+  const meta = {
+    url,
+    fileName,
+    lastModified: null,
+    etag: null,
   };
 
-  for (const { name, platform, arch, chmod } of assets) {
-    const releaseAsset = releaseAssets.find((a) => a.name.toLowerCase() === name.toLowerCase());
-    if (!releaseAsset) {
-      console.warn(
-        `Asset [${yellow(name)}] was not found in GitHub release ${releaseData.html_url}`,
-      );
-      continue;
-    }
-
-    try {
-      console.group(yellow(releaseAsset.name));
-      await downloadAndExtractGitHubReleaseAsset(
-        targetDirectory,
-        releaseAsset,
-        platform,
-        arch,
-        chmod,
-        process.env.GITHUB_TOKEN,
-      );
-    } finally {
-      console.groupEnd();
-    }
-    metadata.assets.push({
-      name: releaseAsset.name,
-      platform,
-      arch,
-      chmod: !!chmod,
-      updatedAt: releaseAsset.updated_at,
-    });
-  }
-
-  await fs.writeJson(metaFile, metadata, { spaces: 2 });
-  console.log(`Metadata written to ${metaFile}`);
-  console.log(`All assets downloaded to: ${targetDirectory}`);
-}
-
-export async function downloadAndExtractTarGz({ targetDirectory, url, sha256 }) {
+  console.group(bold("Download:"), blue(url));
+  console.log("Destination:", downloadDirectory);
   try {
-    console.group(yellow(url));
-    console.log(bold("Download:"), url, bold("To:"), targetDirectory);
-    await fs.ensureDir(targetDirectory);
+    await fs.ensureDir(downloadDirectory);
 
-    // Download the tar.gz file
-    const fileName = basename(new URL(url).pathname);
-    const targetFile = join(targetDirectory, fileName);
+    const headers = {};
+    if (bearerToken) {
+      headers["Authorization"] = `Bearer ${bearerToken}`;
+    }
+
+    let existingFileHash;
+    if ((await isFile(targetFile)) && (await isFile(targetFile + ".etag"))) {
+      try {
+        existingFileHash = await fileSha256(targetFile);
+        const etagFile = await fs.readFile(targetFile + ".etag");
+        const [hash, etag] = etagFile.toString().split("/");
+        if (hash === existingFileHash) {
+          headers["If-None-Match"] = etag;
+          console.log(`Found existing file sha256: ${green(hash)}, ETag: ${green(etag)}`);
+        }
+      } catch (err) {
+        console.log("Skipping ETag check", err);
+      }
+    }
 
     console.log("Downloading:", yellow(fileName));
-    const response = await fetch(url);
-    if (!response.ok) {
+    const response = await fetch(url, { headers });
+    if (!response.ok && response.status !== 304) {
       throw new Error(`Failed to download ${url}: ${response.statusText}`);
     }
-    const downloadSha256 = await streamResponseToFile(targetFile, response);
+    if (response.status === 304) {
+      console.log("The downloaded copy is current!");
+    }
+    const downloadSha256 =
+      response.status === 304
+        ? (existingFileHash ?? (await fileSha256(targetFile)))
+        : await streamResponseToFile(targetFile, response);
 
     // If a sha256 is provided, verify against the downloaded file
     console.log(`Asset sha256: ${green(downloadSha256)}`);
@@ -170,216 +102,206 @@ export async function downloadAndExtractTarGz({ targetDirectory, url, sha256 }) 
       }
     }
 
+    meta.sha256 = downloadSha256;
+    meta.lastModified = response.headers.get("Last-Modified") ?? headers["If-Modified-Since"];
+    meta.etag = response.headers.get("ETag");
+    await fs.writeFile(targetFile + ".etag", [meta.sha256, meta.etag].join("/"));
+  } catch (error) {
+    console.error("Error downloading:", error);
+    throw error;
+  } finally {
+    console.groupEnd();
+  }
+
+  return [targetFile, meta];
+}
+
+export async function downloadGitHubReleaseAssets({
+  targetDirectory,
+  org,
+  repo,
+  releaseTag,
+  bearerToken,
+  assets,
+}) {
+  const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+  octokit.request = octokit.request.defaults({ owner: org, repo });
+  const metadata = {
+    org,
+    repo,
+    releaseTag,
+  };
+
+  console.group(`GitHub repo: ${yellow(`${org}/${repo}`)}, release: ${yellow(releaseTag)}`);
+  try {
+    const releaseData = await fetchGitHubReleaseMetadata(octokit, releaseTag);
+    const commitId = await fetchGitHubTagSha(octokit, releaseTag);
+    const releaseAssets = releaseData.assets;
+
+    metadata.commitId = commitId;
+    metadata.collectedAt = new Date().toISOString();
+    metadata.assets = [];
+
+    for (const { name } of assets) {
+      const releaseAsset = releaseAssets.find((a) => a.name === name);
+      if (!releaseAsset) {
+        throw new Error(
+          `Asset [${yellow(name)}] was not found in GitHub release ${releaseData.html_url}`,
+        );
+      }
+
+      const [, assetMeta] = await downloadUrl({
+        downloadDirectory: targetDirectory,
+        targetFileName: name,
+        url: releaseAsset.browser_download_url,
+        bearerToken,
+      });
+
+      metadata.assets.push({
+        name,
+        ...assetMeta,
+      });
+    }
+  } finally {
+    console.groupEnd();
+  }
+
+  return metadata;
+}
+
+export async function downloadAndExtractTarGz({ downloadDirectory, targetDirectory, url, sha256 }) {
+  let meta = {
+    url,
+    fileName: null,
+    sha256,
+    lastModified: null,
+    etag: null,
+    fileSetDirectory: targetDirectory,
+  };
+
+  console.group("Download and extract:", blue(url));
+  try {
+    // Download the file
+    const [targetFile, urlMeta] = await downloadUrl({ downloadDirectory, url, sha256 });
+    meta = { ...meta, ...urlMeta };
+
     // Extract the tar.gz file
-    console.log(`Extracting to ${targetDirectory}`);
-    tar.extract({
-      f: targetFile,
-      z: true,
-      cwd: targetDirectory,
-    });
+    console.group(bold("Unpacking:"), yellow(targetFile));
+    console.log(`Destination: ${targetDirectory}`);
+    try {
+      await fs.ensureDir(targetDirectory);
+      meta.fileSet = await unpackTarGz({
+        sourceFile: targetFile,
+        targetDirectory,
+      });
+      console.log(`Extracted ${green(meta.fileSet.length)} items`);
+    } finally {
+      console.groupEnd();
+    }
   } catch (error) {
     console.error("Error downloading/extracting tar.gz:", error);
   } finally {
     console.groupEnd();
   }
+
+  return meta;
 }
 
 /**
- * Download a workflow artifact from GitHub
- *
- * @param {string} url - Download URL for the artifact
- * @param {string} name - Name of the artifact file
- * @param {string} outputDir - Directory to save the downloaded artifact
- * @returns {Promise<string>} - Path to the downloaded artifact file
+ * Download workflow artifacts and extract contents as assets
  */
-export async function downloadArtifact(url, name, outputDir, token) {
-  const assetDir = join(outputDir);
-  const assetFileName = join(assetDir, `${name}`);
-  await fs.ensureDir(assetDir);
-
-  console.log(`Downloading asset: ${name}`);
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/vnd.github.v3+json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(`Failed to download ${name}: ${response.statusText}`);
-  }
-
-  const sha256 = await streamResponseToFile(assetFileName, response);
-  console.log(`Verifying download of: ${name}`);
-  console.log(`Asset sha256: ${green(sha256)}`);
-
-  console.log(`Downloaded ${name} to ${assetFileName}`);
-  return assetFileName;
-}
-
-/**
- * Extract an artifact ZIP file.
- *
- * @param {string} filePath - Path to the ZIP file
- * @param {string} tempDir - Temporary directory for extraction
- * @param {string} finalDir - Final directory for extracted files
- */
-export async function extractArtifact(filePath, tempDir, finalDir) {
-  console.log(`Checking if ${filePath} is a valid ZIP archive.`);
-
-  // First extraction to temporary directory
-  console.log(`Extracting ${filePath} to temporary directory: ${tempDir}`);
-  const unzipArtifact = await unzipper.Open.file(filePath);
-  await unzipArtifact.extract({ path: tempDir });
-
-  // Find and extract any nested zip files in the temp directory
-  const zipFiles = await globby("*.zip", { cwd: tempDir });
-  if (zipFiles.length > 0) {
-    for (const file of zipFiles) {
-      const nestedZipPath = join(tempDir, file);
-      console.log(`Extracting nested zip: ${nestedZipPath} to ${finalDir}`);
-      const unzipNestedArtifact = await unzipper.Open.file(nestedZipPath);
-      await unzipNestedArtifact.extract({ path: finalDir });
-      await fs.unlink(nestedZipPath);
-    }
-  } else {
-    // If no nested zip files were found, move all extracted files into finalDir.
-    const files = await globby(["**/*"], { cwd: tempDir, absolute: true });
-    for (const file of files) {
-      const relativePath = relative(tempDir, file);
-      const destPath = join(finalDir, relativePath);
-      await fs.move(file, destPath, { overwrite: true });
-    }
-  }
-
-  // Cleanup temporary directory
-  await fs.rm(tempDir, { recursive: true, force: true });
-
-  // Cleanup the original zip file
-  await fs.unlink(filePath);
-
-  console.log(`Extraction complete: ${filePath} -> ${finalDir}`);
-}
-
-/**
- * Download and process workflow artifacts.
- *
- * @param {string} targetDirectory - Directory to store downloaded artifacts
- * @param {string} metaFile - Path to the metadata file
- * @param {string} org - GH org
- * @param {string} repo - GH repo
- * @param {string} workflow - Name of the workflow file
- * @param {Array} assets - List of assets to download
- */
-export async function downloadWorkflowArtifacts({
+export async function downloadWorkflowArtifactsAndExtractAssets({
+  downloadDirectory,
   targetDirectory,
-  metaFile,
   org,
   repo,
   branch,
   workflow,
-  assets,
+  bearerToken,
+  artifacts,
 }) {
-  const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-  const octokit = new Octokit({ auth: GITHUB_TOKEN });
-  octokit.request = octokit.request.defaults({ owner: org, repo });
-
-  if (!GITHUB_TOKEN) {
-    const errorMessage = "GITHUB_TOKEN environment variable is not set.";
+  if (!bearerToken) {
+    const errorMessage =
+      "A bearer token is required. Ensure the GITHUB_TOKEN environment variable is set.";
     console.error(errorMessage);
     throw new Error(errorMessage);
   }
 
-  console.log(
-    `Fetching most recent successful workflow run on repo ${yellow(`${org}/${repo}`)}, workflow: ${yellow(workflow)}, branch: ${yellow(branch)}`,
-  );
-  const { workflowRunId, workflowRunUrl, headSha } = await fetchFirstSuccessfulRun(
-    octokit,
-    branch,
-    workflow,
-  );
-  if (!workflowRunId) {
-    throw new Error("No successful workflow runs found.");
-  }
-  console.log(
-    `Branch head commit sha: ${yellow(headSha)}, workflow run id: ${yellow(workflowRunId)}, url: ${workflowRunUrl}`,
-  );
-
-  const artifactUrls = await fetchArtifactsForRun(octokit, workflowRunId);
-  if (!artifactUrls || artifactUrls.length === 0) {
-    throw new Error("No artifacts found for the workflow run.");
-  }
-  console.log("Artifact Download URLs:", artifactUrls);
-
+  const octokit = new Octokit({ auth: bearerToken });
+  octokit.request = octokit.request.defaults({ owner: org, repo });
   const metadata = {
     org,
     repo,
     branch,
     workflow,
-    workflowRunId,
-    commitId: headSha,
-    collectedAt: new Date().toISOString(),
-    assets: [],
   };
 
-  for (const asset of assets) {
-    const { name, platform, arch, chmod: shouldChmod } = asset;
-    const artifact = artifactUrls.find((a) => a.name === name);
-    if (!artifact) {
-      console.warn(`Asset [${name}] was not found in the workflow artifacts.`);
-      continue;
+  console.group(
+    `GitHub repo: ${yellow(`${org}/${repo}`)}, branch: ${yellow(branch)}, workflow: ${yellow(workflow)}`,
+  );
+  try {
+    await fs.ensureDir(targetDirectory);
+
+    // Figure out the source workflow artifacts
+    const { workflowRunId, workflowRunUrl, headSha } = await fetchFirstSuccessfulRun(
+      octokit,
+      branch,
+      workflow,
+    );
+    if (!workflowRunId) {
+      throw new Error("No successful workflow runs found.");
     }
 
-    try {
-      console.group(yellow(name));
-      console.log(`Processing artifact: ${name}`);
+    const artifactUrls = await fetchArtifactsForRun(octokit, workflowRunId);
+    if (!artifactUrls || artifactUrls.length === 0) {
+      throw new Error("No artifacts found for the workflow run.");
+    }
 
-      const finalDir =
-        platform && arch
-          ? join(targetDirectory, `${platform}-${arch}`)
-          : join(targetDirectory, name.replace(/\.zip$/, ""));
+    console.log(`Using workflow run: ${yellow(workflowRunId)}, url: ${workflowRunUrl}`);
+    console.log(`Branch head commit sha: ${yellow(headSha)}`);
+    console.log("Found workflow artifacts:", artifactUrls);
 
-      const tempDir = join(targetDirectory, "temp", name.replace(/\.zip$/, ""));
-      await fs.mkdirp(tempDir);
-      await fs.mkdirp(finalDir);
+    metadata.workflowRunId = workflowRunId;
+    metadata.commitId = headSha;
+    metadata.collectedAt = new Date().toISOString();
+    metadata.artifacts = [];
 
-      // Download the artifact zip
-      const downloadedFilePath = await downloadArtifact(
-        artifact.url,
-        name,
-        targetDirectory,
-        GITHUB_TOKEN,
-      );
-
-      // Extract the artifact (moves files from tempDir into finalDir)
-      await extractArtifact(downloadedFilePath, tempDir, finalDir);
-
-      //set executable permission on extracted files
-      if (shouldChmod) {
-        for (const file of await globby(["*", "!*.zip"], { cwd: finalDir, absolute: true })) {
-          chmodOwnerPlusX(file);
-        }
+    // Download and unpack contents from the artifacts
+    for (const { name, contents } of artifacts) {
+      const artifact = artifactUrls.find((a) => a.name === name);
+      if (!artifact) {
+        console.warn(`Artifact [${name}] was not found in the workflow artifacts.`);
+        continue;
       }
-      metadata.assets.push({
-        name,
-        extractionDir: finalDir,
-        downloadedAt: new Date().toISOString(),
-      });
-    } catch (error) {
-      console.error(`Error processing artifact [${name}]:`, error.message);
-      throw new Error(`Failed to process artifact ${name}: ${error.message}`);
-    } finally {
-      console.groupEnd();
+
+      console.group(yellow(name));
+      try {
+        const [downloadedFile, artifactMeta] = await downloadUrl({
+          downloadDirectory,
+          targetFileName: name,
+          url: artifact.url,
+          bearerToken,
+        });
+
+        const fileSet = await unpackAsset({
+          sourceFile: downloadedFile,
+          globs: contents,
+          targetDirectory,
+        });
+
+        metadata.artifacts.push({
+          name,
+          ...artifactMeta,
+          fileSetDirectory: targetDirectory,
+          fileSet,
+        });
+      } finally {
+        console.groupEnd();
+      }
     }
+  } finally {
+    console.groupEnd();
   }
 
-  await fs.writeJson(metaFile, metadata, { spaces: 2 });
-  console.log(`Metadata written to ${metaFile}`);
-
-  // Cleanup the parent "temp" folder if it exists.
-  const parentTempDir = join(targetDirectory, "temp");
-  if (await fs.pathExists(parentTempDir)) {
-    await fs.rm(parentTempDir, { recursive: true, force: true });
-    console.log(`Cleaned up temporary folder: ${parentTempDir}`);
-  }
+  return metadata;
 }

--- a/scripts/_github.js
+++ b/scripts/_github.js
@@ -15,14 +15,14 @@ export async function fetchGitHubReleaseMetadata(octokit, releaseTag) {
 }
 
 /**
- * Fetch the commit sha for a GitHub repository release.
+ * Fetch the commit sha for a GitHub repository tag.
  *
  * @param {Octokit} octokit Octokit configured for auth and the target owner/repo
- * @param {string} releaseTag The release's tag
+ * @param {string} tag The commit's tag
  */
-export async function fetchGitHubReleaseTagSha(octokit, releaseTag) {
+export async function fetchGitHubTagSha(octokit, tag) {
   const response = await octokit.request("GET /repos/{owner}/{repo}/commits/{tag}", {
-    tag: releaseTag,
+    tag,
   });
 
   return await response.data.sha;

--- a/scripts/_unpack.js
+++ b/scripts/_unpack.js
@@ -1,0 +1,153 @@
+import { dirname, join } from "node:path";
+import { createWriteStream } from "node:fs";
+import { pipeline } from "node:stream/promises";
+import fs from "fs-extra";
+import micromatch from "micromatch";
+import * as tar from "tar";
+import unzipper from "unzipper";
+import { blue, bold, green, yellow } from "colorette";
+import { isFile, isDirectory, chmodOwnerPlusX } from "./_util.js";
+
+/**
+ * @param {{
+ *  sourceFile: string,
+ *  globs?: string[],
+ *  targetDirectory: string
+ * }} args
+ */
+export async function unpackTarGz({ sourceFile, globs = ["**/*"], targetDirectory }) {
+  if (!(await isFile(sourceFile))) {
+    throw new Error(`Source file does not exist: ${sourceFile}`);
+  }
+  if (!(await isDirectory(targetDirectory))) {
+    throw new Error(`Destination path does not exist: ${targetDirectory}`);
+  }
+
+  const pathsExtracted = [];
+  const matcher = micromatch.matcher(globs);
+  try {
+    await tar.extract({
+      f: sourceFile,
+      z: true,
+      cwd: targetDirectory,
+      filter: (path) => {
+        const isMatch = matcher(path);
+        if (isMatch) {
+          pathsExtracted.push(path);
+        }
+        return isMatch;
+      },
+    });
+  } catch (err) {
+    throw new Error(`Could not unpack ${sourceFile}`, { cause: err });
+  }
+  return pathsExtracted;
+}
+
+/**
+ * @param {{
+ *  sourceFile: string,
+ *  globs?: string[],
+ *  targetDirectory: string
+ * }} args
+ */
+export async function unpackZip({ sourceFile, globs = ["**/*"], targetDirectory }) {
+  if (!(await isFile(sourceFile))) {
+    throw new Error(`Source file does not exist: ${sourceFile}`);
+  }
+  if (!(await isDirectory(targetDirectory))) {
+    throw new Error(`Destination path does not exist: ${targetDirectory}`);
+  }
+
+  const pathsExtracted = [];
+  try {
+    const matcher = micromatch.matcher(globs);
+    const directory = await unzipper.Open.file(sourceFile);
+    for (const file of directory.files.filter((file) => matcher(file.path))) {
+      // See: https://github.com/ZJONSSON/node-unzipper/blob/d19c3fb9c1bbdce6e6bcb701ac65ddb071e1eb31/lib/extract.js#L18-L40
+      const extractPath = join(targetDirectory, file.path.replace(/\\/g, "/"));
+      if (extractPath.indexOf(targetDirectory) !== 0) {
+        continue;
+      }
+      if (file.type === "Directory") {
+        await fs.ensureDir(extractPath);
+      } else {
+        await fs.ensureDir(dirname(extractPath));
+        await pipeline(file.stream(), createWriteStream(extractPath));
+      }
+      pathsExtracted.push(file.path);
+    }
+  } catch (err) {
+    throw new Error(`Could not unpack ${sourceFile}`, { cause: err });
+  }
+  return pathsExtracted;
+}
+
+/**
+ * @param {{
+ *  sourceFile: string,
+ *  globs?: string[],
+ *  targetDirectory: string,
+ *  chmod: boolean,
+ * }} args
+ */
+export async function unpackAsset({ sourceFile, globs, targetDirectory, chmod }) {
+  let pathsExtracted = [];
+  console.group(bold("Unpacking:"), yellow(sourceFile));
+  console.log("Destination:", targetDirectory);
+  try {
+    pathsExtracted = await unpackZip({ sourceFile, globs, targetDirectory });
+    console.log(`Extracted ${green(pathsExtracted.length)} items`);
+
+    if (chmod) {
+      const extractedFiles = await fs.readdir(targetDirectory);
+      for (const file of extractedFiles) {
+        console.log(`chmod o+x ${blue(file)}`);
+        chmodOwnerPlusX(join(targetDirectory, file));
+      }
+    }
+  } finally {
+    console.groupEnd();
+  }
+  return pathsExtracted;
+}
+
+/**
+ * @param {{
+ *  sourceDirectory: string,
+ *  globs?: string[],
+ *  targetDirectory: function,
+ *  assets: [{*}]
+ * }} args
+ */
+export async function unpackAssets({ title, sourceDirectory, globs, targetDirectory, assets }) {
+  if (!(await isDirectory(sourceDirectory))) {
+    throw new Error(`Source directory does not exist: ${sourceDirectory}`);
+  }
+
+  const meta = { assets: [] };
+  console.group(`${title} - Unpacking ${assets.length} assets:`);
+  try {
+    for (const asset of assets) {
+      const source = join(sourceDirectory, asset.name);
+      const target = targetDirectory(asset);
+      await fs.ensureDir(target);
+
+      const pathsExtracted = await unpackAsset({
+        sourceFile: source,
+        targetDirectory: target,
+        globs,
+        chmod: asset.chmod,
+      });
+
+      meta.assets.push({
+        ...asset,
+        fileSetDirectory: target,
+        fileSet: pathsExtracted,
+      });
+    }
+  } finally {
+    console.groupEnd();
+  }
+  return meta;
+}

--- a/scripts/collect-assets.js
+++ b/scripts/collect-assets.js
@@ -1,70 +1,156 @@
 #! /usr/bin/env node
-import { ensureDir } from "fs-extra/esm";
-import { resolve, join } from "path";
-import { cwdToProjectRoot } from "./_util.js";
+import { writeJson } from "fs-extra/esm";
+import { join } from "path";
+import { cwdToProjectRoot, ensureDirs, parseCli } from "./_util.js";
 import {
   downloadAndExtractTarGz,
-  downloadGitHubRelease,
-  downloadWorkflowArtifacts,
+  downloadGitHubReleaseAssets,
+  downloadWorkflowArtifactsAndExtractAssets,
 } from "./_download.js";
+import { unpackAssets } from "./_unpack.js";
 
-cwdToProjectRoot();
-
-// Setup download target
-const DOWNLOAD_DIR = resolve("downloaded_assets");
-await ensureDir(DOWNLOAD_DIR);
-
-if (process.env.WORKFLOW && process.env.WORKFLOW !== "False") {
-  console.log("WORKFLOW environment variable is set. Downloading workflow artifacts...");
-
-  // Download Kai assets via workflow artifacts
-  await downloadWorkflowArtifacts({
-    targetDirectory: join(DOWNLOAD_DIR, "kai/"),
-    metaFile: join(DOWNLOAD_DIR, "kai", "collect.json"),
-    org: "konveyor",
-    repo: "kai",
-    branch: "main",
-    workflow: "build-and-push-binaries.yml",
-    assets: [
-      { name: "java-deps.zip", chmod: false },
-      { name: "kai-rpc-server.linux-aarch64.zip", platform: "linux", arch: "arm64", chmod: true },
-      { name: "kai-rpc-server.linux-x86_64.zip", platform: "linux", arch: "x64", chmod: true },
-      { name: "kai-rpc-server.macos-arm64.zip", platform: "darwin", arch: "arm64", chmod: true },
-      { name: "kai-rpc-server.macos-x86_64.zip", platform: "darwin", arch: "x64", chmod: true },
-      { name: "kai-rpc-server.windows-X64.zip", platform: "win32", arch: "x64", chmod: false },
-    ],
-  });
-} else {
-  console.log("WORKFLOW environment variable is not set. Downloading GitHub release assets...");
-
-  // Download Kai assets from GitHub release
-  await downloadGitHubRelease({
-    targetDirectory: join(DOWNLOAD_DIR, "kai/"),
-    metaFile: join(DOWNLOAD_DIR, "kai", "collect.json"),
+const cli = parseCli(
+  {
     org: "konveyor",
     repo: "kai",
     releaseTag: "v0.1.0",
-    /*
-      Release asset filenames and nodejs equivalent platform/arch
-      platform: https://nodejs.org/docs/latest-v22.x/api/process.html#processplatform
-      arch: https://nodejs.org/docs/latest-v22.x/api/process.html#processarch
-      */
-    assets: [
-      { name: "java-deps.zip" },
-      { name: "kai-rpc-server.linux-x86_64.zip", platform: "linux", arch: "x64", chmod: true },
-      { name: "kai-rpc-server.linux-aarch64.zip", platform: "linux", arch: "arm64", chmod: true },
-      { name: "kai-rpc-server.macos-x86_64.zip", platform: "darwin", arch: "x64", chmod: true },
-      { name: "kai-rpc-server.macos-arm64.zip", platform: "darwin", arch: "arm64", chmod: true },
-      { name: "kai-rpc-server.windows-x64.zip", platform: "win32", arch: "x64" },
-      // { name: "kai-rpc-server.windows-arm64.zip", platform: "win32", arch: "arm64" },
-    ],
-  });
-}
+    branch: "main",
+    workflow: "build-and-push-binaries.yml",
+  },
+  "release",
+);
+console.log("collect-assets configuration:", cli);
 
-// Download jdt.ls
-// Base release url: https://download.eclipse.org/jdtls/milestones/1.38.0/
-await downloadAndExtractTarGz({
-  targetDirectory: join(DOWNLOAD_DIR, "jdt.ls-1.38.0/"),
-  url: "https://download.eclipse.org/jdtls/milestones/1.38.0/jdt-language-server-1.38.0-202408011337.tar.gz",
-  sha256: "ba697788a19f2ba57b16302aba6b343c649928c95f76b0d170494ac12d17ac78",
-});
+// Run in project root
+const cwd = cwdToProjectRoot();
+
+// Setup download target
+const [DOWNLOAD_CACHE, DOWNLOAD_DIR] = await ensureDirs(["downloaded_cache", "downloaded_assets"]);
+const { useWorkflow, useRelease, org, repo, releaseTag, branch, workflow } = cli;
+const bearerToken = process.env.GITHUB_TOKEN ?? undefined;
+
+const actions = [
+  // If from a release, download the release asset zips
+  useRelease &&
+    (async () => ({
+      id: "download release assets",
+      meta: await downloadGitHubReleaseAssets({
+        targetDirectory: join(DOWNLOAD_CACHE, "assets"),
+        org,
+        repo,
+        releaseTag,
+        bearerToken,
+
+        assets: [
+          { name: "kai-rpc-server.linux-x86_64.zip" },
+          { name: "kai-rpc-server.linux-aarch64.zip" },
+          { name: "kai-rpc-server.macos-x86_64.zip" },
+          { name: "kai-rpc-server.macos-arm64.zip" },
+          { name: "kai-rpc-server.windows-X64.zip" },
+        ],
+      }),
+    })),
+
+  // If from a workflow, download the artifacts and unpack
+  useWorkflow &&
+    (async () => ({
+      id: "download workflow artifacts and extract assets",
+      meta: await downloadWorkflowArtifactsAndExtractAssets({
+        downloadDirectory: join(DOWNLOAD_CACHE, "artifacts"),
+        targetDirectory: join(DOWNLOAD_CACHE, "assets"),
+        org,
+        repo,
+        branch,
+        workflow,
+        bearerToken,
+
+        artifacts: [
+          { name: "kai-rpc-server.linux-aarch64.zip", contents: ["kai-rpc-server.*.zip"] },
+          { name: "kai-rpc-server.linux-x86_64.zip", contents: ["kai-rpc-server.*.zip"] },
+          { name: "kai-rpc-server.macos-arm64.zip", contents: ["kai-rpc-server.*.zip"] },
+          { name: "kai-rpc-server.macos-x86_64.zip", contents: ["kai-rpc-server.*.zip"] },
+          { name: "kai-rpc-server.windows-X64.zip", contents: ["kai-rpc-server.*.zip"] },
+        ],
+      }),
+    })),
+
+  // Extract Kai binaries from the downloaded workflows artifact or release assets
+  async () => ({
+    id: "kai binaries",
+    meta: await unpackAssets({
+      title: "kai binary",
+      sourceDirectory: join(DOWNLOAD_CACHE, "assets"),
+      targetDirectory: ({ platform, arch }) => join(DOWNLOAD_DIR, "kai", `${platform}-${arch}`),
+
+      globs: ["kai-analyzer-rpc*", "kai-rpc-server*"],
+      assets: [
+        { name: "kai-rpc-server.linux-x86_64.zip", platform: "linux", arch: "x64", chmod: true },
+        { name: "kai-rpc-server.linux-aarch64.zip", platform: "linux", arch: "arm64", chmod: true },
+        { name: "kai-rpc-server.macos-x86_64.zip", platform: "darwin", arch: "x64", chmod: true },
+        { name: "kai-rpc-server.macos-arm64.zip", platform: "darwin", arch: "arm64", chmod: true },
+        { name: "kai-rpc-server.windows-X64.zip", platform: "win32", arch: "x64" },
+      ],
+    }),
+  }),
+
+  // Extract opensource-labels-file from the linux-x64_64 downloaded workflow artifact or release asset
+  async () => ({
+    id: "opensource-labels-file",
+    meta: await unpackAssets({
+      title: "opensource-labels-file",
+      sourceDirectory: join(DOWNLOAD_CACHE, "assets"),
+      targetDirectory: () => join(DOWNLOAD_DIR, "opensource-labels-file"),
+
+      globs: ["maven.default.index"],
+      assets: [{ name: "kai-rpc-server.linux-x86_64.zip" }],
+    }),
+  }),
+
+  // Extract seed rulesets from the linux-x64_64 downloaded workflow artifact or release asset
+  async () => ({
+    id: "seed rulesets",
+    meta: await unpackAssets({
+      title: "rulesets",
+      sourceDirectory: join(DOWNLOAD_CACHE, "assets"),
+      targetDirectory: () => join(DOWNLOAD_DIR, "rulesets"),
+
+      globs: ["example/analysis/rulesets/**/*"],
+      assets: [{ name: "kai-rpc-server.linux-x86_64.zip" }],
+    }),
+  }),
+
+  // Extract jdt.ls bundles from the linux-x64_64 downloaded workflow artifact or release asset
+  async () => ({
+    id: "jdt.ls bundles",
+    meta: await unpackAssets({
+      title: "jdt.ls bundles",
+      sourceDirectory: join(DOWNLOAD_CACHE, "assets"),
+      targetDirectory: () => join(DOWNLOAD_DIR, "jdtls-bundles"),
+
+      globs: ["*.jar"],
+      assets: [{ name: "kai-rpc-server.linux-x86_64.zip" }],
+    }),
+  }),
+
+  // Download and extract `jdt.ls`
+  // Base release url: https://download.eclipse.org/jdtls/milestones/1.38.0/
+  async () => ({
+    id: "jdt.ls",
+    meta: await downloadAndExtractTarGz({
+      downloadDirectory: join(DOWNLOAD_CACHE, "assets"),
+      targetDirectory: join(DOWNLOAD_DIR, "jdt.ls-1.38.0"),
+      url: "https://download.eclipse.org/jdtls/milestones/1.38.0/jdt-language-server-1.38.0-202408011337.tar.gz",
+      sha256: "ba697788a19f2ba57b16302aba6b343c649928c95f76b0d170494ac12d17ac78",
+    }),
+  }),
+];
+
+// Run the queued actions
+const meta = [];
+for (const action of actions) {
+  if (action && typeof action === "function") {
+    const actionMeta = await action();
+    meta.push(actionMeta);
+  }
+}
+writeJson(join(DOWNLOAD_DIR, "collect-assets-meta.json"), { cwd, actions: meta }, { spaces: 2 });


### PR DESCRIPTION
Resolves: #234
Resolves: #334

Update the collect-assets script such that assets can be sourced from GitHub release assess or from a GitHub workflow's artifacts.  Download of assets and artifacts is separated from unpacking of the assets.

When complete, the full set of downloaded assets that the editor-extensions can use will be located under `{project_root}/downloaded_assets`.

Downloaded files will have the ETag stored in a sidecar file.  This allows future runs to skip the download step if the url's data has not been changed.

Note: File globs are used during unpacking to allow extracting only a portion of an archive that is
relevant to the desired file set.
