### PR TITLE
:bug: Stop upload failures caused by duplicate names

### DIFF
--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -17,9 +17,6 @@ on:
 
   workflow_call:
 
-  schedule:
-    - cron: '0 2 * * *'
-
 concurrency:
   group: ci-repo-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -183,6 +180,10 @@ jobs:
           name: vscode-extension
           path: "dist/*.vsix"
 
+      - name: Set vsix suffix
+        if: ${{ ! (github.event_name == 'pull_request' && ! github.event.pull_request.merged) }}
+        id: set_time
+        run: echo "vsix_suffix=$(date +%Y%m%d-%H%M)-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Move vsix
         if: ${{ ! (github.event_name == 'pull_request' && ! github.event.pull_request.merged) }}
@@ -198,7 +199,19 @@ jobs:
           upload_url: https://uploads.github.com/repos/konveyor/editor-extensions/releases/223723085/assets{?name,label}
           release_id: 223723085
           asset_path: ./dist/konveyor-ai.vsix
-          asset_name: konveyor-ai-$$.vsix
+          asset_name: konveyor-ai-${{ steps.set_time.outputs.vsix_suffix }}.vsix
           asset_content_type: application/octet-stream
-          max_releases: 14
           ignore_hash: true
+
+      - name: Cleanup old assets
+        if: ${{ ! (github.event_name == 'pull_request' && ! github.event.pull_request.merged) }}
+        run: |
+             c=1
+             for i in $(gh release view -R konveyor/editor-extensions development-builds --json assets | jq -r .assets[].name | sort -r); do
+               if [ "$c" -gt 7 ]; then
+                 gh release delete-asset -y -R konveyor/editor-extensions development-builds $i
+               fi
+               c=$((c+1))
+             done
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
- Remove the nightly-ci-repo.yml since I added a schedule directly to this workflow
- Updated the schedule to match the old nightly ci schedule
- Generate an asset name with the time (HHMM) as part of it so it's more unique and prevents conflicts
- Having a unique asset name causes the cleanup to break so do our own cleanup using gh.