### PR TITLE
:seedling: fail hard if collect-assets fails

### DIFF
--- a/scripts/collect-assets.js
+++ b/scripts/collect-assets.js
@@ -156,10 +156,15 @@ const actions = [
 
 // Run the queued actions
 const meta = [];
-for (const action of actions) {
-  if (action && typeof action === "function") {
-    const actionMeta = await action();
-    meta.push(actionMeta);
+try {
+  for (const action of actions) {
+    if (action && typeof action === "function") {
+      const actionMeta = await action();
+      meta.push(actionMeta);
+    }
   }
+  writeJson(join(DOWNLOAD_DIR, "collect-assets-meta.json"), { cwd, actions: meta }, { spaces: 2 });
+} catch (error) {
+  console.error("Asset collection failed:", error);
+  process.exit(1);
 }
-writeJson(join(DOWNLOAD_DIR, "collect-assets-meta.json"), { cwd, actions: meta }, { spaces: 2 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during asset collection to ensure that errors are logged and the process exits if any step fails. Metadata is now only written if all actions complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->