### PR TITLE
:bug: ignoresToExcludedPaths should return strings, even on Windows

### DIFF
--- a/vscode/src/paths.ts
+++ b/vscode/src/paths.ts
@@ -185,5 +185,6 @@ export const ignoresToExcludedPaths = () => {
     absolute: true,
     unique: true,
   });
-  return exclude;
+
+  return exclude.map((path) => slash(String(path)));
 };


### PR DESCRIPTION
Fixes konveyor/kai#784 
