### PR TITLE
:sparkles: Implement Profile Deletion and Test Cleanup

### DIFF
--- a/tests/e2e/pages/vscode.pages.ts
+++ b/tests/e2e/pages/vscode.pages.ts
@@ -213,7 +213,7 @@ export class VSCode extends Application {
     await manageProfileView.getByRole('button', { name: '+ New Profile' }).click();
 
     const randomName = generateRandomString();
-    const nameToUse = profileName ? `${profileName}-${randomName}` : randomName;
+    const nameToUse = profileName ? profileName : randomName;
     await manageProfileView.getByRole('textbox', { name: 'Profile Name' }).fill(nameToUse);
 
     // Select Targets
@@ -237,5 +237,31 @@ export class VSCode extends Application {
       await manageProfileView.getByRole('option', { name: source, exact: true }).click();
     }
     await this.window.keyboard.press('Escape');
+  }
+
+  public async deleteProfile(profileName: string) {
+    await this.executeQuickCommand('Konveyor: Manage Analysis Profile');
+    // await this.getWindow().pause();
+    const manageProfileView = await this.getView(KAIViews.manageProfiles);
+    const profileList = manageProfileView.getByRole('list', {
+      name: 'Profile list',
+    });
+
+    const profileItems = profileList.getByRole('listitem');
+    try {
+      await profileItems.filter({ hasText: profileName }).click();
+      await manageProfileView.getByRole('button', { name: 'Delete Profile' }).click();
+      const confirmButton = manageProfileView
+        .getByRole('dialog', { name: 'Delete profile?' })
+        .getByRole('button', { name: 'Confirm' });
+      await confirmButton.click();
+      await manageProfileView
+        .getByRole('listitem')
+        .filter({ hasText: profileName })
+        .waitFor({ state: 'hidden', timeout: 10000 });
+    } catch (error) {
+      console.log('Error deleting profile:', error);
+      throw error;
+    }
   }
 }

--- a/tests/e2e/tests/configure-and-run-analysis.test.ts
+++ b/tests/e2e/tests/configure-and-run-analysis.test.ts
@@ -1,10 +1,12 @@
 import { expect, test } from '../fixtures/test-repo-fixture';
 import { VSCode } from '../pages/vscode.pages';
 import { OPENAI_PROVIDER } from '../fixtures/provider-configs.fixture';
+import { generateRandomString } from '../utilities/utils';
 
 test.describe(`Configure extension and run analysis`, () => {
   let vscodeApp: VSCode;
-
+  const randomString = generateRandomString();
+  const profileName = `automation-${randomString}`;
   test.beforeAll(async ({ testRepoData }) => {
     test.setTimeout(600000);
     const repoInfo = testRepoData['coolstore'];
@@ -14,7 +16,7 @@ test.describe(`Configure extension and run analysis`, () => {
   test('Create Profile and Set Sources and targets', async ({ testRepoData }) => {
     await vscodeApp.waitDefault();
     const repoInfo = testRepoData['coolstore'];
-    await vscodeApp.createProfile(repoInfo.sources, repoInfo.targets);
+    await vscodeApp.createProfile(repoInfo.sources, repoInfo.targets, profileName);
   });
 
   test('Configure GenAI Provider', async () => {
@@ -32,6 +34,10 @@ test.describe(`Configure extension and run analysis`, () => {
     await expect(vscodeApp.getWindow().getByText('Analysis completed').first()).toBeVisible({
       timeout: 300000,
     });
+  });
+
+  test('delete profile', async () => {
+    await vscodeApp.deleteProfile(profileName);
   });
 
   test.afterAll(async () => {


### PR DESCRIPTION
**Description**
This PR adds the functionality to delete analysis profiles and integrates it into the e2e test suite to ensure tests clean up after themselves.

**Implementation Details**

**1. New Deletion Method:**
- A deleteProfile method was added to the page object, automating the UI flow for deleting a profile.

**2. E2E Test Integration:**
- The configure-and-run-analysis.test.ts file was updated to verify this new feature.
- The test now generates a unique profile name during setup.
- A new test case was added that calls deleteProfile with this unique name, confirming the end-to-end deletion flow and ensuring no artifacts are left behind.