### PR TITLE
:seedling: Adjust collect-asset sources on workflow actions

### DIFF
--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -99,8 +99,8 @@ jobs:
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       #   run: |
-      #     npm run collect-assets \
-      #       --workflow \
+      #     npm run collect-assets -- \
+      #       --use-workflow-artifacts \
       #       --branch=main \
       #       --platform=runtime \
       #       --arch=runtime
@@ -151,7 +151,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm run build
-          npm run collect-assets
+          npm run collect-assets -- --use-workflow-artifacts --branch=main
           npm run dist
           npm run package
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,19 @@ on:
         required: true
         type: boolean
         default: false
+      dry-run:
+        description: "Should this be a dry run of the release?"
+        required: false
+        type: boolean
+        default: false
 
 # https://typicode.github.io/husky/how-to.html#ci-server-and-docker
 env:
   HUSKY: 0
 
 jobs:
-  test_build_package:
-    name: Build, Test, and Package (${{ matrix.platform }})
+  test_the_release:
+    name: Test the release (${{ matrix.platform }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -56,8 +61,12 @@ jobs:
           fi
         shell: bash
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Install dependencies, download runtime assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm ci
+          npm run collect-assets -- --use-release
 
       # Run tests on different OSes
       - name: Run tests (Linux)
@@ -73,29 +82,36 @@ jobs:
         shell: cmd
         run: npm test
 
-      # clean
-      - name: Clean build
-        run: |
-          npm run clean
-          npm run build
+  package:
+    needs: test_the_release
+    name: Generate the vsix for the release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
 
-      # Collect assets
-      - name: Collect assets
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Build the project and generate the .vsix
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm run collect-assets
+        run: |
+          npm ci
+          npm run build
+          npm run collect-assets -- --use-release
+          npm run dist
+          npm run package
 
-      # Copy files to dist folder
-      - name: Copy files to dist folder
-        run: npm run dist
-
-      # Build VSIX package
-      - name: Build VSIX package
-        run: npm run package
-
-      # Upload VSIX artifact (linux)
       - name: Upload VSIX artifact
-        if: matrix.platform == 'linux'
         uses: actions/upload-artifact@v4
         with:
           name: vscode-extension-${{ matrix.platform }}
@@ -103,7 +119,7 @@ jobs:
 
   generate_changelog:
     name: Generate Changelog
-    needs: test_build_package
+    needs: test_the_release
     uses: konveyor/release-tools/.github/workflows/generate-changelog.yml@main
     with:
       version: ${{ needs.test_build_package.outputs.tag_name }}
@@ -116,7 +132,7 @@ jobs:
   release:
     name: Final Release
     runs-on: ubuntu-latest
-    needs: [test_build_package, generate_changelog]
+    needs: [package, generate_changelog]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -147,6 +163,7 @@ jobs:
           mv ./artifacts/vscode-extension-linux/*.vsix ./artifacts/konveyor-${{ needs.test_build_package.outputs.tag_name }}.vsix
 
       - name: Create Release
+        if: ${{ github.event.inputs.dry-run == 'false' }}
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ needs.test_build_package.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
     needs: test_the_release
     uses: konveyor/release-tools/.github/workflows/generate-changelog.yml@main
     with:
-      version: ${{ needs.test_build_package.outputs.tag_name }}
+      version: ${{ needs.test_the_release.outputs.tag_name }}
       prev_version: $(gh api repos/${{ github.repository }}/releases/latest | jq -r '.tag_name')
       repository: ${{ github.repository }}
       ref: ${{ github.sha }}
@@ -160,13 +160,13 @@ jobs:
 
       - name: Rename VSIX Packages
         run: |
-          mv ./artifacts/vscode-extension-linux/*.vsix ./artifacts/konveyor-${{ needs.test_build_package.outputs.tag_name }}.vsix
+          mv ./artifacts/vscode-extension-linux/*.vsix ./artifacts/konveyor-${{ needs.test_the_release.outputs.tag_name }}.vsix
 
       - name: Create Release
         if: ${{ github.event.inputs.dry-run == 'false' }}
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ needs.test_build_package.outputs.tag_name }}
+          tag: ${{ needs.test_the_release.outputs.tag_name }}
           commit: ${{ github.sha }}
           bodyFile: ./artifacts/release.md
           artifacts: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,8 +132,17 @@ jobs:
   release:
     name: Final Release
     runs-on: ubuntu-latest
-    needs: [package, generate_changelog]
+    needs: [test_the_release, package, generate_changelog]
     steps:
+      - name: Add release details to the step summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Release Information
+          Tag: __${{ needs.test_the_release.outputs.tag_name }}__
+          Pre-Release: __${{ github.event.inputs.prerelease }}__
+          Dry run? __${{ github.event.inputs.dry-run}}__
+          EOF
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
On the `ci-repo.yml` action:
  - pull assets from the Kai build workflow artifacts (the "latest" build)
  - Note: If the head commit to the configured branch does not yet have a successful run of the build workflow, the collect-assets script should fail and fail the CI run

On the `release.yml` action:
  - explicitly pull assets from the default configured Kai release
  - update the workflows to mirror how `ci-repo.yml` builds the vsix
  - write a release summary to the step output to see the info without opening the logs
  - add a dry-run option to be able to test everything up to but not including posting the release

The source of all of the assets will be listed in the workflow run log.
