### PR TITLE
:bug: Fix: Search fails to display existing analysis incidents

### DIFF
--- a/webview-ui/src/components/ViolationIncidentsList.tsx
+++ b/webview-ui/src/components/ViolationIncidentsList.tsx
@@ -153,9 +153,11 @@ const ViolationIncidentsList = ({
       filtered = filtered.filter(
         (incident) =>
           incident.message.toLowerCase().includes(lowercaseSearchTerm) ||
-          incident.uri.toLowerCase().includes(lowercaseSearchTerm),
+          incident.uri.toLowerCase().includes(lowercaseSearchTerm)||
+          incident.violation_description?.toLowerCase().includes(lowercaseSearchTerm),
       );
     }
+
 
     if (filters.category.length > 0) {
       filtered = filtered.filter((incident) =>


### PR DESCRIPTION
Fixes #594

This PR addresses the issue where analysis results were not appearing in search when the search term matched only the incident's detailed "violation description." The search filter has been updated to include this field, ensuring all relevant incidents are displayed.

