### PR TITLE
:sparkles: Allow sidebar unified analysis / resolution view

### DIFF
--- a/shared/src/types/types.ts
+++ b/shared/src/types/types.ts
@@ -1,7 +1,7 @@
 import { Uri } from "vscode";
 import { SolutionEffortLevel } from "../effort";
 
-export type WebviewType = "sidebar" | "resolution" | "profiles";
+export type WebviewType = "sidebar" | "resolution" | "profiles" | "unified";
 
 export interface Incident {
   uri: string;

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -73,7 +73,19 @@
       },
       {
         "command": "konveyor.showResolutionPanel",
-        "title": "Open Konveyor Resolution View",
+        "title": "Open Konveyor AI Assistant (Side Panel)",
+        "category": "Konveyor",
+        "icon": "$(beaker)"
+      },
+      {
+        "command": "konveyor.showUnifiedView",
+        "title": "Open Konveyor AI Assistant",
+        "category": "Konveyor",
+        "icon": "$(robot)"
+      },
+      {
+        "command": "konveyor.showResolutionPanelAsTab",
+        "title": "Open Konveyor Resolution View in Tab",
         "category": "Konveyor",
         "icon": "$(beaker)"
       },
@@ -296,6 +308,12 @@
         {
           "id": "konveyor.diffView",
           "name": "Konveyor Resolutions"
+        },
+        {
+          "id": "konveyor.unifiedView",
+          "name": "Konveyor AI Assistant",
+          "type": "webview",
+          "when": "konveyor:hasResolutionData"
         }
       ]
     },
@@ -307,7 +325,7 @@
           "when": "view == konveyor.issueView"
         },
         {
-          "command": "konveyor.showResolutionPanel",
+          "command": "konveyor.showResolutionPanelAsTab",
           "group": "navigation@2",
           "when": "view == konveyor.issueView"
         },

--- a/vscode/src/KonveyorGUIWebviewViewProvider.ts
+++ b/vscode/src/KonveyorGUIWebviewViewProvider.ts
@@ -23,6 +23,7 @@ const DEV_SERVER_ROOT = "http://localhost:5173/out/webview";
 export class KonveyorGUIWebviewViewProvider implements WebviewViewProvider {
   public static readonly SIDEBAR_VIEW_TYPE = "konveyor.konveyorAnalysisView";
   public static readonly RESOLUTION_VIEW_TYPE = "konveyor.konveyorResolutionView";
+  public static readonly UNIFIED_VIEW_TYPE = "konveyor.unifiedView";
   public static readonly PROFILES_VIEW_TYPE = "konveyor.konveyorProfilesView";
 
   private static instance: KonveyorGUIWebviewViewProvider;
@@ -66,6 +67,11 @@ export class KonveyorGUIWebviewViewProvider implements WebviewViewProvider {
           return {
             viewType: KonveyorGUIWebviewViewProvider.RESOLUTION_VIEW_TYPE,
             title: "Resolution Details",
+          };
+        case "unified":
+          return {
+            viewType: KonveyorGUIWebviewViewProvider.UNIFIED_VIEW_TYPE,
+            title: "Konveyor AI Assistant",
           };
         case "profiles":
           return {

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -645,6 +645,15 @@ const commandsMap: (
     "konveyor.discardAll": async () => discardAll(state),
     "konveyor.discardFile": async (item: FileItem | Uri) => discardFile(item, state),
     "konveyor.showResolutionPanel": () => {
+      const unifiedProvider = state.webviewProviders?.get("unified");
+      if (unifiedProvider) {
+        // For unified view, focus the view - it will auto-switch to resolution tab if data is available
+        commands.executeCommand("konveyor.unifiedView.focus");
+      } else {
+        logger.error("Unified view provider not found");
+      }
+    },
+    "konveyor.showResolutionPanelAsTab": () => {
       const resolutionProvider = state.webviewProviders?.get("resolution");
       resolutionProvider?.showWebviewPanel();
     },
@@ -715,6 +724,14 @@ const commandsMap: (
       window.showInformationMessage(
         `getSolution parameters updated: max_priority=${maxPriority}, max_depth=${maxDepth}, max_iterations=${maxIterations}`,
       );
+    },
+    "konveyor.showUnifiedView": () => {
+      const unifiedProvider = state.webviewProviders?.get("unified");
+      if (unifiedProvider) {
+        commands.executeCommand("konveyor.unifiedView.focus");
+      } else {
+        logger.error("Unified view provider not found");
+      }
     },
   };
 };

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import { viewType } from "./utils/vscode";
 import AnalysisPage from "./components/AnalysisPage/AnalysisPage";
 import ResolutionPage from "./components/ResolutionsPage/ResolutionsPage";
+import UnifiedPage from "./components/UnifiedPage/UnifiedPage";
 import { WebviewType } from "@editor-extensions/shared";
 import { ExtensionStateProvider } from "./context/ExtensionStateContext";
 import { ProfileManagerPage } from "./components/ProfileManager/ProfileManagerPage";
@@ -20,6 +21,7 @@ const App: React.FC = () => {
       <ExtensionStateProvider>
         {currentView === "sidebar" && <AnalysisPage />}
         {currentView === "resolution" && <ResolutionPage />}
+        {currentView === "unified" && <UnifiedPage />}
         {currentView === "profiles" && <ProfileManagerPage />}
       </ExtensionStateProvider>
     </div>

--- a/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
+++ b/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
@@ -57,7 +57,11 @@ import { ProfileSelector } from "../ProfileSelector/ProfileSelector";
 import ProgressIndicator from "../ProgressIndicator";
 import { Incident } from "@editor-extensions/shared";
 
-const AnalysisPage: React.FC = () => {
+interface AnalysisPageProps {
+  hideControls?: boolean; // Hide masthead controls when in unified mode
+}
+
+const AnalysisPage: React.FC<AnalysisPageProps> = ({ hideControls = false }) => {
   const { state, dispatch } = useExtensionStateContext();
 
   const {
@@ -129,33 +133,35 @@ const AnalysisPage: React.FC = () => {
               </PageSidebar>
             }
             masthead={
-              <Masthead>
-                <MastheadMain />
-                <MastheadContent>
-                  <Toolbar>
-                    <ToolbarContent>
-                      <ToolbarGroup align={{ default: "alignEnd" }}>
-                        <ToolbarItem>
-                          <ServerStatusToggle
-                            isRunning={serverRunning}
-                            isStarting={isStartingServer}
-                            isInitializing={isInitializingServer}
-                            onToggle={handleServerToggle}
-                            hasWarning={configInvalid}
-                          />
-                        </ToolbarItem>
-                        <ToolbarItem>
-                          <ConfigButton
-                            onClick={() => setIsConfigOpen(true)}
-                            hasWarning={configErrors.length > 0}
-                            warningMessage="Please review your configuration before running analysis."
-                          />
-                        </ToolbarItem>
-                      </ToolbarGroup>
-                    </ToolbarContent>
-                  </Toolbar>
-                </MastheadContent>
-              </Masthead>
+              !hideControls ? (
+                <Masthead>
+                  <MastheadMain />
+                  <MastheadContent>
+                    <Toolbar>
+                      <ToolbarContent>
+                        <ToolbarGroup align={{ default: "alignEnd" }}>
+                          <ToolbarItem>
+                            <ServerStatusToggle
+                              isRunning={serverRunning}
+                              isStarting={isStartingServer}
+                              isInitializing={isInitializingServer}
+                              onToggle={handleServerToggle}
+                              hasWarning={configInvalid}
+                            />
+                          </ToolbarItem>
+                          <ToolbarItem>
+                            <ConfigButton
+                              onClick={() => setIsConfigOpen(true)}
+                              hasWarning={configErrors.length > 0}
+                              warningMessage="Please review your configuration before running analysis."
+                            />
+                          </ToolbarItem>
+                        </ToolbarGroup>
+                      </ToolbarContent>
+                    </Toolbar>
+                  </MastheadContent>
+                </Masthead>
+              ) : undefined
             }
           >
             {!selectedProfile && (

--- a/webview-ui/src/components/ResolutionsPage/ResolutionsPage.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ResolutionsPage.tsx
@@ -193,7 +193,7 @@ const UserRequestMessages: React.FC<{
   );
 };
 
-const ResolutionPage: React.FC = () => {
+const ResolutionPage: React.FC<{ hideTitle?: boolean }> = ({ hideTitle = false }) => {
   const { state, dispatch } = useExtensionStateContext();
   const { solutionScope } = state;
 
@@ -406,15 +406,17 @@ const ResolutionPage: React.FC = () => {
         </PageSidebar>
       }
     >
-      <PageSection>
-        <Title headingLevel="h1" size="2xl" style={{ display: "flex", alignItems: "center" }}>
-          Kai Results
-          {isFetchingSolution && <LoadingIndicator />}
-          {!isFetchingSolution && (
-            <CheckCircleIcon style={{ marginLeft: "10px", color: "green" }} />
-          )}
-        </Title>
-      </PageSection>
+      {!hideTitle && (
+        <PageSection>
+          <Title headingLevel="h1" size="2xl" style={{ display: "flex", alignItems: "center" }}>
+            Kai Results
+            {isFetchingSolution && <LoadingIndicator />}
+            {!isFetchingSolution && (
+              <CheckCircleIcon style={{ marginLeft: "10px", color: "green" }} />
+            )}
+          </Title>
+        </PageSection>
+      )}
       <Chatbot displayMode={ChatbotDisplayMode.embedded}>
         <ChatbotContent>
           <MessageBox ref={messageBoxRef} style={{ paddingBottom: "2rem" }}>

--- a/webview-ui/src/components/ServerStatusToggle/ServerStatusToggle.tsx
+++ b/webview-ui/src/components/ServerStatusToggle/ServerStatusToggle.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Button, Label, Spinner } from "@patternfly/react-core";
-import { OnIcon } from "@patternfly/react-icons";
+import { Button, Label, Spinner, Tooltip } from "@patternfly/react-core";
+import { OnIcon, OffIcon } from "@patternfly/react-icons";
 import "./styles.css";
 
 interface ServerStatusToggleProps {
@@ -18,30 +18,70 @@ export function ServerStatusToggle({
   hasWarning,
   onToggle,
 }: ServerStatusToggleProps) {
+  const getButtonContent = () => {
+    if (isStarting || isInitializing) {
+      return (
+        <>
+          <Spinner size="sm" aria-label="Loading spinner" className="header-spinner" />
+          <span className="button-text">
+            {isStarting ? "Starting..." : "Initializing..."}
+          </span>
+        </>
+      );
+    }
+    
+    return (
+      <>
+        {isRunning ? <OnIcon className="button-icon" /> : <OffIcon className="button-icon" />}
+        <span className="button-text">
+          {isRunning ? "Stop Server" : "Start Server"}
+        </span>
+        <span className="button-text-short">
+          {isRunning ? "Stop" : "Start"}
+        </span>
+      </>
+    );
+  };
+
+  const getTooltipContent = () => {
+    if (hasWarning) {
+      return "Cannot start server: Check your configuration";
+    }
+    if (isStarting) {
+      return "Server is starting...";
+    }
+    if (isInitializing) {
+      return "Server is initializing...";
+    }
+    return isRunning ? "Click to stop the analyzer server" : "Click to start the analyzer server";
+  };
+
   return (
-    <div>
-      <div className="server-status-wrapper">
-        {isStarting ? (
-          <Spinner size="sm" aria-label="Loading spinner" className="server-status-spinner" />
-        ) : isInitializing ? (
-          <Spinner size="sm" aria-label="Loading spinner" className="server-status-spinner" />
-        ) : (
-          <Button
-            variant="control"
-            size="sm"
-            icon={<OnIcon />}
-            onClick={onToggle}
-            isDisabled={isStarting || isInitializing || hasWarning}
-            className="server-action-button"
-          >
-            {isStarting || isInitializing ? "" : isRunning ? "Stop" : "Start"}
-          </Button>
-        )}
-        <p>Server Status</p>
-        <Label color={isRunning ? "green" : "red"} isCompact>
-          {isRunning ? "Running" : "Stopped"}
-        </Label>
-      </div>
+    <div className="server-status-header-wrapper">
+      <Tooltip content={getTooltipContent()}>
+        <Button
+          variant={isRunning ? "secondary" : "primary"}
+          size="sm"
+          onClick={onToggle}
+          isDisabled={isStarting || isInitializing || hasWarning}
+          className={`header-server-button ${isRunning ? 'server-running' : 'server-stopped'}`}
+        >
+          {getButtonContent()}
+        </Button>
+      </Tooltip>
+      
+      <Label 
+        color={isRunning ? "green" : hasWarning ? "orange" : "red"} 
+        isCompact 
+        className="server-status-label"
+      >
+        <span className="status-text-full">
+          {isRunning ? "Running" : hasWarning ? "Config Error" : "Stopped"}
+        </span>
+        <span className="status-text-short">
+          {isRunning ? "On" : hasWarning ? "Err" : "Off"}
+        </span>
+      </Label>
     </div>
   );
 }

--- a/webview-ui/src/components/ServerStatusToggle/styles.css
+++ b/webview-ui/src/components/ServerStatusToggle/styles.css
@@ -5,3 +5,108 @@
   gap: 12px;
   padding: 8px 0px;
 }
+
+.server-status-header-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.header-server-button {
+  min-width: 120px;
+  justify-content: flex-start;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.header-server-button.server-running {
+  border-color: var(--pf-v6-global--success-color--100);
+}
+
+.header-server-button.server-stopped {
+  border-color: var(--pf-v6-global--danger-color--100);
+}
+
+.header-spinner {
+  display: inline-block;
+}
+
+.button-icon {
+  flex-shrink: 0;
+}
+
+.button-text {
+  display: inline;
+}
+
+.button-text-short {
+  display: none;
+}
+
+.server-status-label {
+  font-size: 0.75rem;
+  margin-left: 4px;
+}
+
+.status-text-full {
+  display: inline;
+}
+
+.status-text-short {
+  display: none;
+}
+
+/* Responsive behavior */
+@media (max-width: 600px) {
+  .header-server-button {
+    min-width: 80px;
+    gap: 0.25rem;
+  }
+
+  .server-status-header-wrapper {
+    gap: 4px;
+  }
+}
+
+@media (max-width: 480px) {
+  .button-text {
+    display: none;
+  }
+
+  .button-text-short {
+    display: inline;
+  }
+
+  .status-text-full {
+    display: none;
+  }
+
+  .status-text-short {
+    display: inline;
+  }
+
+  .header-server-button {
+    min-width: 60px;
+  }
+}
+
+@media (max-width: 320px) {
+  .server-status-label {
+    display: none;
+  }
+
+  .header-server-button {
+    min-width: 40px;
+    padding: 0.25rem 0.5rem;
+  }
+
+  .button-text-short {
+    display: none;
+  }
+
+  .header-server-button {
+    justify-content: center;
+  }
+}

--- a/webview-ui/src/components/UnifiedPage/UnifiedPage.css
+++ b/webview-ui/src/components/UnifiedPage/UnifiedPage.css
@@ -1,0 +1,125 @@
+/* Responsive header styles */
+.unified-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.responsive-tabs {
+  width: 100%;
+  min-width: 0;
+}
+
+.responsive-tab-title {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.tab-icon {
+  flex-shrink: 0;
+  font-size: 0.875rem;
+}
+
+.tab-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.processing-indicator {
+  margin-left: 0.25rem;
+  color: #f0ad4e;
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.data-indicator {
+  margin-left: 0.25rem;
+  background-color: #06c;
+  color: white;
+  border-radius: 50%;
+  width: 6px;
+  height: 6px;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.analysis-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.config-button-item {
+  flex-shrink: 0;
+}
+
+/* Mobile and very narrow widths */
+@media (max-width: 480px) {
+  .unified-title {
+    display: none !important;
+  }
+
+  .tab-text {
+    display: none;
+  }
+
+  .processing-indicator {
+    display: none;
+  }
+
+  .responsive-tab-title {
+    justify-content: center;
+    min-width: 32px;
+  }
+
+  .config-button-item {
+    display: none;
+  }
+}
+
+/* Small sidebar widths */
+@media (max-width: 600px) {
+  .unified-title {
+    font-size: 1rem !important;
+  }
+
+  .tab-text {
+    font-size: 0.875rem;
+  }
+
+  .processing-indicator {
+    font-size: 0.625rem;
+  }
+
+  .analysis-controls {
+    gap: 0.25rem;
+  }
+}
+
+/* Medium sidebar widths */
+@media (max-width: 800px) {
+  .processing-indicator {
+    display: none;
+  }
+}
+
+/* Very narrow - icon only mode */
+@media (max-width: 320px) {
+  .responsive-tabs .pf-v6-c-tabs__list {
+    justify-content: center;
+  }
+
+  .responsive-tabs .pf-v6-c-tabs__item {
+    min-width: 40px;
+  }
+
+  .analysis-controls {
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+}

--- a/webview-ui/src/components/UnifiedPage/UnifiedPage.tsx
+++ b/webview-ui/src/components/UnifiedPage/UnifiedPage.tsx
@@ -1,0 +1,221 @@
+import "./UnifiedPage.css";
+import React, { useState, useMemo } from "react";
+import { 
+  Page, 
+  PageSection, 
+  PageSidebar, 
+  PageSidebarBody, 
+  Title,
+  Tabs,
+  Tab,
+  TabTitleText,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+  Masthead,
+  MastheadMain,
+  MastheadContent,
+  Drawer,
+  DrawerContent,
+  DrawerContentBody
+} from "@patternfly/react-core";
+import { SearchIcon, FlaskIcon } from "@patternfly/react-icons";
+import AnalysisPage from "../AnalysisPage/AnalysisPage";
+import ResolutionPage from "../ResolutionsPage/ResolutionsPage";
+import { ServerStatusToggle } from "../ServerStatusToggle/ServerStatusToggle";
+import { ConfigButton } from "../AnalysisPage/ConfigButton/ConfigButton";
+import { WalkthroughDrawer } from "../AnalysisPage/WalkthroughDrawer/WalkthroughDrawer";
+import { useExtensionStateContext } from "../../context/ExtensionStateContext";
+import { 
+  startServer, 
+  stopServer
+} from "../../hooks/actions";
+
+const UnifiedPage: React.FC = () => {
+  const { state, dispatch } = useExtensionStateContext();
+  const [activeTab, setActiveTab] = useState<string>("analysis");
+  const [hasAutoSwitched, setHasAutoSwitched] = useState<boolean>(false);
+  const [isConfigOpen, setIsConfigOpen] = useState(false);
+  const drawerRef = React.useRef<HTMLDivElement>(null);
+
+  const {
+    serverState,
+    isStartingServer,
+    isInitializingServer,
+    isAnalyzing,
+    configErrors,
+    profiles,
+    activeProfileId
+  } = state;
+
+  const serverRunning = serverState === "running";
+  
+  // Check if there's resolution data to show the resolution tab
+  const hasResolutionData = useMemo(() => {
+    return (
+      state.solutionState !== "none" ||
+      (Array.isArray(state.chatMessages) && state.chatMessages.length > 0) ||
+      (Array.isArray(state.localChanges) && state.localChanges.length > 0)
+    );
+  }, [state.solutionState, state.chatMessages, state.localChanges]);
+
+  // Check if resolution is actively processing
+  const isResolutionActive = useMemo(() => {
+    return state.isFetchingSolution;
+  }, [state.isFetchingSolution]);
+
+  // Auto-switch to resolution tab when data becomes available (only once)
+  React.useEffect(() => {
+    if (hasResolutionData && activeTab === "analysis" && !hasAutoSwitched) {
+      setActiveTab("resolution");
+      setHasAutoSwitched(true);
+    }
+    // Reset auto-switch flag when resolution data is cleared
+    if (!hasResolutionData) {
+      setHasAutoSwitched(false);
+    }
+  }, [hasResolutionData, activeTab, hasAutoSwitched]);
+
+  const handleTabClick = (event: React.MouseEvent, tabIndex: string | number) => {
+    // Allow manual switching to any tab regardless of data state
+    setActiveTab(String(tabIndex));
+  };
+
+  const handleServerToggle = () => dispatch(serverRunning ? stopServer() : startServer());
+
+  const selectedProfile = profiles.find((p) => p.id === activeProfileId);
+  const configInvalid =
+    !selectedProfile?.labelSelector?.trim() ||
+    (!selectedProfile.useDefaultRules && (selectedProfile.customRules?.length ?? 0) === 0);
+
+  const panelContent = (
+    <WalkthroughDrawer
+      isOpen={isConfigOpen}
+      onClose={() => setIsConfigOpen(false)}
+      drawerRef={drawerRef}
+    />
+  );
+
+  return (
+    <Drawer isExpanded={isConfigOpen}>
+      <DrawerContent panelContent={panelContent}>
+        <DrawerContentBody>
+          <Page
+            sidebar={
+              <PageSidebar isSidebarOpen={false}>
+                <PageSidebarBody />
+              </PageSidebar>
+            }
+            masthead={
+              <Masthead style={{ position: "sticky", top: 0, zIndex: 1000 }}>
+                <MastheadMain>
+                  <Title 
+                    headingLevel="h1" 
+                    size="lg" 
+                    style={{ 
+                      color: "white",
+                      fontSize: "1.2rem",
+                      display: "none" // Hide on small screens, show tabs instead
+                    }}
+                    className="unified-title"
+                  >
+                    Konveyor AI
+                  </Title>
+                </MastheadMain>
+                <MastheadContent>
+                  <Toolbar style={{ padding: "0 0.5rem" }}>
+                    <ToolbarContent>
+                      <ToolbarGroup style={{ flex: 1, minWidth: 0 }}>
+                        <ToolbarItem style={{ flex: 1, minWidth: 0 }}>
+                          <Tabs
+                            activeKey={activeTab}
+                            onSelect={handleTabClick}
+                            aria-label="Konveyor AI Assistant tabs"
+                            variant="secondary"
+                            className="responsive-tabs"
+                          >
+                            <Tab
+                              eventKey="analysis"
+                              title={
+                                <TabTitleText className="responsive-tab-title">
+                                  <SearchIcon className="tab-icon" />
+                                  <span className="tab-text">Analysis</span>
+                                  {isResolutionActive && activeTab === "analysis" && (
+                                    <span 
+                                      className="processing-indicator"
+                                      title="Resolution processing in background"
+                                    >
+                                      (Processing...)
+                                    </span>
+                                  )}
+                                </TabTitleText>
+                              }
+                              aria-label="Analysis tab"
+                            />
+                            
+                            <Tab
+                              eventKey="resolution"
+                              title={
+                                <TabTitleText className="responsive-tab-title">
+                                  <FlaskIcon className="tab-icon" />
+                                  <span className="tab-text">Resolution</span>
+                                  {hasResolutionData && (
+                                    <span className="data-indicator" />
+                                  )}
+                                </TabTitleText>
+                              }
+                              aria-label="Resolution tab"
+                            />
+                          </Tabs>
+                        </ToolbarItem>
+                      </ToolbarGroup>
+                      
+                      {/* Analysis Controls - only show when on analysis tab */}
+                      {activeTab === "analysis" && (
+                        <ToolbarGroup className="analysis-controls">
+                          <ToolbarItem>
+                            <ServerStatusToggle
+                              isRunning={serverRunning}
+                              isStarting={isStartingServer}
+                              isInitializing={isInitializingServer}
+                              onToggle={handleServerToggle}
+                              hasWarning={configInvalid}
+                            />
+                          </ToolbarItem>
+                          <ToolbarItem className="config-button-item">
+                            <ConfigButton
+                              onClick={() => setIsConfigOpen(true)}
+                              hasWarning={configErrors.length > 0}
+                              warningMessage="Please review your configuration before running analysis."
+                            />
+                          </ToolbarItem>
+                        </ToolbarGroup>
+                      )}
+                    </ToolbarContent>
+                  </Toolbar>
+                </MastheadContent>
+              </Masthead>
+            }
+          >
+            <PageSection style={{ paddingTop: 0 }}>
+              {activeTab === "analysis" && (
+                <div style={{ marginTop: "1rem" }}>
+                  <AnalysisPage hideControls={true} />
+                </div>
+              )}
+              
+              {activeTab === "resolution" && (
+                <div style={{ marginTop: "1rem" }}>
+                  <ResolutionPage hideTitle={true} />
+                </div>
+              )}
+            </PageSection>
+          </Page>
+        </DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export default UnifiedPage; 


### PR DESCRIPTION
https://github.com/user-attachments/assets/b012467e-da6e-4314-b18c-6e38e2e7bf47

https://github.com/user-attachments/assets/584d8976-6b57-45b7-a996-379e2b8bd64b


- Adds an option for users to "open konveyor ai assistant" in side panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a unified AI Assistant view with a tabbed interface for "Analysis" and "Resolution".
  * Added commands to open the unified view and the resolution view as a side panel or in a tab.
  * Added a new view and updated command titles, categories, and icons for improved UI consistency.

* **Improvements**
  * Server status toggle now offers enhanced feedback with dynamic tooltips and responsive styling.
  * Analysis and Resolution pages support optional hiding of controls and titles for a streamlined interface.
  * UI components and styles updated for better responsiveness across different screen sizes.

* **Bug Fixes**
  * Improved error handling when focusing views if providers are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->