### PR TITLE
:bug: fix windows file paths

### DIFF
--- a/agentic/package.json
+++ b/agentic/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "ci": "npx jest",
+    "test": "jest",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "prebuild": "npm run clean",

--- a/agentic/src/nodes/analysisIssueFix.ts
+++ b/agentic/src/nodes/analysisIssueFix.ts
@@ -72,6 +72,7 @@ export class AnalysisIssueFix extends BaseNode {
           nextState.inputFileUri = nextEntry.uri;
           nextState.inputIncidentsDescription = incidentsDescription;
         } catch (err) {
+          console.error("Failed to read input file", nextEntry.uri);
           this.emitWorkflowMessage({
             type: KaiWorkflowMessageType.Error,
             data: String(err),

--- a/agentic/src/nodes/base.ts
+++ b/agentic/src/nodes/base.ts
@@ -110,6 +110,7 @@ export abstract class BaseNode extends KaiWorkflowEventEmitter {
         return this.stream(messageId, enableTools, emitResponseChunks, stream);
       }
     } catch (err) {
+      console.error("Error callling stream()", err);
       if (emitResponseChunks) {
         this.emitWorkflowMessage({
           id: messageId,

--- a/agentic/src/utils.ts
+++ b/agentic/src/utils.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { fileURLToPath } from "url";
 import {
   type BaseChatModel,
   type BaseChatModelCallOptions,
@@ -75,6 +76,22 @@ export async function modelHealthCheck(
         );
       }
     }
+    console.log("Health check response", response);
     return response;
   }
+}
+
+/**
+ * Removes file:// prefix in URLs passed by vscode extension
+ * @param path input path to clean
+ */
+export function fileUriToPath(path: string): string {
+  let cleanPath = path;
+  if (path.startsWith("file://")) {
+    cleanPath = fileURLToPath(path);
+  }
+  if (process.platform === "win32" && path.startsWith("/")) {
+    cleanPath = cleanPath.replace("/", "");
+  }
+  return cleanPath;
 }

--- a/agentic/src/workflows/interactiveWorkflow.ts
+++ b/agentic/src/workflows/interactiveWorkflow.ts
@@ -19,9 +19,9 @@ import {
   SummarizeHistoryOutputState,
   AnalysisIssueFixOutputState,
 } from "../schemas/analysisIssueFix";
-import { modelHealthCheck } from "../utils";
 import { FileSystemTools } from "../tools/filesystem";
 import { KaiWorkflowEventEmitter } from "../eventEmitter";
+import { fileUriToPath, modelHealthCheck } from "../utils";
 import { AnalysisIssueFix } from "../nodes/analysisIssueFix";
 import { JavaDependencyTools } from "../tools/javaDependency";
 import { DiagnosticsIssueFix } from "../nodes/diagnosticsIssueFix";
@@ -94,7 +94,7 @@ export class KaiInteractiveWorkflow
   }
 
   async init(options: KaiWorkflowInitOptions): Promise<void> {
-    const workspaceDir = options.workspaceDir.replace("file://", "");
+    const workspaceDir = fileUriToPath(options.workspaceDir);
     const fsTools = new FileSystemTools(workspaceDir, options.fsCache);
     const depTools = new JavaDependencyTools();
     const { supportsTools, connected, supportsToolsInStreaming } = await modelHealthCheck(
@@ -219,13 +219,13 @@ export class KaiInteractiveWorkflow
         (acc, incident) => {
           const existingEntry = acc.find(
             (entry: { uri: string; incidents: EnhancedIncident[] }) =>
-              entry.uri === incident.uri.replace("file://", ""),
+              entry.uri === fileUriToPath(incident.uri),
           );
           if (existingEntry) {
             existingEntry.incidents.push(incident);
           } else {
             acc.push({
-              uri: incident.uri.replace("file://", ""),
+              uri: fileUriToPath(incident.uri),
               incidents: [incident],
             });
           }

--- a/agentic/tests/utils.test.ts
+++ b/agentic/tests/utils.test.ts
@@ -1,7 +1,7 @@
 import { AIMessage } from "@langchain/core/messages";
 
-import { modelHealthCheck } from "../src/utils";
 import { FakeChatModelWithToolCalls } from "./base";
+import { fileUriToPath, modelHealthCheck } from "../src/utils";
 
 describe("modelHealthCheck", () => {
   it("should have tools enabled for model with tool support", async () => {
@@ -41,5 +41,23 @@ describe("modelHealthCheck", () => {
     const { supportsTools, connected } = await modelHealthCheck(model);
     expect(supportsTools).toBe(false);
     expect(connected).toBe(true);
+  });
+});
+
+describe("fileUriToPath", () => {
+  it("should correctly return linux/darwin paths", () => {
+    const tc1 = "file:///root/coolstore/src/main/webapp/WEB-INF/web.xml";
+    const tc2 = "/root/coolstore/src/main/webapp/WEB-INF/web.xml";
+
+    expect(fileUriToPath(tc1)).toBe("/root/coolstore/src/main/webapp/WEB-INF/web.xml");
+    expect(fileUriToPath(tc2)).toBe("/root/coolstore/src/main/webapp/WEB-INF/web.xml");
+  });
+
+  (process.platform === "win32" ? it : it.skip)("should correctly return windows paths", () => {
+    const tc1 = "file:///C:\\root\\coolstore\\src\\main\\webapp\\WEB-INF\\web.xml";
+    const tc2 = "/C:\\root\\coolstore\\src\\main\\webapp\\WEB-INF\\web.xml";
+
+    expect(fileUriToPath(tc1)).toBe("C:\\root\\coolstore\\src\\main\\webapp\\WEB-INF\\web.xml");
+    expect(fileUriToPath(tc2)).toBe("C:\\root\\coolstore\\src\\main\\webapp\\WEB-INF\\web.xml");
   });
 });


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
