### PR TITLE
:bug: make build files reload workspace configuration

### DIFF
--- a/vscode/src/utilities/fileUtils.ts
+++ b/vscode/src/utilities/fileUtils.ts
@@ -7,6 +7,21 @@ import { paths } from "../paths";
 
 const isWindows = platform === "win32";
 
+// TODO (pgaikwad) - ideally, programming language should come from analysis profiles instead
+// this is a list of files for the workspace which are saved when modified by the agent to refresh diagnostics
+export const getBuildFilesForLanguage = (programmingLanguage: string): Array<string> => {
+  switch (programmingLanguage.toLowerCase()) {
+    case "java":
+      return ["pom.xml", "build.gradle"];
+    case "go":
+      return ["go.mod"];
+    case "ts":
+      return ["package.json"];
+    default:
+      return [];
+  }
+};
+
 export const checkIfExecutable = async (filePath: string): Promise<boolean> => {
   try {
     // Normalize the path for cross-platform compatibility


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
