### PR TITLE
:sparkles: Feature/hot rerun of analysis

### DIFF
--- a/shared/src/types/types.ts
+++ b/shared/src/types/types.ts
@@ -132,6 +132,7 @@ export interface ExtensionData {
   isStartingServer: boolean;
   isInitializingServer: boolean;
   isContinueInstalled: boolean;
+  isAnalysisScheduled: boolean;
   serverState: ServerState;
   solutionState: SolutionState;
   solutionData?: Solution;

--- a/vscode/src/analysis/backoffManager.ts
+++ b/vscode/src/analysis/backoffManager.ts
@@ -1,0 +1,64 @@
+export class BackoffManager {
+  // next scheduled analysis runs after this delay
+  private backoffTimer: NodeJS.Timeout | null = null;
+  // reset the backoff delay when we are idle for a while
+  private idleResetTimer: NodeJS.Timeout | null = null;
+
+  private baseBackoffDelay: number;
+  private maxBackoffDelay: number;
+  private currentBackoffDelay: number;
+  private idleResetDelay: number;
+  private runningCallback: boolean = false;
+  constructor(
+    baseBackoffDelay: number = 1000,
+    maxBackoffDelay: number = 30000,
+    idleResetDelay: number = 10000,
+  ) {
+    this.baseBackoffDelay = baseBackoffDelay;
+    this.maxBackoffDelay = maxBackoffDelay;
+    this.currentBackoffDelay = baseBackoffDelay;
+    this.idleResetDelay = idleResetDelay;
+    this.runningCallback = false;
+  }
+
+  schedule(callback: () => void) {
+    if (this.idleResetTimer) {
+      clearTimeout(this.idleResetTimer);
+    }
+    this.idleResetTimer = setTimeout(() => this.resetBackoff(), this.idleResetDelay);
+
+    if (this.backoffTimer) {
+      clearTimeout(this.backoffTimer);
+    }
+    this.backoffTimer = setTimeout(() => {
+      if (!this.runningCallback) {
+        this.runningCallback = true;
+        callback();
+        this.runningCallback = false;
+      }
+    }, this.currentBackoffDelay);
+  }
+
+  public isRunningCallback() {
+    return this.runningCallback;
+  }
+
+  public increaseBackoff() {
+    this.currentBackoffDelay = Math.min(this.currentBackoffDelay * 2, this.maxBackoffDelay);
+  }
+
+  private resetBackoff() {
+    this.currentBackoffDelay = this.baseBackoffDelay;
+  }
+
+  dispose() {
+    if (this.backoffTimer) {
+      clearTimeout(this.backoffTimer);
+      this.backoffTimer = null;
+    }
+    if (this.idleResetTimer) {
+      clearTimeout(this.idleResetTimer);
+      this.idleResetTimer = null;
+    }
+  }
+}

--- a/vscode/src/analysis/batchedAnalysisTrigger.ts
+++ b/vscode/src/analysis/batchedAnalysisTrigger.ts
@@ -22,11 +22,13 @@ export class BatchedAnalysisTrigger {
 
   async notifyFileChanges(change: FileChange) {
     if (this.enableHotRerun) {
+      // hot re-run if enabled
       this.notifyFileChangesQueue.set(change.path.fsPath, change);
       this.scheduleNotifyFileChanges();
       this.analysisFileChangesQueue.add(change.path);
       this.schedulePartialAnalysis();
     } else if (change.saved) {
+      // when a file is saved, we still want to call analysis
       this.analysisFileChangesQueue.add(change.path);
       this.schedulePartialAnalysis();
     }

--- a/vscode/src/analysis/batchedAnalysisTrigger.ts
+++ b/vscode/src/analysis/batchedAnalysisTrigger.ts
@@ -1,0 +1,105 @@
+import { FileChange } from "src/client/types";
+import { isUriIgnored } from "../paths";
+import * as vscode from "vscode";
+import { BackoffManager } from "./backoffManager";
+import { ExtensionState } from "src/extensionState";
+
+export class BatchedAnalysisTrigger {
+  private analysisBackoff: BackoffManager;
+  private notifyFileChangesBackoff: BackoffManager;
+  private notifyFileChangesQueue: Map<string, FileChange> = new Map();
+  private analysisFileChangesQueue: Set<vscode.Uri> = new Set();
+
+  constructor(
+    private readonly extensionState: ExtensionState,
+    private readonly enableHotRerun: boolean = true,
+  ) {
+    this.analysisBackoff = new BackoffManager(5000, 30000, 10000);
+    this.notifyFileChangesBackoff = new BackoffManager(1000, 10000, 10000);
+    this.extensionState = extensionState;
+    this.enableHotRerun = enableHotRerun;
+  }
+
+  async notifyFileChanges(change: FileChange) {
+    if (this.enableHotRerun) {
+      this.notifyFileChangesQueue.set(change.path.fsPath, change);
+      this.scheduleNotifyFileChanges();
+      this.analysisFileChangesQueue.add(change.path);
+      this.schedulePartialAnalysis();
+    } else if (change.saved) {
+      this.analysisFileChangesQueue.add(change.path);
+      this.schedulePartialAnalysis();
+    }
+  }
+
+  private scheduleNotifyFileChanges() {
+    this.notifyFileChangesBackoff.schedule(async () => {
+      if (this.extensionState.data.isAnalyzing || this.analysisBackoff.isRunningCallback()) {
+        // if there is an analysis in progress,
+        // postpone notifying file changes
+        this.scheduleNotifyFileChanges();
+        return;
+      }
+      const changes = Array.from(this.notifyFileChangesQueue.values()).filter(
+        (change) => !isUriIgnored(change.path),
+      );
+      if (changes.length < 1) {
+        // no changes to notify
+        return;
+      }
+      console.log(
+        "notifyFileChanges",
+        changes.map((c) => c.path.fsPath),
+      );
+      try {
+        await this.extensionState.analyzerClient.notifyFileChanges(changes);
+        for (const change of changes) {
+          this.notifyFileChangesQueue.delete(change.path.fsPath);
+        }
+      } catch (error) {
+        console.error("error notifying file changes", error);
+      }
+      this.notifyFileChangesBackoff.increaseBackoff();
+    });
+  }
+
+  private schedulePartialAnalysis() {
+    this.analysisBackoff.schedule(async () => {
+      if (
+        this.extensionState.data.isAnalyzing ||
+        this.notifyFileChangesBackoff.isRunningCallback()
+      ) {
+        // if there is an analysis or notifyFileChanges
+        // in progress, postpone the partialAnalysis
+        this.schedulePartialAnalysis();
+        return;
+      }
+      const changedFiles = Array.from(this.analysisFileChangesQueue).filter(
+        (uri) => !isUriIgnored(uri),
+      );
+      if (changedFiles.length < 1) {
+        // no changes to analyze
+        return;
+      }
+      console.log(
+        "runAnalysis",
+        changedFiles.map((f) => f.fsPath),
+      );
+      try {
+        const response = await this.extensionState.analyzerClient.runAnalysis(changedFiles);
+        console.log("runAnalysis response", response);
+        for (const file of changedFiles) {
+          this.analysisFileChangesQueue.delete(file);
+        }
+      } catch (error) {
+        console.error("error running analysis", error);
+      }
+      this.analysisBackoff.increaseBackoff();
+    });
+  }
+
+  dispose() {
+    this.analysisBackoff.dispose();
+    this.notifyFileChangesBackoff.dispose();
+  }
+}

--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -11,7 +11,7 @@ import {
   SolutionState,
   Violation,
 } from "@editor-extensions/shared";
-import { paths, fsPaths } from "../paths";
+import { paths, fsPaths, ignoresToExcludedPaths } from "../paths";
 import { Extension } from "../helpers/Extension";
 import { buildAssetPaths, AssetPaths } from "./paths";
 import { getConfigAnalyzerPath, getConfigKaiDemoMode, isAnalysisResponse } from "../utilities";
@@ -355,6 +355,7 @@ export class AnalyzerClient {
             label_selector: activeProfile.labelSelector,
             included_paths: filePaths?.map((uri) => uri.fsPath),
             reset_cache: !(filePaths && filePaths.length > 0),
+            excluded_paths: ignoresToExcludedPaths(),
           };
           this.outputChannel.appendLine(
             `Sending 'analysis_engine.Analyze' request with params: ${JSON.stringify(

--- a/vscode/src/client/types.ts
+++ b/vscode/src/client/types.ts
@@ -1,3 +1,5 @@
+import * as vscode from "vscode";
+
 export type ServerLogLevels = "TRACE" | "DEBUG" | "INFO" | "WARN" | "ERROR" | "CRITICAL";
 
 export interface ServerCliArguments {
@@ -66,4 +68,10 @@ export interface KaiRpcApplicationConfig {
 
   // TODO: Do we need to include `fernFlowerPath` to support the java decompiler?
   // analyzerLspFernFlowerPath?: string;
+}
+
+export interface FileChange {
+  path: vscode.Uri;
+  content: string;
+  saved: boolean;
 }

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -5,12 +5,12 @@ import { ExtensionState } from "./extensionState";
 import { ExtensionData } from "@editor-extensions/shared";
 import { ViolationCodeActionProvider } from "./ViolationCodeActionProvider";
 import { AnalyzerClient } from "./client/analyzerClient";
-import { registerDiffView, KonveyorFileModel } from "./diffView";
+import { KonveyorFileModel, registerDiffView } from "./diffView";
 import { MemFS } from "./data";
 import { Immutable, produce } from "immer";
 import { registerAnalysisTrigger } from "./analysis";
 import { IssuesModel, registerIssueView } from "./issueView";
-import { ensurePaths, ExtensionPaths, paths } from "./paths";
+import { ExtensionPaths, ensurePaths, paths } from "./paths";
 import { copySampleProviderSettings } from "./utilities/fileUtils";
 import { getConfigSolutionMaxEffortLevel, updateAnalysisConfig } from "./utilities";
 import { getBundledProfiles } from "./utilities/profiles/bundledProfiles";
@@ -37,6 +37,7 @@ class VsCodeExtension {
         isFetchingSolution: false,
         isStartingServer: false,
         isInitializingServer: false,
+        isAnalysisScheduled: false,
         isContinueInstalled: false,
         solutionData: undefined,
         serverState: "initial",

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -118,7 +118,7 @@ class VsCodeExtension {
         }),
       );
 
-      registerAnalysisTrigger(this.listeners);
+      registerAnalysisTrigger(this.listeners, this.state);
 
       this.listeners.push(
         vscode.workspace.onDidSaveTextDocument((doc) => {

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -11,6 +11,7 @@ const defaultState: ExtensionData = {
   isFetchingSolution: false,
   isStartingServer: false,
   isInitializingServer: false,
+  isAnalysisScheduled: false,
   isContinueInstalled: false,
   solutionData: undefined,
   serverState: "initial",


### PR DESCRIPTION
Fixes #472 

Introduces hot rerun of analysis in that analysis is run whenever - 
1. A file is saved (immediately)
2. A file is modified (after notifying file changes to the backend with a backoff)
   - File changes are communicated to the backend, the backend is supposed to handle in-memory changes
Makes sure server is not overwhelmed at any point using backoffs but we may have to tweak the numbers as we test this more. So far its working well.

Needs https://github.com/konveyor/kai/pull/764

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
