### PR TITLE
:sparkles: Support disabling generative AI

### DIFF
--- a/shared/src/types/types.ts
+++ b/shared/src/types/types.ts
@@ -189,7 +189,8 @@ export type ConfigErrorType =
   | "provider-not-configured"
   | "provider-connection-failed"
   | "no-custom-rules"
-  | "missing-auth-credentials";
+  | "missing-auth-credentials"
+  | "genai-disabled";
 
 export interface ConfigError {
   type: ConfigErrorType;
@@ -231,6 +232,11 @@ export const createConfigError = {
   missingAuthCredentials: (): ConfigError => ({
     type: "missing-auth-credentials",
     message: "Authentication is enabled but credentials are not configured.",
+  }),
+
+  genaiDisabled: (): ConfigError => ({
+    type: "genai-disabled",
+    message: "GenAI functionality is disabled.",
   }),
 };
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -540,12 +540,19 @@
           "scope": "window",
           "order": 9
         },
+        "konveyor.genai.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable GenAI functionality for solution generation.",
+          "scope": "window",
+          "order": 10
+        },
         "konveyor.kai.agentMode": {
           "type": "boolean",
           "default": false,
           "description": "(Experimental) Use agentic flow when getting solution. Requires automatic analysis.",
           "scope": "window",
-          "order": 10
+          "order": 11
         },
         "konveyor.kai.excludedDiagnosticSources": {
           "type": "array",
@@ -554,7 +561,7 @@
           ],
           "description": "List of diagnostic sources to exclude from agentic workflow.",
           "scope": "window",
-          "order": 11
+          "order": 12
         },
         "konveyor.kai.getSolutionMaxPriority": {
           "type": [

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -144,23 +144,10 @@ const commandsMap: (
         return;
       }
 
-      // Check if GenAI is available
-      const genaiDisabledError = state.data.configErrors.find((e) => e.type === "genai-disabled");
-      const genaiConfigError = state.data.configErrors.find(
-        (e) => e.type === "provider-not-configured" || e.type === "provider-connection-failed",
-      );
-
-      if (genaiDisabledError) {
+      // Check if GenAI is disabled
+      if (state.data.configErrors.some((e) => e.type === "genai-disabled")) {
         logger.info("GenAI disabled, cannot get solution");
         window.showErrorMessage("GenAI functionality is disabled.");
-        return;
-      }
-
-      if (genaiConfigError) {
-        logger.info("GenAI not available, cannot get solution");
-        window.showErrorMessage(
-          "GenAI features are not available. Please configure your model provider settings.",
-        );
         return;
       }
 

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -144,6 +144,26 @@ const commandsMap: (
         return;
       }
 
+      // Check if GenAI is available
+      const genaiDisabledError = state.data.configErrors.find((e) => e.type === "genai-disabled");
+      const genaiConfigError = state.data.configErrors.find(
+        (e) => e.type === "provider-not-configured" || e.type === "provider-connection-failed",
+      );
+
+      if (genaiDisabledError) {
+        logger.info("GenAI disabled, cannot get solution");
+        window.showErrorMessage("GenAI functionality is disabled.");
+        return;
+      }
+
+      if (genaiConfigError) {
+        logger.info("GenAI not available, cannot get solution");
+        window.showErrorMessage(
+          "GenAI features are not available. Please configure your model provider settings.",
+        );
+        return;
+      }
+
       // Read agent mode from configuration instead of parameter
       const agentMode = getConfigAgentMode();
       logger.info("Get solution command called", { incidents, agentMode });
@@ -544,12 +564,12 @@ const commandsMap: (
         openLabel: "Select Analyzer Binary",
         filters: isWindows
           ? {
-            "Executable Files": ["exe"],
-            "All Files": ["*"],
-          }
+              "Executable Files": ["exe"],
+              "All Files": ["*"],
+            }
           : {
-            "All Files": ["*"],
-          },
+              "All Files": ["*"],
+            },
       };
 
       const fileUri = await window.showOpenDialog(options);

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -66,6 +66,8 @@ export const getTraceEnabled = (): boolean => getConfigValue<boolean>("kai.trace
 export const getConfigKaiDemoMode = (): boolean => getConfigValue<boolean>("kai.demoMode") ?? false;
 export const getConfigMaxLLMQueries = (): number | undefined =>
   getConfigValue<number | null>("kai.getSolutionMaxLLMQueries") ?? undefined;
+export const getConfigGenAIEnabled = (): boolean =>
+  getConfigValue<boolean>("genai.enabled") ?? true;
 export const getConfigAgentMode = (): boolean => getConfigValue<boolean>("kai.agentMode") ?? false;
 export const getExcludedDiagnosticSources = (): string[] =>
   getConfigValue<string[]>("kai.excludedDiagnosticSources") ?? [];

--- a/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
+++ b/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
@@ -70,7 +70,7 @@ const AnalysisPage: React.FC = () => {
     isFetchingSolution: isWaitingForSolution,
     ruleSets: analysisResults,
     enhancedIncidents,
-    configErrors,
+    configErrors: rawConfigErrors,
     profiles,
     activeProfileId,
     serverState,
@@ -79,7 +79,9 @@ const AnalysisPage: React.FC = () => {
     isAgentMode,
   } = state;
 
-  console.log(configErrors);
+  console.log(rawConfigErrors);
+  const configErrors = rawConfigErrors.filter((error) => error.type !== "genai-disabled");
+  const isGenAIDisabled = rawConfigErrors.some((error) => error.type === "genai-disabled");
 
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [focusedIncident, setFocusedIncident] = useState<Incident | null>(null);
@@ -154,24 +156,26 @@ const AnalysisPage: React.FC = () => {
                             hasWarning={configInvalid}
                           />
                         </ToolbarItem>
-                        <ToolbarItem>
-                          <div>
-                            <div className="agent-mode-wrapper">
-                              <Switch
-                                id="agent-mode-switch"
-                                isChecked={isAgentMode}
-                                label="Agent Mode"
-                                onChange={(_event) => handleAgentModeToggle()}
-                                aria-label="Toggle Agent Mode"
-                                isReversed
-                              />
+                        {!isGenAIDisabled && (
+                          <ToolbarItem>
+                            <div>
+                              <div className="agent-mode-wrapper">
+                                <Switch
+                                  id="agent-mode-switch"
+                                  isChecked={isAgentMode}
+                                  label="Agent Mode"
+                                  onChange={(_event) => handleAgentModeToggle()}
+                                  aria-label="Toggle Agent Mode"
+                                  isReversed
+                                />
+                              </div>
                             </div>
-                          </div>
-                        </ToolbarItem>
+                          </ToolbarItem>
+                        )}
                         <ToolbarItem>
                           <ConfigButton
                             onClick={() => setIsConfigOpen(true)}
-                            hasWarning={configErrors.length > 0}
+                            hasWarning={rawConfigErrors.length > 0}
                             warningMessage="Please review your configuration before running analysis."
                           />
                         </ToolbarItem>

--- a/webview-ui/src/components/AnalysisPage/WalkthroughDrawer/WalkthroughDrawer.tsx
+++ b/webview-ui/src/components/AnalysisPage/WalkthroughDrawer/WalkthroughDrawer.tsx
@@ -47,7 +47,7 @@ export function WalkthroughDrawer({
     (error) => error.type === "provider-connection-failed",
   );
   const providerNotConfigured = state.configErrors.some(
-    (error) => error.type === "provider-not-configured",
+    (error) => error.type === "provider-not-configured" || error.type === "genai-disabled",
   );
   const providerConfigured = !providerConnectionError && !providerNotConfigured;
 

--- a/webview-ui/src/components/GetSolutionDropdown.tsx
+++ b/webview-ui/src/components/GetSolutionDropdown.tsx
@@ -34,38 +34,13 @@ const GetSolutionDropdown: React.FC<GetSolutionDropdownProps> = ({ incidents, sc
     dispatch(getSolutionWithKonveyorContext(incident));
   };
 
-  const genaiDisabled = state.configErrors.some((e) => e.type === "genai-disabled");
-  const genaiConfigError = state.configErrors.some(
-    (e) => e.type === "provider-not-configured" || e.type === "provider-connection-failed",
-  );
-
   // Hide component completely when GenAI is disabled
-  if (genaiDisabled) {
+  if (state.configErrors.some((e) => e.type === "genai-disabled")) {
     return null;
   }
 
   const isButtonDisabled =
-    state.isFetchingSolution ||
-    state.isAnalyzing ||
-    state.serverState !== "running" ||
-    genaiConfigError;
-
-  // Get tooltip message for disabled state
-  const getDisabledTooltip = () => {
-    if (genaiConfigError) {
-      return "GenAI features unavailable. Please configure your model provider settings.";
-    }
-    if (state.isFetchingSolution) {
-      return "Currently fetching solution...";
-    }
-    if (state.isAnalyzing) {
-      return "Analysis in progress...";
-    }
-    if (state.serverState !== "running") {
-      return "Kai analyzer server not running";
-    }
-    return "";
-  };
+    state.isFetchingSolution || state.isAnalyzing || state.serverState !== "running";
 
   const dropdown = (
     <Dropdown
@@ -121,11 +96,6 @@ const GetSolutionDropdown: React.FC<GetSolutionDropdownProps> = ({ incidents, sc
       </DropdownList>
     </Dropdown>
   );
-
-  // Wrap with tooltip if disabled
-  if (isButtonDisabled) {
-    return <Tooltip content={getDisabledTooltip()}>{dropdown}</Tooltip>;
-  }
 
   return dropdown;
 };


### PR DESCRIPTION
With this change, a user can disable genAI in the extension settings and we just disable all of the generative AI portions of the user flows.

Resolves #656 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - New toggle to enable/disable GenAI across the extension (default: enabled).
  - Added a distinct "GenAI disabled" error state to signal when GenAI is turned off.
  - Get Solution dropdown accepts a scope and can show an extra incident-specific action.

- UX Updates
  - Commands and UI respect the disabled state: Get Solution is blocked with a clear message, Agent Mode switch is hidden, walkthrough shows “Not configured” when disabled, and config warnings are more visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->