### PR TITLE
:bug: Fixes duplicate no profile selected alert

### DIFF
--- a/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
+++ b/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
@@ -3,6 +3,7 @@ import "./styles.css";
 import React, { useState, useEffect } from "react";
 import {
   Alert,
+  AlertActionLink,
   AlertGroup,
   Backdrop,
   Button,
@@ -160,22 +161,6 @@ const AnalysisPage: React.FC = () => {
               </Masthead>
             }
           >
-            {!selectedProfile && (
-              <PageSection padding={{ default: "noPadding" }}>
-                <Card isCompact style={{ maxWidth: "600px", margin: "0 auto" }}>
-                  <Alert variant="danger" title="No active profile selected">
-                    Please select or create a profile before running an analysis.
-                    <Button
-                      variant="link"
-                      onClick={() => dispatch({ type: "OPEN_PROFILE_MANAGER", payload: {} })}
-                      style={{ marginLeft: "0.5rem" }}
-                    >
-                      Manage Profiles
-                    </Button>
-                  </Alert>
-                </Card>
-              </PageSection>
-            )}
             {errorMessage && (
               <PageSection padding={{ default: "noPadding" }}>
                 <Card isCompact style={{ maxWidth: "600px", margin: "0 auto" }}>
@@ -209,7 +194,19 @@ const AnalysisPage: React.FC = () => {
                     style={{ maxWidth: "600px", marginTop: "1rem", margin: "0 auto" }}
                     key={index}
                   >
-                    <Alert variant="warning" title={error.message}>
+                    <Alert 
+                      variant="warning" 
+                      title={error.message}
+                      actionLinks={
+                        error.type === "no-active-profile" ? (
+                          <AlertActionLink
+                            onClick={() => dispatch({ type: "OPEN_PROFILE_MANAGER", payload: {} })}
+                          >
+                            Manage Profiles
+                          </AlertActionLink>
+                        ) : undefined
+                      }
+                    >
                       {error.error ?? ""}
                     </Alert>
                   </Card>

--- a/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
+++ b/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
@@ -194,8 +194,8 @@ const AnalysisPage: React.FC = () => {
                     style={{ maxWidth: "600px", marginTop: "1rem", margin: "0 auto" }}
                     key={index}
                   >
-                    <Alert 
-                      variant="warning" 
+                    <Alert
+                      variant="warning"
                       title={error.message}
                       actionLinks={
                         error.type === "no-active-profile" ? (


### PR DESCRIPTION
Current behavior (before changes) :

<img width="770" height="571" alt="Screenshot 2025-07-30 at 3 12 59 PM" src="https://github.com/user-attachments/assets/633d7984-5c2e-4ab0-ac21-676069400320" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated the separate "No active profile selected" alert into the configuration errors area to simplify the UI and reduce duplicate messages.
  * The "Manage Profiles" action now appears inline within relevant configuration error alerts as an action link, replacing the previous separate alert and button for a cleaner, more consistent user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->