### PR TITLE
:bug: make sure extension logs are added to debug archive

### DIFF
--- a/tests/e2e/tests/configure-and-run-analysis.test.ts
+++ b/tests/e2e/tests/configure-and-run-analysis.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from '../fixtures/test-repo-fixture';
 import { VSCode } from '../pages/vscode.page';
 import { OPENAI_GPT4O_PROVIDER } from '../fixtures/provider-configs.fixture';
 import { generateRandomString } from '../utilities/utils';
+import { extractZip } from '../utilities/archive';
 
 test.describe(`Configure extension and run analysis`, () => {
   let vscodeApp: VSCode;
@@ -62,10 +63,18 @@ test.describe(`Configure extension and run analysis`, () => {
       await vscodeApp.getWindow().keyboard.press('Enter');
       await vscodeApp.waitDefault();
     }
-    const zipStat = await fs.stat(
-      pathlib.join(testRepoData['coolstore'].repoName, '.vscode', 'debug-archive.zip')
+    const zipPath = pathlib.join(
+      testRepoData['coolstore'].repoName,
+      '.vscode',
+      'debug-archive.zip'
     );
+    const zipStat = await fs.stat(zipPath);
     expect(zipStat.isFile()).toBe(true);
+    const extractedPath = pathlib.join(testRepoData['coolstore'].repoName, '.vscode');
+    extractZip(zipPath, extractedPath);
+    const logsPath = pathlib.join(extractedPath, 'logs', 'extension.log');
+    const logsStat = await fs.stat(logsPath);
+    expect(logsStat.isFile()).toBe(true);
   });
 
   test('delete profile', async () => {

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -51,6 +51,7 @@ import {
   getTraceEnabled,
   getTraceDir,
   getConfigSolutionServerAuth,
+  fileUriToPath,
 } from "./utilities/configuration";
 import { promptForCredentials } from "./utilities/auth";
 import { runPartialAnalysis } from "./analysis";
@@ -544,12 +545,12 @@ const commandsMap: (
         openLabel: "Select Analyzer Binary",
         filters: isWindows
           ? {
-            "Executable Files": ["exe"],
-            "All Files": ["*"],
-          }
+              "Executable Files": ["exe"],
+              "All Files": ["*"],
+            }
           : {
-            "All Files": ["*"],
-          },
+              "All Files": ["*"],
+            },
       };
 
       const fileUri = await window.showOpenDialog(options);
@@ -732,8 +733,9 @@ const commandsMap: (
       // add logs and write zip
       try {
         const zipArchive = new AdmZip();
+        zipArchive.addLocalFolder(fileUriToPath(state.extensionContext.logUri.fsPath), "logs"); // add logs folder
         if (traceDirFound && includeLLMTraces === "Yes") {
-          zipArchive.addLocalFolder(traceDir as string);
+          zipArchive.addLocalFolder(traceDir as string, "traces");
         }
         if (providerConfigWritten) {
           zipArchive.addLocalFile(providerConfigPath);


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
