### PR TITLE
:seedling: Update CODEOWNERS for kai-qe-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @konveyor/kai-ide-reviewers
+/tests @konveyor/kai-qe-reviewers
+


### PR DESCRIPTION
Add the team "@konveyor/kai-qe-reviewers" as owners on the `tests/` folder (and all sub-folders).
