### PR TITLE
:seedling: Include the collect-assets metadata in dist/assets

### DIFF
--- a/scripts/copy-dist.js
+++ b/scripts/copy-dist.js
@@ -95,5 +95,12 @@ await copy({
       src: ["*/kai*", "!**/*.zip"],
       dest: "dist/assets/kai",
     },
+
+    // include the collect-assets metadata
+    {
+      context: "downloaded_assets",
+      src: "collect-assets-meta.json",
+      dest: "dist/assets",
+    },
   ],
 });


### PR DESCRIPTION
Include the record of where the assets came from that are included in the `dist/assets` folder of the vsix archive.
