### PR TITLE
:bug: fix bad state in analysis issue fix

### DIFF
--- a/agentic/src/nodes/base.ts
+++ b/agentic/src/nodes/base.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import zodToJsonSchema from "zod-to-json-schema";
 import { type BaseLanguageModelInput } from "@langchain/core/language_models/base";
 import {
@@ -345,7 +346,7 @@ Make sure you always use \`\`\` at the start and end of the JSON block to clearl
   private renderTextDescriptionAndArgs(tools: DynamicStructuredTool[]): string {
     let description = "";
     tools.forEach((tool) => {
-      description += `${tool.name}: ${tool.description}, Args: ${JSON.stringify(zodToJsonSchema(tool.schema))}`;
+      description += `${tool.name}: ${tool.description}, Args: ${JSON.stringify(zodToJsonSchema(tool.schema as z.ZodSchema))}`;
     });
     return description;
   }

--- a/agentic/src/workflows/interactiveWorkflow.ts
+++ b/agentic/src/workflows/interactiveWorkflow.ts
@@ -17,6 +17,7 @@ import {
   SummarizeAdditionalInfoOutputState,
   AnalysisIssueFixOrchestratorState,
   SummarizeHistoryOutputState,
+  AnalysisIssueFixOutputState,
 } from "../schemas/analysisIssueFix";
 import { modelHealthCheck } from "../utils";
 import { FileSystemTools } from "../tools/filesystem";
@@ -37,6 +38,7 @@ export interface KaiInteractiveWorkflowInput extends KaiWorkflowInput {
 
 // output state of the initial analysis workflow
 const AnalysisWorkflowOutputState = Annotation.Root({
+  ...AnalysisIssueFixOutputState.spec,
   ...SummarizeAdditionalInfoOutputState.spec,
   ...SummarizeHistoryOutputState.spec,
 });


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
