### PR TITLE
:bug: Fix copy-dist to put the jdtls bundle in the right place

### DIFF
--- a/scripts/copy-dist.js
+++ b/scripts/copy-dist.js
@@ -71,7 +71,7 @@ await copy({
     {
       context: "downloaded_assets/jdtls-bundles",
       src: ["**/*.jar"],
-      dest: "dist/assets/jdtls",
+      dest: "dist/assets/jdtls-bundles",
     },
 
     // seed assets - opensource-labels-file


### PR DESCRIPTION
The jdtls bundle was going to the wrong location,
change the destination to the correct folder.
