### PR TITLE
:seedling: Support running test in dev mode

### DIFF
--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -246,8 +246,8 @@ jobs:
           dbus-daemon --session --address=$DBUS_SESSION_BUS_ADDRESS --nofork --nopidfile --syslog-only &
           mkdir ~/.vscode && echo '{ "disable-hardware-acceleration": true }' > ~/.vscode/argv.json
 
-      - name: Verify Installation and install Java extension
-        run: code --version && code --install-extension redhat.java
+      - name: Verify Installation
+        run: code --version
 
       - name: Ensure no VSCode instances are running
         run: |

--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -187,7 +187,6 @@ jobs:
     name: Test E2E
     runs-on: ubuntu-latest
     needs: package
-    if: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 dist/
 downloaded_assets/
 downloaded_cache/
+test-data-dir/
 vscode/jdtls-plugin/
 .idea/
 *.vsix
@@ -15,3 +16,4 @@ vscode/.metadata
 # Miscellaneous
 .vscode/*.aider*
 .vscode/settings.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ build/
 dist/
 downloaded_assets/
 downloaded_cache/
-test-data-dir/
 vscode/jdtls-plugin/
 .idea/
 *.vsix

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,9 @@
       "request": "launch",
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}/vscode",
-        "--enable-proposed-api=konveyor.konveyor-ai"
+        "--enable-proposed-api=konveyor.konveyor-ai",
+        "--verbose"
+
       ],
 
       "cwd": "${workspaceFolder}/vscode",
@@ -39,7 +41,7 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }

--- a/tests/.env.example
+++ b/tests/.env.example
@@ -19,3 +19,11 @@
 
 # Name of the bucket to store the evaluator results in
 # KAI_QE_S3_BUCKET_NAME="exampleBucket"
+
+# Defines the source of the extension used during E2E testing.
+#
+# Set to 1 to run tests using the local extension under development
+# (launches VS Code with --extensionDevelopmentPath and --enable-proposed-api).
+#
+# Set to 0 to run tests using the packaged VSIX build of the extension.
+E2E_DEV_MODE=0

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -88,3 +88,4 @@ screenshots/
 coolstore/
 test-output
 *.vsix
+test-data-dir/

--- a/tests/docs/contrib/e2e-environment.md
+++ b/tests/docs/contrib/e2e-environment.md
@@ -64,14 +64,15 @@ yours.
 
 Additionally, you can directly pass the env variables.
 
-| KEY                    | DESCRIPTION                                                                                                         |
-|------------------------|---------------------------------------------------------------------------------------------------------------------|
-| VSCODE_EXECUTABLE_PATH | Path to executable vscode                                                                                           |
-| VSIX_FILE_PATH         | Path to the extension in vsix format                                                                                |
-| VSIX_DOWNLOAD_URL      | (Optional) URL to get vsix from (only used if VSIX_FILE_PATH is not defined)                                        |
-| OPENAI_API_KEY         | OPENAI API KEY FOR GenAI provider                                                                                   |
-| KAI_QE_S3_BUCKET_NAME  | (Optional) AWS S3 bucket name (only needed if running evaluation)                                                   |
-| PARASOL_API_KEY        | (Optional) API key for MaaS provider (Only used if working with https://maas.apps.prod.rhoai.rh-aiservices-bu.com/) |
+| KEY                    | DESCRIPTION                                                                                                                                                                                                                                                                                              |
+|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| VSCODE_EXECUTABLE_PATH | Path to executable vscode                                                                                                                                                                                                                                                                                |
+| VSIX_FILE_PATH         | Path to the extension in vsix format                                                                                                                                                                                                                                                                     |
+| VSIX_DOWNLOAD_URL      | (Optional) URL to get vsix from (only used if VSIX_FILE_PATH is not defined)                                                                                                                                                                                                                             |
+| OPENAI_API_KEY         | OPENAI API KEY FOR GenAI provider                                                                                                                                                                                                                                                                        |
+| KAI_QE_S3_BUCKET_NAME  | (Optional) AWS S3 bucket name (only needed if running evaluation)                                                                                                                                                                                                                                        |
+| PARASOL_API_KEY        | (Optional) API key for MaaS provider (Only used if working with https://maas.apps.prod.rhoai.rh-aiservices-bu.com/)                                                                                                                                                                                      |
+| E2E_DEV_MODE           | (Optional) (Defaults to 0) Defines the source of the extension used. <br/>Set to 1 to run tests using the local extension under development (launches VS Code with `--extensionDevelopmentPath` and `--enable-proposed-api`). <br/>Set to 0 to run tests using the packaged VSIX build of the extension. |
 
 ## Running Tests
 

--- a/tests/e2e/enums/left-bar-items.enum.ts
+++ b/tests/e2e/enums/left-bar-items.enum.ts
@@ -1,3 +1,4 @@
 export enum LeftBarItems {
   Konveyor = 'Konveyor',
+  AdditionalViews = 'Additional Views',
 }

--- a/tests/e2e/pages/vscode.pages.ts
+++ b/tests/e2e/pages/vscode.pages.ts
@@ -88,11 +88,7 @@ export class VSCode extends Application {
 
   private static async installExtension(): Promise<void> {
     try {
-      const installedExtensions = execSync('code --list-extensions', {
-        encoding: 'utf-8',
-      });
-
-      if (installedExtensions.includes('konveyor.konveyor-ai')) {
+      if (VSCode.isExtensionInstalled('konveyor.konveyor-ai')) {
         console.log(`Extension already installed`);
         return;
       }
@@ -296,5 +292,13 @@ export class VSCode extends Application {
       console.log('Error deleting profile:', error);
       throw error;
     }
+  }
+
+  public static isExtensionInstalled(extension: string) {
+    const installedExtensions = execSync('code --list-extensions', {
+      encoding: 'utf-8',
+    });
+
+    return installedExtensions.includes(extension);
   }
 }

--- a/tests/e2e/tests/analyze_coolstore.test.ts
+++ b/tests/e2e/tests/analyze_coolstore.test.ts
@@ -2,13 +2,15 @@ import { expect, test } from '../fixtures/test-repo-fixture';
 import { VSCode } from '../pages/vscode.pages';
 import { SCREENSHOTS_FOLDER, TEST_OUTPUT_FOLDER } from '../utilities/consts';
 import { getOSInfo, getRepoName, generateRandomString } from '../utilities/utils';
-import { providerConfigs } from '../fixtures/provider-configs.fixture';
+import { DEFAULT_PROVIDER, providerConfigs } from '../fixtures/provider-configs.fixture';
 import path from 'path';
 import { runEvaluation } from '../../kai-evaluator/core';
 import { prepareEvaluationData, saveOriginalAnalysisFile } from '../utilities/evaluation.utils';
 import { KAIViews } from '../enums/views.enum';
 
-providerConfigs.forEach((config) => {
+const providers = process.env.CI ? providerConfigs : [DEFAULT_PROVIDER];
+
+providers.forEach((config) => {
   test.describe(`Coolstore app tests | ${config.model}`, () => {
     let vscodeApp: VSCode;
     let allOk = true;

--- a/tests/e2e/tests/configure-and-run-analysis.test.ts
+++ b/tests/e2e/tests/configure-and-run-analysis.test.ts
@@ -7,6 +7,7 @@ test.describe(`Configure extension and run analysis`, () => {
   let vscodeApp: VSCode;
   const randomString = generateRandomString();
   const profileName = `automation-${randomString}`;
+
   test.beforeAll(async ({ testRepoData }) => {
     test.setTimeout(600000);
     const repoInfo = testRepoData['coolstore'];

--- a/tests/e2e/utilities/consts.ts
+++ b/tests/e2e/utilities/consts.ts
@@ -1,3 +1,4 @@
 export const TEST_OUTPUT_FOLDER = 'test-output';
 export const SCREENSHOTS_FOLDER = 'test-output/screenshots';
 export const ORIGINAL_ANALYSIS_FILENAME = 'original_analysis.json';
+export const TEST_DATA_DIR = 'test-data-dir';

--- a/tests/global.setup.ts
+++ b/tests/global.setup.ts
@@ -4,6 +4,11 @@ import { getOSInfo } from './e2e/utilities/utils';
 async function globalSetup() {
   console.log('Running global setup...');
   const vscodeApp = await VSCode.init();
+
+  if (!VSCode.isExtensionInstalled('redhat.java')) {
+    throw new Error('Required extension `redhat.java` not found');
+  }
+
   if (getOSInfo() === 'windows' && process.env.CI) {
     await vscodeApp.getWindow().waitForTimeout(60000);
   }


### PR DESCRIPTION
Completes #619 

This PR introduces the following changes:

1. Adds functionality to run tests on the extension being developed without needing to package it as a VSIX.
To achieve this, the E2E_DEV_MODE variable has been added.

This works by launching a separate instance of VS Code using a different user-data-dir to prevent the process from being coupled, which could cause Playwright to detect it as finished. It also mimics the behavior of launch.json to enable the extension’s API.

2. Removes the installation of the `redhat.java` extension and adds a check in the global setup to ensure it is installed before running any other tests.
This allows verifying that Kai, when installed, also installs this dependency.

3. Enables the PR gating workflow that sets up the GenAI provider, creates and deletes a profile, and runs an analysis.

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
