### PR TITLE
:bug: Fix type errors in dev spaces

### DIFF
--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -27,10 +27,32 @@ const defaultState: ExtensionData = {
   isAgentMode: false,
 };
 
-const windowState =
-  typeof window["konveyorInitialData"] === "object"
-    ? (window["konveyorInitialData"] as ExtensionData)
-    : defaultState;
+// Safely merge window state with default state to ensure all arrays are defined
+const getInitialState = (): ExtensionData => {
+  try {
+    if (typeof window !== "undefined" && window["konveyorInitialData"]) {
+      const windowData = window["konveyorInitialData"] as Partial<ExtensionData>;
+      
+      // Ensure all array properties exist and are arrays
+      return {
+        ...defaultState,
+        ...windowData,
+        localChanges: Array.isArray(windowData.localChanges) ? windowData.localChanges : [],
+        ruleSets: Array.isArray(windowData.ruleSets) ? windowData.ruleSets : [],
+        enhancedIncidents: Array.isArray(windowData.enhancedIncidents) ? windowData.enhancedIncidents : [],
+        chatMessages: Array.isArray(windowData.chatMessages) ? windowData.chatMessages : [],
+        configErrors: Array.isArray(windowData.configErrors) ? windowData.configErrors : [],
+        profiles: Array.isArray(windowData.profiles) ? windowData.profiles : [],
+      };
+    }
+  } catch (error) {
+    console.warn("Failed to parse konveyorInitialData, using default state:", error);
+  }
+  
+  return defaultState;
+};
+
+const windowState = getInitialState();
 
 type ExtensionStateContextType = {
   state: ExtensionData;
@@ -44,7 +66,18 @@ export function ExtensionStateProvider({ children }: PropsWithChildren) {
 
   useEffect(() => {
     const handleMessage = (event: MessageEvent<ExtensionData>) => {
-      setState(event.data);
+      // Ensure incoming data has all required array properties
+      const safeData: ExtensionData = {
+        ...defaultState,
+        ...event.data,
+        localChanges: Array.isArray(event.data.localChanges) ? event.data.localChanges : [],
+        ruleSets: Array.isArray(event.data.ruleSets) ? event.data.ruleSets : [],
+        enhancedIncidents: Array.isArray(event.data.enhancedIncidents) ? event.data.enhancedIncidents : [],
+        chatMessages: Array.isArray(event.data.chatMessages) ? event.data.chatMessages : [],
+        configErrors: Array.isArray(event.data.configErrors) ? event.data.configErrors : [],
+        profiles: Array.isArray(event.data.profiles) ? event.data.profiles : [],
+      };
+      setState(safeData);
     };
     window.addEventListener("message", handleMessage);
 

--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -3,6 +3,72 @@ body {
   padding: 0;
 }
 
+/* Force PatternFly to use bundled fonts - fixes DevSpaces 401 error */
+@font-face {
+  font-family: "RedHatDisplay";
+  font-style: normal;
+  font-weight: 100 900;
+  font-display: swap;
+  src: url("./assets/RedHatDisplayVF.woff2") format("woff2-variations");
+}
+
+@font-face {
+  font-family: "RedHatDisplay";
+  font-style: italic;
+  font-weight: 100 900;
+  font-display: swap;
+  src: url("./assets/RedHatDisplayVF-Italic.woff2") format("woff2-variations");
+}
+
+@font-face {
+  font-family: "RedHatText";
+  font-style: normal;
+  font-weight: 100 900;
+  font-display: swap;
+  src: url("./assets/RedHatTextVF.woff2") format("woff2-variations");
+}
+
+@font-face {
+  font-family: "RedHatText";
+  font-style: italic;
+  font-weight: 100 900;
+  font-display: swap;
+  src: url("./assets/RedHatTextVF-Italic.woff2") format("woff2-variations");
+}
+
+@font-face {
+  font-family: "RedHatMono";
+  font-style: normal;
+  font-weight: 100 900;
+  font-display: swap;
+  src: url("./assets/RedHatMonoVF.woff2") format("woff2-variations");
+}
+
+@font-face {
+  font-family: "RedHatMono";
+  font-style: italic;
+  font-weight: 100 900;
+  font-display: swap;
+  src: url("./assets/RedHatMonoVF-Italic.woff2") format("woff2-variations");
+}
+
+/* Override PatternFly font variables to use local fonts */
+:root {
+  --pf-t--global--font--family--heading:
+    "RedHatDisplay", "Red Hat Display", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP",
+    "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai",
+    BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
+    "Droid Sans", "Helvetica Neue", sans-serif;
+  --pf-t--global--font--family--body:
+    "RedHatText", "Red Hat Text", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP",
+    "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai",
+    BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
+    "Droid Sans", "Helvetica Neue", sans-serif;
+  --pf-t--global--font--family--mono:
+    "RedHatMono", "Red Hat Mono", "SFMono-Regular", "Menlo", "Monaco", "Consolas",
+    "Liberation Mono", "Courier New", monospace;
+}
+
 .pf-v6-c-masthead,
 .pf-v6-c-page,
 .pf-v6-c-page__main-container,


### PR DESCRIPTION
In DevSpaces, there's often a race condition where React components mount before the extension fully initializes the webview data. 

There is also a CDN pf font that is unreachable in prod mode. This is now overridden by local PF fonts. 