### PR TITLE
:sparkles: Unified logging in extension

### DIFF
--- a/agentic/tests/tools.test.ts
+++ b/agentic/tests/tools.test.ts
@@ -2,12 +2,19 @@ import * as pathlib from "path";
 
 import { FileSystemTools } from "../src/tools/filesystem";
 import { SimpleInMemoryCache } from "../src/";
+import { format, Logger } from "winston";
+import { Console } from "winston/lib/winston/transports";
 
 describe("searchFilesTool", () => {
   it("should handle nested directories correctly", async () => {
     const fsToolsFactory = new FileSystemTools(
       pathlib.resolve(".", "tests", "test_data", "tools"),
       new SimpleInMemoryCache(),
+      new Logger({
+        level: "debug",
+        format: format.combine(format.timestamp(), format.json()),
+        transports: [new Console()],
+      }),
     );
 
     //TODO (pgaikwad) - do this better

--- a/package-lock.json
+++ b/package-lock.json
@@ -1705,6 +1705,15 @@
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
       "license": "MIT"
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
@@ -1818,6 +1827,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "license": "MIT",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -6483,6 +6503,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -7861,7 +7887,6 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-function": {
@@ -9013,6 +9038,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -9031,12 +9066,47 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -10105,6 +10175,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -11299,6 +11375,12 @@
         }
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/fflate": {
       "version": "0.4.8",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
@@ -11441,6 +11523,12 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/focus-trap": {
       "version": "7.6.2",
@@ -15726,6 +15814,12 @@
       "resolved": "vscode",
       "link": true
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
     "node_modules/langsmith": {
       "version": "0.3.30",
       "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.30.tgz",
@@ -16355,6 +16449,23 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/longest-streak": {
@@ -18223,6 +18334,15 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/onetime": {
@@ -20615,6 +20735,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -21037,6 +21166,21 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
+    },
     "node_modules/simple-wcswidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.0.1.tgz",
@@ -21192,6 +21336,15 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -21261,7 +21414,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -21271,7 +21423,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-argv": {
@@ -22059,6 +22210,12 @@
         "node": "*"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -22255,6 +22412,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/trough": {
@@ -23043,7 +23209,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -23980,6 +24145,99 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/winston": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport-vscode": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/winston-transport-vscode/-/winston-transport-vscode-0.1.0.tgz",
+      "integrity": "sha512-iHJEJP5vinrVxMId+gWN00kUR4haP+VMY5pydB53Ug3ZyXZ0EmWZp46hFJQtFQGP+BnxdCA0UElLjUz8QQPEGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "logform": "^2.6.0",
+        "triple-beam": "^1.4.1",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "winston": ">=3.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -24378,7 +24636,9 @@
         "@types/mustache": "^4.2.5",
         "diff": "^7.0.0",
         "jsesc": "^3.1.0",
-        "mustache": "^4.2.0"
+        "mustache": "^4.2.0",
+        "winston": "^3.17.0",
+        "winston-transport-vscode": "^0.1.0"
       },
       "devDependencies": {
         "@types/diff": "^6.0.0",

--- a/shared/src/types/types.ts
+++ b/shared/src/types/types.ts
@@ -297,3 +297,5 @@ export interface ModifiedFileState {
   modifiedContent: string;
   editType: "inMemory" | "toDisk";
 }
+
+export const KONVEYOR_OUTPUT_CHANNEL_NAME = "Konveyor Editor Extension";

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -460,15 +460,16 @@
         "konveyor.logLevel": {
           "type": "string",
           "enum": [
-            "TRACE",
-            "DEBUG",
-            "INFO",
-            "WARN",
-            "ERROR",
-            "CRITICAL"
+            "error",
+            "warn",
+            "info",
+            "http",
+            "verbose",
+            "debug",
+            "silly"
           ],
-          "default": "DEBUG",
-          "description": "Logging level used for the server binaries",
+          "default": "debug",
+          "description": "Logging level used for the extension",
           "scope": "window",
           "order": 0
         },
@@ -640,12 +641,6 @@
           "description": "Should the analyzer analyze project dependencies?",
           "scope": "window",
           "order": 99
-        },
-        "konveyor.logging.traceMessageConnection": {
-          "type": "boolean",
-          "default": false,
-          "description": "Trace the jsonrpc calls between the extension and the kai server?",
-          "order": 100
         }
       }
     },
@@ -703,6 +698,8 @@
     "@types/mustache": "^4.2.5",
     "diff": "^7.0.0",
     "jsesc": "^3.1.0",
-    "mustache": "^4.2.0"
+    "mustache": "^4.2.0",
+    "winston": "^3.17.0",
+    "winston-transport-vscode": "^0.1.0"
   }
 }

--- a/vscode/src/client/types.ts
+++ b/vscode/src/client/types.ts
@@ -1,36 +1,5 @@
 import * as vscode from "vscode";
 
-export type ServerLogLevels = "TRACE" | "DEBUG" | "INFO" | "WARN" | "ERROR" | "CRITICAL";
-
-export interface ServerCliArguments {
-  /** The initial log level for the server. Default: INFO */
-  logLevel?: ServerLogLevels;
-
-  /** The initial stderr log level for the server. Default: TRACE */
-  stderrLogLevel?: ServerLogLevels;
-
-  /** The initial file log level for the server. Default: DEBUG */
-  fileLogLevel?: ServerLogLevels;
-
-  /** The directory path for log files. Default: "./logs" */
-  logDirPath?: string;
-
-  /** The name of the log file. Default: "./kai-rpc-server.log" */
-  logFileName?: string;
-}
-
-/**
- * Logging configurations on initialization. These match {@link ServerCliArguments} currently
- * but have slightly different uses.
- */
-export interface KaiLogConfig {
-  logLevel?: ServerLogLevels; // defaults to "INFO"
-  stderrLogLevel?: ServerLogLevels; // defaults to "TRACE"
-  fileLogLevel?: ServerLogLevels; // defaults to "DEBUG"
-  logDirPath?: string; // defaults to "./logs"
-  logFileName?: string; // defaults to "./kai_server.log"
-}
-
 export type SupportedModelProviders =
   | "AzureChatOpenAI"
   | "ChatBedrock"
@@ -46,36 +15,6 @@ export interface KaiModelConfig {
   llamaHeader?: boolean;
   llmRetries?: number;
   llmRetryDelay?: number;
-}
-
-/**
- * `initialize` request content as camel case (camelCase and snake_case are both accepted)
- *
- * {@link https://github.com/konveyor/kai/blob/78f31fa609a5b53bf66f334803afa72f3849a7e2/kai/rpc_server/server.py#L61}
- */
-export interface KaiRpcApplicationConfig {
-  processId?: number;
-
-  rootPath: string;
-  modelProvider: KaiModelConfig;
-
-  logConfig: KaiLogConfig;
-
-  demoMode?: boolean; // defaults to `false`
-  cacheDir?: string; // defaults to `None`
-  enableReflection?: boolean; // defaults to `true`
-  traceEnabled?: boolean; // defaults to `false`
-
-  analyzerLspLspPath: string;
-  analyzerLspRpcPath: string;
-  analyzerLspRulesPaths: string[];
-  analyzerLspJavaBundlePaths: string[];
-  analyzerLspDepLabelsPath?: string; // defaults to `None`
-  analyzerLspExcludedPaths: string[];
-  analyzerLspLabelSelector: string;
-
-  // TODO: Do we need to include `fernFlowerPath` to support the java decompiler?
-  // analyzerLspFernFlowerPath?: string;
 }
 
 export interface FileChange {

--- a/vscode/src/extensionState.ts
+++ b/vscode/src/extensionState.ts
@@ -13,6 +13,7 @@ import { DiagnosticTaskManager } from "./taskManager/taskManager";
 import { MemFS } from "./data/fileSystemProvider";
 import { KonveyorFileModel } from "./diffView/fileModel";
 import { EventEmitter } from "events";
+import winston from "winston";
 
 export interface ExtensionState {
   analyzerClient: AnalyzerClient;
@@ -46,4 +47,5 @@ export interface ExtensionState {
   isWaitingForUserInteraction: boolean;
   lastMessageId: string;
   currentTaskManagerIterations: number;
+  logger: winston.Logger;
 }

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -2,7 +2,6 @@ import * as vscode from "vscode";
 import * as yaml from "js-yaml";
 import * as fs from "fs";
 import deepEqual from "fast-deep-equal";
-import { ServerLogLevels } from "../client/types";
 import { KONVEYOR_CONFIG_KEY } from "./constants";
 import { ExtensionState } from "../extensionState";
 import {
@@ -35,10 +34,7 @@ export const getConfigSolutionServerUrl = (): string =>
   getConfigValue<string>("solutionServer.url") || "http://localhost:8000";
 export const getConfigSolutionServerEnabled = (): boolean =>
   getConfigValue<boolean>("solutionServer.enabled") ?? false;
-export const getConfigLogLevel = (): ServerLogLevels =>
-  getConfigValue<ServerLogLevels>("logLevel") || "DEBUG";
-export const getConfigLoggingTraceMessageConnection = (): boolean =>
-  getConfigValue<boolean>("logging.traceMessageConnection") ?? false;
+export const getConfigLogLevel = (): string => getConfigValue<string>("logLevel") || "debug";
 export const getConfigIncidentLimit = (): number =>
   getConfigValue<number>("analysis.incidentLimit") || 10000;
 export const getConfigContextLines = (): number =>

--- a/vscode/src/utilities/logger.ts
+++ b/vscode/src/utilities/logger.ts
@@ -1,0 +1,50 @@
+import * as winston from "winston";
+import * as vscode from "vscode";
+import * as path from "path";
+import { ExtensionPaths } from "../paths";
+import { OutputChannelTransport } from "winston-transport-vscode";
+import { getConfigLogLevel } from "./configuration";
+import { KONVEYOR_OUTPUT_CHANNEL_NAME } from "@editor-extensions/shared";
+
+// Create logger instance
+export function createLogger(paths: ExtensionPaths): winston.Logger {
+  // Create or get the output channel
+  const outputChannel = vscode.window.createOutputChannel(KONVEYOR_OUTPUT_CHANNEL_NAME, "log");
+
+  // Create log file path
+  const logFile = path.join(paths.serverLogs.fsPath, "konveyor-extension.log");
+
+  const logger = winston.createLogger({
+    level: getConfigLogLevel(),
+    format: winston.format.combine(
+      winston.format.timestamp(),
+      winston.format.errors({ stack: true }),
+      winston.format.json(),
+    ),
+    transports: [
+      // File transport
+      new winston.transports.File({
+        filename: logFile,
+        maxsize: 10 * 1024 * 1024, // 10MB
+        maxFiles: 3,
+      }),
+      // VS Code output channel transport
+      new OutputChannelTransport({
+        outputChannel,
+        level: "warn",
+      }),
+    ],
+  });
+
+  // Add console transport in development mode
+  if (process.env.NODE_ENV === "development") {
+    logger.add(
+      new winston.transports.Console({
+        level: "silly",
+      }),
+    );
+  }
+
+  logger.info("Logger created");
+  return logger;
+}


### PR DESCRIPTION
With this change we can, throughout the extension codebase, use the logger to write to both the vscode output console AND a file in konveyor-logs in such a way that everything from commands, interactive workflows, interactions with the solution server, and even analyzer queries are logged as they happen.

Resolves #542 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a centralized, structured logging system across the extension using Winston, with logs written to both files and the VS Code output channel.
  * Added a new output channel name constant for improved log visibility within the editor.

* **Refactor**
  * Replaced all direct console logging with Winston-based structured logging in both extension and agent components.
  * Updated constructors and interfaces to accept and use a logger instance for consistent logging.

* **Chores**
  * Updated configuration options for logging levels and removed deprecated logging settings.
  * Added new dependencies to support structured logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->