### PR TITLE
:bug: Do not show ViolationsCount when analyzing

### DIFF
--- a/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
+++ b/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
@@ -292,13 +292,15 @@ const AnalysisPage: React.FC = () => {
                       <Flex className="header-layout">
                         <FlexItem>
                           <CardTitle>Analysis Results</CardTitle>
-                          <ViolationsCount
-                            violationsCount={violations.length}
-                            incidentsCount={violations.reduce(
-                              (prev, curr) => prev + curr.incidents.length,
-                              0,
-                            )}
-                          />
+                          {!isAnalyzing && (
+                            <ViolationsCount
+                              violationsCount={violations.length}
+                              incidentsCount={violations.reduce(
+                                (prev, curr) => prev + curr.incidents.length,
+                                0,
+                              )}
+                            />
+                          )}
                         </FlexItem>
                       </Flex>
                     </CardHeader>


### PR DESCRIPTION

<img width="516" height="242" alt="image" src="https://github.com/user-attachments/assets/83b28dac-e69b-4a52-b7fa-59115fd1726c" />


Fixes #289 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The violations count is now hidden while analysis is in progress, improving the clarity of the analysis page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->