### PR TITLE
:sparkles: Feature/debug tarball

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "editor-extensions",
-  "version": "0.1.0",
+  "version": "0.2.0-pre.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "editor-extensions",
-      "version": "0.1.0",
+      "version": "0.2.0-pre.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -23,6 +23,8 @@
         "@langchain/google-genai": "^0.2.4",
         "@langchain/ollama": "^0.2.0",
         "@langchain/openai": "^0.5.6",
+        "@types/adm-zip": "^0.5.7",
+        "adm-zip": "^0.5.16",
         "fast-deep-equal": "^3.1.3",
         "fs-extra": "^11.2.0",
         "globby": "^14.0.2",
@@ -89,7 +91,7 @@
     },
     "agentic": {
       "name": "@editor-extensions/agentic",
-      "version": "0.1.0",
+      "version": "0.2.0-pre.1",
       "dependencies": {
         "@langchain/core": "^0.3.50",
         "@langchain/langgraph": "^0.2.67",
@@ -5821,6 +5823,15 @@
         "@textlint/ast-node-types": "15.2.1"
       }
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.7.tgz",
+      "integrity": "sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
       "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
@@ -7198,6 +7209,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
@@ -23058,11 +23078,11 @@
     },
     "shared": {
       "name": "@editor-extensions/shared",
-      "version": "0.1.0"
+      "version": "0.2.0-pre.1"
     },
     "vscode": {
       "name": "konveyor-ai",
-      "version": "0.1.0",
+      "version": "0.2.0-pre.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
@@ -23107,7 +23127,7 @@
     },
     "webview-ui": {
       "name": "@editor-extensions/webview-ui",
-      "version": "0.1.0",
+      "version": "0.2.0-pre.1",
       "dependencies": {
         "@patternfly/chatbot": "^6.3.0",
         "@patternfly/patternfly": "^6.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,6 @@
         "@langchain/google-genai": "^0.2.4",
         "@langchain/ollama": "^0.2.0",
         "@langchain/openai": "^0.5.6",
-        "@types/adm-zip": "^0.5.7",
-        "adm-zip": "^0.5.16",
         "fast-deep-equal": "^3.1.3",
         "fs-extra": "^11.2.0",
         "globby": "^14.0.2",
@@ -5827,6 +5825,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.7.tgz",
       "integrity": "sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -23087,6 +23086,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
         "@types/mustache": "^4.2.5",
+        "adm-zip": "^0.5.16",
         "diff": "^7.0.0",
         "jsesc": "^3.1.0",
         "mustache": "^4.2.0",
@@ -23094,6 +23094,7 @@
         "winston-transport-vscode": "^0.1.0"
       },
       "devDependencies": {
+        "@types/adm-zip": "^0.5.7",
         "@types/diff": "^6.0.0",
         "@types/jsesc": "^3.0.3",
         "@types/uuid": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,8 @@
     "@langchain/google-genai": "^0.2.4",
     "@langchain/ollama": "^0.2.0",
     "@langchain/openai": "^0.5.6",
+    "@types/adm-zip": "^0.5.7",
+    "adm-zip": "^0.5.16",
     "fast-deep-equal": "^3.1.3",
     "fs-extra": "^11.2.0",
     "globby": "^14.0.2",

--- a/package.json
+++ b/package.json
@@ -110,8 +110,6 @@
     "@langchain/google-genai": "^0.2.4",
     "@langchain/ollama": "^0.2.0",
     "@langchain/openai": "^0.5.6",
-    "@types/adm-zip": "^0.5.7",
-    "adm-zip": "^0.5.16",
     "fast-deep-equal": "^3.1.3",
     "fs-extra": "^11.2.0",
     "globby": "^14.0.2",

--- a/tests/e2e/tests/configure-and-run-analysis.test.ts
+++ b/tests/e2e/tests/configure-and-run-analysis.test.ts
@@ -1,3 +1,5 @@
+import * as pathlib from 'path';
+import * as fs from 'fs/promises';
 import { expect, test } from '../fixtures/test-repo-fixture';
 import { VSCode } from '../pages/vscode.page';
 import { OPENAI_PROVIDER } from '../fixtures/provider-configs.fixture';
@@ -35,6 +37,28 @@ test.describe(`Configure extension and run analysis`, () => {
     await expect(vscodeApp.getWindow().getByText('Analysis completed').first()).toBeVisible({
       timeout: 300000,
     });
+  });
+
+  test('Generate debug archive', async () => {
+    await vscodeApp.executeQuickCommand('Konveyor: Generate Debug Archive');
+    await vscodeApp.waitDefault();
+    const zipPathInput = vscodeApp
+      .getWindow()
+      .getByPlaceholder('Enter the path where the debug archive will be saved');
+    expect(await zipPathInput.count()).toEqual(1);
+    await zipPathInput.fill(pathlib.join('.vscode', 'debug-archive.zip'));
+    await vscodeApp.getWindow().keyboard.press('Enter');
+    await vscodeApp.waitDefault();
+    const redactProviderConfigInput = vscodeApp
+      .getWindow()
+      .getByText(
+        'Select provider settings values you would like to include in the archive, all other values will be redacted'
+      );
+    expect(await redactProviderConfigInput.count()).toEqual(1);
+    await vscodeApp.getWindow().keyboard.press('Enter');
+    await vscodeApp.waitDefault();
+    const zipStat = await fs.stat(pathlib.join('.vscode', 'debug-archive.zip'));
+    expect(zipStat.isFile()).toBe(true);
   });
 
   test('delete profile', async () => {

--- a/tests/e2e/tests/configure-and-run-analysis.test.ts
+++ b/tests/e2e/tests/configure-and-run-analysis.test.ts
@@ -39,7 +39,7 @@ test.describe(`Configure extension and run analysis`, () => {
     });
   });
 
-  test('Generate debug archive', async () => {
+  test('Generate debug archive', async ({ testRepoData }) => {
     await vscodeApp.executeQuickCommand('Konveyor: Generate Debug Archive');
     await vscodeApp.waitDefault();
     const zipPathInput = vscodeApp
@@ -57,7 +57,14 @@ test.describe(`Configure extension and run analysis`, () => {
     expect(await redactProviderConfigInput.count()).toEqual(1);
     await vscodeApp.getWindow().keyboard.press('Enter');
     await vscodeApp.waitDefault();
-    const zipStat = await fs.stat(pathlib.join('.vscode', 'debug-archive.zip'));
+    const includeLLMTracesPrompt = vscodeApp.getWindow().getByText('Include LLM traces?');
+    if ((await includeLLMTracesPrompt.count()) === 1) {
+      await vscodeApp.getWindow().keyboard.press('Enter');
+      await vscodeApp.waitDefault();
+    }
+    const zipStat = await fs.stat(
+      pathlib.join(testRepoData['coolstore'].repoName, '.vscode', 'debug-archive.zip')
+    );
     expect(zipStat.isFile()).toBe(true);
   });
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -258,6 +258,12 @@
         "icon": "$(arrow-left)",
         "category": "diffEditor",
         "title": "Apply Selection"
+      },
+      {
+        "command": "konveyor.generateDebugArchive",
+        "title": "Generate Debug Archive",
+        "category": "Konveyor",
+        "icon": "$(bug)"
       }
     ],
     "submenus": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -679,6 +679,7 @@
   "devDependencies": {
     "@types/diff": "^6.0.0",
     "@types/jsesc": "^3.0.3",
+    "@types/adm-zip": "^0.5.7",
     "@types/uuid": "^10.0.0",
     "@types/vscode": "^1.93.0",
     "@vscode/test-cli": "^0.0.10",
@@ -693,6 +694,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
     "@types/mustache": "^4.2.5",
+    "adm-zip": "^0.5.16",
     "diff": "^7.0.0",
     "jsesc": "^3.1.0",
     "mustache": "^4.2.0",

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -688,15 +688,17 @@ const commandsMap: (
         logger.error("Failed to parse provider settings file", { error: err });
       }
       // get extension config
-      let extensionConfig: Record<string, any> = {};
       const extensionConfigPath = pathlib.join(
         pathlib.dirname(archivePath),
         `extension-config.json`,
       );
       let extensionConfigWritten = false;
       try {
-        extensionConfig = await getAllConfigurationValues(state.extensionContext.extensionPath);
-        await fs.writeFile(extensionConfigPath, JSON.stringify(extensionConfig, null, 2), "utf8");
+        await fs.writeFile(
+          extensionConfigPath,
+          JSON.stringify(getAllConfigurationValues(), null, 2),
+          "utf8",
+        );
         extensionConfigWritten = true;
       } catch (err) {
         window.showInformationMessage(

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -653,9 +653,12 @@ const commandsMap: (
         const parsedConfig = await parseModelConfig(paths().settingsYaml);
         const configuredKeys = getProviderConfigKeys(parsedConfig);
         const unredactedKeys = await window.showQuickPick(
-          configuredKeys.map((obj) => ({
-            label: obj.key,
-          })),
+          configuredKeys
+            .map((obj) => ({
+              label: obj.key,
+            }))
+            // all envs will be redacted no matter what
+            .filter((item) => !item.label.startsWith("env.")),
           {
             title:
               "Select provider settings values you would like to include in the archive, all other values will be redacted",

--- a/vscode/src/modelProvider/index.ts
+++ b/vscode/src/modelProvider/index.ts
@@ -1,2 +1,2 @@
-export { getModelProviderFromConfig, parseModelConfig } from "./config";
+export { getModelProviderFromConfig, parseModelConfig, getProviderConfigKeys } from "./config";
 export { BaseModelProvider, runModelHealthCheck } from "./modelProvider";

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
 import * as pathlib from "path";
-import * as fs from "fs/promises";
 import { fileURLToPath } from "url";
 import { KONVEYOR_CONFIG_KEY } from "./constants";
 import { AnalysisProfile, createConfigError, ExtensionData } from "@editor-extensions/shared";
@@ -67,22 +66,16 @@ export const getExcludedDiagnosticSources = (): string[] =>
 
 /**
  * Get all configuration values for keys defined in the package.json file. Used in debugging.
- * @param extensionPath - The path to the extension.
  * @returns A record of all configuration values.
  */
-export async function getAllConfigurationValues(
-  extensionPath: string,
-): Promise<Record<string, any>> {
-  const packageJsonPath = pathlib.join(extensionPath, "package.json");
-  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, "utf8"));
-  const configSchema = packageJson.contributes?.configuration?.properties || {};
+export function getAllConfigurationValues(): Record<string, any> {
+  const config = vscode.workspace.getConfiguration(KONVEYOR_CONFIG_KEY);
   const result: Record<string, any> = {};
-  Object.keys(configSchema).forEach((fullKey) => {
-    if (fullKey.startsWith("konveyor.")) {
-      const key = fullKey.replace("konveyor.", "");
-      result[key] = vscode.workspace.getConfiguration(KONVEYOR_CONFIG_KEY).get(key);
+  for (const key of Object.keys(config)) {
+    if (!key.startsWith("inspect") && !key.startsWith("update")) {
+      result[key] = config.get(key);
     }
-  });
+  }
   return result;
 }
 


### PR DESCRIPTION
Fixes #378 


https://github.com/user-attachments/assets/18208d1a-f174-4012-a3a1-cfdd9d1300dd


This is what gets added to the archive (I included traces too):

```
├── ChatBedrock
│   └── meta_llama3-70b-instruct-v1_0
├── extension-config.json
└── provider-config.json
```

These are the contents of extension-config.json: 

```
{
  "logLevel": "debug",
  "analyzerPath": "",
  "kaiRpcServerPath": "",
  "solutionServer.url": "http://localhost:8000",
  "solutionServer.enabled": true,
  "analysis.analyzeOnSave": true,
  "diffEditorType": "merge",
  "kai.agentMode": true,
  "kai.excludedDiagnosticSources": [
    "trunk"
  ],
  "kai.getSolutionMaxPriority": 0,
  "kai.getSolutionMaxEffort": "Low",
  "kai.getSolutionMaxLLMQueries": null,
  "kai.cacheDir": null,
  "kai.traceDir": ".vscode/trace",
  "kai.traceEnabled": true,
  "debug.webview": false,
  "kai.demoMode": false,
  "analysis.incidentLimit": 10000,
  "analysis.contextLines": 10,
  "analysis.codeSnipLimit": 10,
  "analysis.analyzeKnownLibraries": false,
  "analysis.analyzeDependencies": true
}
```

This is how the provider settings looks like:

```
{
  "config.provider": "ChatBedrock",
  "config.args.model": "<redacted>",
  "config.llamaHeader": "<redacted>",
  "config.llmRetries": "<redacted>",
  "config.llmRetryDelay": "<redacted>"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Generate Debug Archive” command to the Konveyor extension (menu/command palette, bug icon). Prompts for a .zip save location, confirms redaction of sensitive provider settings, optionally includes trace logs, and reports success or errors when creating the archive.

* **Tests**
  * Added end-to-end test covering the debug archive flow (invocation, path input, redaction prompt, and archive existence assertion).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->