### PR TITLE
:bug: Missing css variables for diff view

### DIFF
--- a/webview-ui/src/components/ResolutionsPage/ModifiedFile/HunkSelectionInterface.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ModifiedFile/HunkSelectionInterface.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Button, Flex, FlexItem, Badge } from "@patternfly/react-core";
 import { CheckCircleIcon, TimesCircleIcon } from "@patternfly/react-icons";
 import { DiffLegend } from "./DiffLegend";
+import "./modifiedFileMessage.css";
 import { DiffLinesRenderer } from "./DiffLinesRenderer";
 
 interface ParsedHunk {

--- a/webview-ui/src/components/ResolutionsPage/ModifiedFile/SingleHunkDisplay.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ModifiedFile/SingleHunkDisplay.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { DiffLegend } from "./DiffLegend";
 import { DiffLinesRenderer } from "./DiffLinesRenderer";
 import { EnhancedDiffRenderer } from "./EnhancedDiffRenderer";
+import "./modifiedFileMessage.css";
 
 interface SingleHunkDisplayProps {
   diff: string;

--- a/webview-ui/src/components/ResolutionsPage/ModifiedFile/modifiedFileMessage.css
+++ b/webview-ui/src/components/ResolutionsPage/ModifiedFile/modifiedFileMessage.css
@@ -579,7 +579,13 @@
 }
 
 .legend-color.context {
-  background-color: var(--pf-global--Color--200);
+  background-color: var(--pf-global--BackgroundColor--100);
+  border: 2px solid var(--pf-global--BorderColor--300);
+}
+
+.vscode-dark .legend-color.context {
+  background-color: var(--pf-global--BackgroundColor--dark-100);
+  border-color: var(--pf-global--BorderColor--dark-300);
 }
 
 /* Diff line styling */

--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -64,6 +64,27 @@ body {
   --pf-v6-c-page__main-container--BackgroundColor: var(--vscode-editor-background) !important;
   --pf-t--global--text--color--link--100: #3794ff;
   --pf-t--global--color--status--danger--100: #f48771;
+
+  /* PatternFly global background colors */
+  --pf-global--BackgroundColor--100: #f5f5f5;
+  --pf-global--BackgroundColor--200: #e5e5e5;
+  --pf-global--BackgroundColor--dark-100: #2d2d2d;
+  --pf-global--BackgroundColor--dark-200: #1e1e1e;
+  --pf-global--BackgroundColor--dark-150: #262626;
+
+  /* PatternFly global border colors */
+  --pf-global--BorderColor--100: #d1d1d1;
+  --pf-global--BorderColor--200: #b8bbbe;
+  --pf-global--BorderColor--300: #8b8d8f;
+  --pf-global--BorderColor--dark-100: #6a6a6a;
+  --pf-global--BorderColor--dark-200: #525252;
+  --pf-global--BorderColor--dark-300: #3c3f41;
+
+  /* PatternFly global text colors */
+  --pf-global--Color--100: #151515;
+  --pf-global--Color--200: #6a6e73;
+  --pf-global--Color--dark-100: #f0f0f0;
+  --pf-global--Color--dark-200: #b8bbbe;
 }
 
 #root {


### PR DESCRIPTION
Address missing css variables. This was causing the context item in the diff legend to appear blank. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the appearance of context legend elements by updating background and border colors for both light and dark themes.
  * Enhanced theme support by adding new global color variables for backgrounds, borders, and text.
  * Updated styling imports to ensure consistent visual presentation across relevant components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->