### PR TITLE
:seedling: Collect rulesets directly from GitHub release

### DIFF
--- a/scripts/_util.js
+++ b/scripts/_util.js
@@ -63,7 +63,10 @@ export async function ensureDirs(directories) {
   );
 }
 
-export function parseCli({ org, repo, releaseTag, workflow, branch }, useDefault = "release") {
+export function parseCli(
+  { org, repo, releaseTag, workflow, branch, rulesetOrg, rulesetRepo, rulesetReleaseTag },
+  useDefault = "release",
+) {
   const { values } = parseArgs({
     options: {
       "use-release": {
@@ -102,9 +105,27 @@ export function parseCli({ org, repo, releaseTag, workflow, branch }, useDefault
         short: "b",
         default: branch,
       },
+      "ruleset-org": {
+        type: "string",
+        default: rulesetOrg,
+      },
+      "ruleset-repo": {
+        type: "string",
+        default: rulesetRepo,
+      },
+      "ruleset-release-tag": {
+        type: "string",
+        default: rulesetReleaseTag,
+      },
     },
     allowNegative: true,
   });
+
+  const ruleset = {
+    rulesetOrg: values["ruleset-org"],
+    rulesetRepo: values["ruleset-repo"],
+    rulesetReleaseTag: values["ruleset-release-tag"],
+  };
 
   if (values["use-workflow-artifacts"] && values.workflow && values.branch) {
     return {
@@ -113,6 +134,7 @@ export function parseCli({ org, repo, releaseTag, workflow, branch }, useDefault
       repo: values.repo,
       workflow: values.workflow,
       branch: values.branch,
+      ...ruleset,
     };
   }
   if (values["use-release"] && values["release-tag"]) {
@@ -121,10 +143,12 @@ export function parseCli({ org, repo, releaseTag, workflow, branch }, useDefault
       org: values.org,
       repo: values.repo,
       releaseTag: values["release-tag"],
+      ...ruleset,
     };
   }
   return {
     org: values.org,
     repo: values.repo,
+    ...ruleset,
   };
 }

--- a/scripts/_util.js
+++ b/scripts/_util.js
@@ -36,6 +36,10 @@ export async function isDirectory(path) {
   return (await fs.pathExists(path)) && (await fs.stat(path)).isDirectory;
 }
 
+export function relativeToCwd(pathTo) {
+  return path.relative(path.resolve("."), path.resolve(pathTo));
+}
+
 export async function fileSha256(path) {
   if (!isFile(path)) {
     return "";

--- a/scripts/collect-assets.js
+++ b/scripts/collect-assets.js
@@ -3,6 +3,7 @@ import { writeJson } from "fs-extra/esm";
 import { join } from "path";
 import { cwdToProjectRoot, ensureDirs, parseCli } from "./_util.js";
 import {
+  downloadAndExtractGitHubReleaseSourceCode,
   downloadAndExtractTarGz,
   downloadGitHubReleaseAssets,
   downloadWorkflowArtifactsAndExtractAssets,
@@ -106,16 +107,20 @@ const actions = [
     }),
   }),
 
-  // Extract seed rulesets from the linux-x64_64 downloaded workflow artifact or release asset
+  // Download and extract seed rulesets from a rulesets repo release
   async () => ({
     id: "seed rulesets",
-    meta: await unpackAssets({
-      title: "rulesets",
-      sourceDirectory: join(DOWNLOAD_CACHE, "assets"),
-      targetDirectory: () => join(DOWNLOAD_DIR, "rulesets"),
+    meta: await downloadAndExtractGitHubReleaseSourceCode({
+      downloadDirectory: join(DOWNLOAD_CACHE, "sources"),
+      targetDirectory: join(DOWNLOAD_DIR, "rulesets"),
 
-      globs: ["example/analysis/rulesets/**/*"],
-      assets: [{ name: "kai-rpc-server.linux-x86_64.zip" }],
+      org: "konveyor",
+      repo: "rulesets",
+      releaseTag: "v0.6.1",
+      bearerToken,
+
+      context: "{{root}}/default/generated",
+      globs: ["**/*"],
     }),
   }),
 

--- a/scripts/collect-assets.js
+++ b/scripts/collect-assets.js
@@ -17,6 +17,9 @@ const cli = parseCli(
     releaseTag: "v0.1.0",
     branch: "main",
     workflow: "build-and-push-binaries.yml",
+    rulesetOrg: "konveyor",
+    rulesetRepo: "rulesets",
+    rulesetReleaseTag: "v0.6.1",
   },
   "release",
 );
@@ -114,9 +117,9 @@ const actions = [
       downloadDirectory: join(DOWNLOAD_CACHE, "sources"),
       targetDirectory: join(DOWNLOAD_DIR, "rulesets"),
 
-      org: "konveyor",
-      repo: "rulesets",
-      releaseTag: "v0.6.1",
+      org: cli.rulesetOrg,
+      repo: cli.rulesetRepo,
+      releaseTag: cli.rulesetReleaseTag,
       bearerToken,
 
       context: "{{root}}/default/generated",


### PR DESCRIPTION
Update the `collect-assets.js` script to use the sources release of the `konveyor/ruleset` repo as the source of the ruleset files. A single release of the ruleset repo is targeted.

Once this is merged, another PR will swap out the repo assets with the downloaded assets.

Follows: #453