### PR TITLE
:ghost: minor fix

### DIFF
--- a/agentic/tests/base.ts
+++ b/agentic/tests/base.ts
@@ -3,7 +3,11 @@ import { FakeStreamingChatModel } from "@langchain/core/utils/testing";
 import { type BaseLLMParams } from "@langchain/core/language_models/llms";
 import { type BaseLanguageModelInput } from "@langchain/core/language_models/base";
 import { AIMessageChunk, type AIMessage, type BaseMessage } from "@langchain/core/messages";
-import { type BaseChatModelCallOptions } from "@langchain/core/language_models/chat_models";
+import {
+  type BindToolsInput,
+  type BaseChatModelCallOptions,
+} from "@langchain/core/language_models/chat_models";
+import { Runnable } from "@langchain/core/runnables";
 
 export class FakeChatModelWithToolCalls extends FakeStreamingChatModel {
   private ai_responses: AIMessage[];
@@ -22,6 +26,13 @@ export class FakeChatModelWithToolCalls extends FakeStreamingChatModel {
     }
     super(fields);
     this.ai_responses = fields.responses!;
+  }
+
+  bindTools(
+    tools: BindToolsInput[],
+    kwargs?: Partial<BaseChatModelCallOptions> | undefined,
+  ): Runnable<BaseLanguageModelInput, AIMessageChunk, BaseChatModelCallOptions> {
+    return this;
   }
 
   async invoke(


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new method for binding tools in the chat model test class, enabling enhanced testing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->