### PR TITLE
:bug: Remove duplicate selection state for interaction messages

### DIFF
--- a/webview-ui/src/components/ResolutionsPage/ReceivedMessage.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ReceivedMessage.tsx
@@ -68,7 +68,7 @@ export const ReceivedMessage: React.FC<ReceivedMessageProps> = ({
           handleQuickResponse(response.id, response.messageToken);
         },
         isDisabled: response.isDisabled || isProcessing || selectedResponse !== null,
-        content: selectedResponse === response.id ? `✓ ${response.content}` : response.content,
+        content: response.content,
       }))}
       extraContent={
         extraContent


### PR DESCRIPTION
- The yes/no buttons had some duplicate selection state logic. Leave the selection state to the underlying PF component. Use selectedResponse state for disabled, but let click handler indicate the selection.
<img width="704" height="166" alt="Screenshot 2025-07-21 at 9 57 31 PM" src="https://github.com/user-attachments/assets/53450813-9ab7-47e7-9ee2-c00e95802929" />
