### PR TITLE
Add-decorators

### DIFF
--- a/vscode/src/decorations.ts
+++ b/vscode/src/decorations.ts
@@ -1,0 +1,237 @@
+import * as vscode from "vscode";
+
+const removedLineDecorationType = (line: string) =>
+  vscode.window.createTextEditorDecorationType({
+    isWholeLine: true,
+    backgroundColor: { id: "diffEditor.removedLineBackground" },
+    outlineWidth: "1px",
+    outlineStyle: "solid",
+    outlineColor: { id: "diffEditor.removedTextBorder" },
+    rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
+    after: {
+      contentText: line,
+      color: "#808080",
+      textDecoration: "none; white-space: pre",
+    },
+    // Hide the actual text to show only ghost text
+    textDecoration: "none; display: none",
+  });
+
+const addedLineDecorationType = vscode.window.createTextEditorDecorationType({
+  isWholeLine: true,
+  backgroundColor: { id: "diffEditor.insertedLineBackground" },
+  outlineWidth: "1px",
+  outlineStyle: "solid",
+  outlineColor: { id: "diffEditor.insertedTextBorder" },
+  rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
+});
+
+function translateRange(range: vscode.Range, lineOffset: number): vscode.Range {
+  return new vscode.Range(range.start.translate(lineOffset), range.end.translate(lineOffset));
+}
+
+// Class for managing highlight decorations for added lines (GREEN)
+export class AddedLineDecorationManager {
+  constructor(private editor: vscode.TextEditor) {}
+
+  ranges: vscode.Range[] = [];
+  decorationType = addedLineDecorationType;
+
+  applyToNewEditor(newEditor: vscode.TextEditor) {
+    this.editor = newEditor;
+    this.editor.setDecorations(this.decorationType, this.ranges);
+  }
+
+  addLines(startIndex: number, numLines: number) {
+    const lastRange = this.ranges[this.ranges.length - 1];
+    if (lastRange && lastRange.end.line === startIndex - 1) {
+      this.ranges[this.ranges.length - 1] = lastRange.with(
+        undefined,
+        lastRange.end.translate(numLines),
+      );
+    } else {
+      this.ranges.push(
+        new vscode.Range(startIndex, 0, startIndex + numLines - 1, Number.MAX_SAFE_INTEGER),
+      );
+    }
+
+    this.editor.setDecorations(this.decorationType, this.ranges);
+  }
+
+  addLine(index: number) {
+    this.addLines(index, 1);
+  }
+
+  clear() {
+    this.ranges = [];
+    this.editor.setDecorations(this.decorationType, this.ranges);
+  }
+
+  shiftDownAfterLine(afterLine: number, offset: number) {
+    for (let i = 0; i < this.ranges.length; i++) {
+      if (this.ranges[i].start.line >= afterLine) {
+        this.ranges[i] = translateRange(this.ranges[i], offset);
+      }
+    }
+    this.editor.setDecorations(this.decorationType, this.ranges);
+  }
+
+  deleteRangeStartingAt(line: number) {
+    for (let i = 0; i < this.ranges.length; i++) {
+      if (this.ranges[i].start.line === line) {
+        return this.ranges.splice(i, 1)[0];
+      }
+    }
+    this.editor.setDecorations(this.decorationType, this.ranges);
+  }
+}
+
+// Class for managing ghost-text decorations for removed lines (RED)
+export class RemovedLineDecorationManager {
+  constructor(private editor: vscode.TextEditor) {}
+
+  ranges: {
+    line: string;
+    range: vscode.Range;
+    decoration: vscode.TextEditorDecorationType;
+  }[] = [];
+
+  applyToNewEditor(newEditor: vscode.TextEditor) {
+    this.editor = newEditor;
+    this.applyDecorations();
+  }
+
+  addLines(startIndex: number, lines: string[]) {
+    let i = 0;
+    for (const line of lines) {
+      this.ranges.push({
+        line,
+        range: new vscode.Range(startIndex + i, 0, startIndex + i, Number.MAX_SAFE_INTEGER),
+        decoration: removedLineDecorationType(line),
+      });
+      i++;
+    }
+    this.applyDecorations();
+  }
+
+  addLine(index: number, line: string) {
+    this.addLines(index, [line]);
+  }
+
+  applyDecorations() {
+    this.ranges.forEach((r) => {
+      this.editor.setDecorations(r.decoration, [r.range]);
+    });
+  }
+
+  // Removed decorations are always unique, so we'll always dispose
+  clear() {
+    this.ranges.forEach((r) => {
+      r.decoration.dispose();
+    });
+    this.ranges = [];
+  }
+
+  shiftDownAfterLine(afterLine: number, offset: number) {
+    for (let i = 0; i < this.ranges.length; i++) {
+      if (this.ranges[i].range.start.line >= afterLine) {
+        this.ranges[i].range = translateRange(this.ranges[i].range, offset);
+      }
+    }
+    this.applyDecorations();
+  }
+
+  deleteRangesStartingAt(line: number) {
+    for (let i = 0; i < this.ranges.length; i++) {
+      if (this.ranges[i].range.start.line === line) {
+        let sequential = 0;
+        while (
+          i + sequential < this.ranges.length &&
+          this.ranges[i + sequential].range.start.line === line + sequential
+        ) {
+          this.ranges[i + sequential].decoration.dispose();
+          sequential++;
+        }
+        return this.ranges.splice(i, sequential);
+      }
+    }
+  }
+}
+
+// Manager to handle decorations for a file
+export class DiffDecorationManager {
+  private addedLineDecorations: AddedLineDecorationManager | null = null;
+  private removedLineDecorations: RemovedLineDecorationManager | null = null;
+  private editor: vscode.TextEditor | null = null;
+
+  constructor(private fileUri: string) {}
+
+  initializeForEditor(editor: vscode.TextEditor) {
+    this.editor = editor;
+    this.addedLineDecorations = new AddedLineDecorationManager(editor);
+    this.removedLineDecorations = new RemovedLineDecorationManager(editor);
+  }
+
+  applyDiffDecorations(diffLines: Array<{ type: string; line: string; lineNumber: number }>) {
+    if (!this.editor || !this.addedLineDecorations || !this.removedLineDecorations) {
+      throw new Error("Manager not initialized with editor");
+    }
+
+    // Clear existing decorations
+    this.clearDecorations();
+
+    // Group consecutive lines by type
+    let currentGroup: { type: string; lines: string[]; startLine: number } | null = null;
+
+    for (const diffLine of diffLines) {
+      if (!currentGroup || currentGroup.type !== diffLine.type) {
+        // Apply previous group if it exists
+        if (currentGroup) {
+          this.applyGroup(currentGroup);
+        }
+        // Start new group
+        currentGroup = {
+          type: diffLine.type,
+          lines: [diffLine.line],
+          startLine: diffLine.lineNumber,
+        };
+      } else {
+        // Add to current group
+        currentGroup.lines.push(diffLine.line);
+      }
+    }
+
+    // Apply the last group
+    if (currentGroup) {
+      this.applyGroup(currentGroup);
+    }
+  }
+
+  private applyGroup(group: { type: string; lines: string[]; startLine: number }) {
+    if (!this.addedLineDecorations || !this.removedLineDecorations) {
+      return;
+    }
+
+    switch (group.type) {
+      case "added":
+        this.addedLineDecorations.addLines(group.startLine, group.lines.length);
+        break;
+      case "removed":
+        this.removedLineDecorations.addLines(group.startLine, group.lines);
+        break;
+      // "same" lines don't need decorations
+    }
+  }
+
+  clearDecorations() {
+    this.addedLineDecorations?.clear();
+    this.removedLineDecorations?.clear();
+  }
+
+  dispose() {
+    this.clearDecorations();
+    this.addedLineDecorations = null;
+    this.removedLineDecorations = null;
+    this.editor = null;
+  }
+}

--- a/vscode/src/diffCodeLensProvider.ts
+++ b/vscode/src/diffCodeLensProvider.ts
@@ -1,0 +1,76 @@
+import * as vscode from "vscode";
+
+export interface DiffBlock {
+  startLine: number;
+  numAdded: number;
+  numRemoved: number;
+  fileUri: string;
+  messageToken: string;
+}
+
+export class DiffCodeLensProvider implements vscode.CodeLensProvider {
+  private _eventEmitter: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
+  onDidChangeCodeLenses: vscode.Event<void> = this._eventEmitter.event;
+
+  constructor(private readonly diffBlocks: Map<string, DiffBlock[]>) {}
+
+  public refresh(): void {
+    this._eventEmitter.fire();
+  }
+
+  public addDiffBlocks(fileUri: string, blocks: DiffBlock[]): void {
+    this.diffBlocks.set(fileUri, blocks);
+    this.refresh();
+  }
+
+  public clearDiffBlocks(fileUri?: string): void {
+    if (fileUri) {
+      this.diffBlocks.delete(fileUri);
+    } else {
+      this.diffBlocks.clear();
+    }
+    this.refresh();
+  }
+
+  public provideCodeLenses(
+    document: vscode.TextDocument,
+    _: vscode.CancellationToken,
+  ): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
+    const uri = document.uri.toString();
+    const blocks = this.diffBlocks.get(uri);
+
+    if (!blocks || blocks.length === 0) {
+      return [];
+    }
+
+    const codeLenses: vscode.CodeLens[] = [];
+
+    for (let i = 0; i < blocks.length; i++) {
+      const block = blocks[i];
+      const range = new vscode.Range(
+        new vscode.Position(block.startLine, 0),
+        new vscode.Position(block.startLine, 0),
+      );
+
+      // Accept button
+      codeLenses.push(
+        new vscode.CodeLens(range, {
+          title: `Accept`,
+          command: "konveyor.acceptDiffBlock",
+          arguments: [uri, i, block.messageToken],
+        }),
+      );
+
+      // Reject button
+      codeLenses.push(
+        new vscode.CodeLens(range, {
+          title: `Reject`,
+          command: "konveyor.rejectDiffBlock",
+          arguments: [uri, i, block.messageToken],
+        }),
+      );
+    }
+
+    return codeLenses;
+  }
+}

--- a/vscode/src/extensionState.ts
+++ b/vscode/src/extensionState.ts
@@ -5,8 +5,8 @@ import { AnalysisProfile, ExtensionData, ModifiedFileState } from "@editor-exten
 import {
   type InMemoryCacheWithRevisions,
   type KaiInteractiveWorkflow,
-  type SolutionServerClient,
   type KaiModelProvider,
+  type SolutionServerClient,
 } from "@editor-extensions/agentic";
 import { Immutable } from "immer";
 import { IssuesModel } from "./issueView";
@@ -15,6 +15,7 @@ import { MemFS } from "./data/fileSystemProvider";
 import { KonveyorFileModel } from "./diffView/fileModel";
 import { EventEmitter } from "events";
 import winston from "winston";
+import { DiffDecorationManager } from "./decorations";
 
 export interface ExtensionState {
   analyzerClient: AnalyzerClient;
@@ -50,4 +51,5 @@ export interface ExtensionState {
   currentTaskManagerIterations: number;
   logger: winston.Logger;
   modelProvider: KaiModelProvider | undefined;
+  decorationManagers: Map<string, DiffDecorationManager>; // Map to store decoration managers by file URI
 }

--- a/vscode/src/webviewMessageHandler.ts
+++ b/vscode/src/webviewMessageHandler.ts
@@ -247,6 +247,24 @@ const actions: {
     return actions.VIEW_FILE({ path, change }, state, logger);
   },
 
+  SHOW_DIFF_WITH_DECORATORS: async ({ path, diff, content, messageToken }, state, logger) => {
+    try {
+      logger.info("SHOW_DIFF_WITH_DECORATORS called", { path, messageToken });
+
+      // Execute the command to show diff with decorations
+      await vscode.commands.executeCommand(
+        "konveyor.showDiffWithDecorations",
+        path,
+        diff,
+        content,
+        messageToken,
+      );
+    } catch (error) {
+      logger.error("Error handling SHOW_DIFF_WITH_DECORATORS:", error);
+      vscode.window.showErrorMessage(`Failed to show diff with decorations: ${error}`);
+    }
+  },
+
   VIEW_FILE: async ({ path, change }, state, logger) => {
     try {
       const uri = vscode.Uri.file(path);

--- a/webview-ui/src/components/ResolutionsPage/ModifiedFile/ModifiedFileActions.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ModifiedFile/ModifiedFileActions.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button, Flex, FlexItem } from "@patternfly/react-core";
-import { CheckCircleIcon, TimesCircleIcon, EyeIcon, ExpandIcon } from "@patternfly/react-icons";
+import { CheckCircleIcon, TimesCircleIcon, EyeIcon, ExpandIcon, CodeIcon } from "@patternfly/react-icons";
 import { NormalizedFileData } from "./useModifiedFileData";
 
 interface ModifiedFileActionsProps {
@@ -10,6 +10,7 @@ interface ModifiedFileActionsProps {
   onApply: () => void;
   onReject: () => void;
   onView: (path: string, diff: string) => void;
+  onViewWithDecorations?: (path: string, diff: string) => void;
   onExpandToggle: () => void;
   onQuickResponse: (responseId: string) => void;
 }
@@ -39,10 +40,11 @@ const ActionButtons: React.FC<{
   mode: "agent" | "non-agent";
   actionTaken: "applied" | "rejected" | null;
   onView: () => void;
+  onViewWithDecorations?: () => void;
   onExpandToggle: () => void;
   onApply: () => void;
   onReject: () => void;
-}> = ({ isNew, mode, actionTaken, onView, onExpandToggle, onApply, onReject }) => (
+}> = ({ isNew, mode, actionTaken, onView, onViewWithDecorations, onExpandToggle, onApply, onReject }) => (
   <Flex
     className="modified-file-actions"
     justifyContent={{ default: "justifyContentSpaceBetween" }}
@@ -58,6 +60,18 @@ const ActionButtons: React.FC<{
               aria-label="View file in VSCode"
             >
               View
+            </Button>
+          </FlexItem>
+        )}
+        {!isNew && onViewWithDecorations && (
+          <FlexItem>
+            <Button
+              variant="link"
+              icon={<CodeIcon />}
+              onClick={onViewWithDecorations}
+              aria-label="View diff with decorations in VSCode"
+            >
+              View Diff
             </Button>
           </FlexItem>
         )}
@@ -175,6 +189,7 @@ export const ModifiedFileActions: React.FC<ModifiedFileActionsProps> = ({
   onApply,
   onReject,
   onView,
+  onViewWithDecorations,
   onExpandToggle,
   onQuickResponse,
 }) => {
@@ -207,6 +222,7 @@ export const ModifiedFileActions: React.FC<ModifiedFileActionsProps> = ({
       mode={mode}
       actionTaken={actionTaken}
       onView={() => onView(path, diff)}
+      onViewWithDecorations={onViewWithDecorations ? () => onViewWithDecorations(path, diff) : undefined}
       onExpandToggle={onExpandToggle}
       onApply={onApply}
       onReject={onReject}

--- a/webview-ui/src/components/ResolutionsPage/ModifiedFile/ModifiedFileMessage.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ModifiedFile/ModifiedFileMessage.tsx
@@ -128,6 +128,25 @@ export const ModifiedFileMessage: React.FC<ModifiedFileMessageProps> = ({
     }
   };
 
+  const viewFileWithDecorations = (filePath: string, fileDiff: string) => {
+    interface ShowDiffWithDecoratorsPayload {
+      path: string;
+      content: string;
+      diff: string;
+      messageToken: string;
+    }
+    const payload: ShowDiffWithDecoratorsPayload = {
+      path: filePath,
+      content: content,
+      diff: fileDiff,
+      messageToken: messageToken,
+    };
+    window.vscode.postMessage({
+      type: "SHOW_DIFF_WITH_DECORATORS",
+      payload,
+    });
+  };
+
   const handleExpandToggle = () => {
     setIsExpanded(!isExpanded);
   };
@@ -220,6 +239,7 @@ export const ModifiedFileMessage: React.FC<ModifiedFileMessageProps> = ({
               onApply={() => applyFile()}
               onReject={rejectFile}
               onView={viewFileInVSCode}
+              onViewWithDecorations={viewFileWithDecorations}
               onExpandToggle={handleExpandToggle}
               onQuickResponse={handleQuickResponse}
             />


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
