### PR TITLE
:bug: Quiet logger in dev mode

### DIFF
--- a/vscode/src/utilities/logger.ts
+++ b/vscode/src/utilities/logger.ts
@@ -2,7 +2,6 @@ import * as winston from "winston";
 import * as vscode from "vscode";
 import * as path from "path";
 import { ExtensionPaths } from "../paths";
-import { OutputChannelTransport } from "winston-transport-vscode";
 import { getConfigLogLevel } from "./configuration";
 import { KONVEYOR_OUTPUT_CHANNEL_NAME } from "@editor-extensions/shared";
 
@@ -22,28 +21,28 @@ export function createLogger(paths: ExtensionPaths): winston.Logger {
       winston.format.json(),
     ),
     transports: [
-      // File transport
+      // File transport - keep JSON format for file logging
       new winston.transports.File({
         filename: logFile,
         maxsize: 10 * 1024 * 1024, // 10MB
         maxFiles: 3,
       }),
-      // VS Code output channel transport
-      new OutputChannelTransport({
-        outputChannel,
-        level: "warn",
-      }),
+      // VS Code output channel transport - DISABLED to avoid JSON spam
+      // new OutputChannelTransport({
+      //   outputChannel,
+      //   level: "warn",
+      // }),
     ],
   });
 
-  // Add console transport in development mode
-  if (process.env.NODE_ENV === "development") {
-    logger.add(
-      new winston.transports.Console({
-        level: "silly",
-      }),
-    );
-  }
+  // Console transport in development mode - DISABLED to avoid console spam
+  // if (process.env.NODE_ENV === "development") {
+  //   logger.add(
+  //     new winston.transports.Console({
+  //       level: "silly",
+  //     }),
+  //   );
+  // }
 
   logger.info("Logger created");
   return logger;


### PR DESCRIPTION
Need to figure out how to turn off verbose logging in dev mode 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Disabled logging to the VS Code output channel and console to reduce unnecessary log output. Logging to file with JSON formatting remains active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->