### PR TITLE
:bug: actually fail activation by throwing error

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -291,8 +291,7 @@ let extension: VsCodeExtension | undefined;
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   try {
     if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
-      vscode.window.showErrorMessage("Please open a workspace folder before using this extension.");
-      return;
+      throw new Error("Please open a workspace folder before using this extension.");
     }
 
     const paths = await ensurePaths(context);
@@ -305,6 +304,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     extension = undefined;
     console.error("Failed to activate Konveyor extension:", error);
     vscode.window.showErrorMessage(`Failed to activate Konveyor extension: ${error}`);
+    throw error; // Re-throw to ensure VS Code marks the extension as failed to activate
   }
 }
 


### PR DESCRIPTION
Related to #556 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during extension activation to ensure proper notification and failure marking when no workspace folder is open or when activation errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->