### PR TITLE
:bug: Respect analyze on save config setting

### DIFF
--- a/vscode/src/analysis/runAnalysis.ts
+++ b/vscode/src/analysis/runAnalysis.ts
@@ -11,6 +11,10 @@ export const registerAnalysisTrigger = (
 
   vscode.workspace.onDidChangeTextDocument(
     async (e: vscode.TextDocumentChangeEvent) => {
+      if (!getConfigAnalyzeOnSave()) {
+        return;
+      }
+
       if (e.contentChanges.length > 0) {
         batchedAnalysisTrigger.notifyFileChanges({
           path: e.document.uri,


### PR DESCRIPTION
If analyzeOnSave is not explicitly enabled, do not analyze on file change or file save.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented analysis from running on text document changes when analysis on save is disabled in the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->