### PR TITLE
:sparkles: Manage profiles UX improvements

### DIFF
--- a/webview-ui/src/components/ProfileManager/ProfileList.tsx
+++ b/webview-ui/src/components/ProfileManager/ProfileList.tsx
@@ -106,6 +106,11 @@ export const ProfileList: React.FC<{
                           key="make-active"
                           onClick={() => onMakeActive(profile.id)}
                           isDisabled={active === profile.id}
+                          description={
+                            active === profile.id
+                              ? "This profile is already active. No action needed."
+                              : ""
+                          }
                         >
                           {active === profile.id ? "Active" : "Make Active"}
                         </DropdownItem>


### PR DESCRIPTION
- The active profile alert now includes a message stating that changes are saved automatically and no action is needed. This should help new users understand that they don't need to click "Make Active" to save their profile, as it's already active and saved by default.

-Also, added helper text for form fields and a label in header to indicate that changes auto-save.

Resolves https://github.com/konveyor/editor-extensions/issues/552