### PR TITLE
:seedling: yell loudly if commands map is not registered correctly

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -232,7 +232,16 @@ class VsCodeExtension {
   }
 
   private registerCommands(): void {
-    registerAllCommands(this.state);
+    try {
+      registerAllCommands(this.state);
+    } catch (error) {
+      console.error("Critical error during command registration:", error);
+      vscode.window.showErrorMessage(
+        `Konveyor extension failed to register commands properly. The extension may not function correctly. Error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      // Re-throw to indicate the extension is not in a good state
+      throw error;
+    }
   }
 
   private registerLanguageProviders(): void {


### PR DESCRIPTION
Related to #556 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during command creation and registration, ensuring users receive clear error messages if issues occur.
  * Enhanced validation to prevent registration of empty or invalid command sets.
  * Added user notifications for errors encountered during command registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->