### PR TITLE
:sparkles: pull analyzer binary from package definition when not found

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -694,6 +694,31 @@
     "openSourceLabelsFile": "../downloaded_assets/opensource-labels-file/maven.default.index",
     "rulesets": "../downloaded_assets/rulesets"
   },
+  "konveyor.fallbackAssets": {
+    "baseUrl": "https://github.com/konveyor/kai/releases/download/v0.8.0-alpha.4/",
+    "assets": {
+      "linux-x64": {
+        "file": "kai-analyzer-rpc-linux-x86_64",
+        "sha256": "58d88fe81f2507974026cbc216f1e31e5596391cf422e783a6bb55e97816ee86"
+      },
+      "linux-arm64": {
+        "file": "kai-analyzer-rpc-linux-aarch64",
+        "sha256": "6d097960db24c77177f36f775c529861705e73f61eab0dff052aa9c52ce7a5b9"
+      },
+      "darwin-x64": {
+        "file": "kai-analyzer-rpc-macos-x86_64",
+        "sha256": "c6fc52b55426ee730a1290b662bffdba6a372ee50febda1938e4435e91227810"
+      },
+      "darwin-arm64": {
+        "file": "kai-analyzer-rpc-macos-arm64",
+        "sha256": "408243c994517528c7dbc7f4828ddb2c17bb51a2f21a2b73a6121f651174674a"
+      },
+      "win32-x64": {
+        "file": "kai-analyzer-rpc-windows-X64.exe",
+        "sha256": "f512bf519f529f5aad9b7a3cfba79125f8ec1a372afed01da2a1716bb76bfe78"
+      }
+    }
+  },
   "scripts": {
     "clean": "rimraf out",
     "lint": "eslint .",

--- a/vscode/src/paths.ts
+++ b/vscode/src/paths.ts
@@ -192,7 +192,12 @@ export async function ensurePaths(
   }
 
   // Ensure kai-analyzer-rpc binary exists
-  await ensureKaiAnalyzerBinary(context, logger);
+  try {
+    await ensureKaiAnalyzerBinary(context, logger);
+  } catch (error) {
+    logger.error("Failed to install kai analyzer:", error);
+    throw error;
+  }
 
   return _paths;
 }

--- a/vscode/src/paths.ts
+++ b/vscode/src/paths.ts
@@ -1,9 +1,15 @@
-import { relative, dirname, posix } from "node:path";
+import { relative, dirname, posix, join } from "node:path";
 import { readFileSync } from "node:fs";
 import { globbySync, isIgnoredByIgnoreFilesSync } from "globby";
 import * as vscode from "vscode";
 import slash from "slash";
 import winston from "winston";
+import { createHash } from "node:crypto";
+import { createWriteStream, createReadStream } from "node:fs";
+import { mkdir, chmod } from "node:fs/promises";
+import { pipeline } from "node:stream/promises";
+import { platform, arch } from "node:process";
+import * as fs from "fs-extra";
 
 export interface ExtensionPaths {
   /** Directory with the extension's sample resources. */
@@ -49,6 +55,97 @@ async function ensureDirectory(uri: vscode.Uri, ...parts: string[]): Promise<vsc
   return joined;
 }
 
+/**
+ * Downloads the kai-analyzer-rpc binary for the current platform if it doesn't exist
+ */
+async function ensureKaiAnalyzerBinary(
+  context: vscode.ExtensionContext,
+  logger: winston.Logger,
+): Promise<void> {
+  const packageJson = context.extension.packageJSON;
+  const assetPaths = {
+    kai: "./kai",
+    ...packageJson.includedAssetPaths,
+  };
+
+  // Convert to absolute paths
+  const kaiDir = context.asAbsolutePath(assetPaths.kai);
+  const kaiAnalyzerPath = join(
+    kaiDir,
+    `${platform}-${arch}`,
+    `kai-analyzer-rpc${platform === "win32" ? ".exe" : ""}`,
+  );
+
+  if (fs.existsSync(kaiAnalyzerPath)) {
+    return; // Binary already exists
+  }
+
+  logger.info(`kai-analyzer-rpc not found at ${kaiAnalyzerPath}, downloading...`);
+
+  const fallbackConfig = packageJson["konveyor.fallbackAssets"];
+  if (!fallbackConfig) {
+    throw new Error("No fallback asset configuration found in package.json");
+  }
+
+  const platformKey = `${platform}-${arch}`;
+  const assetConfig = fallbackConfig.assets[platformKey];
+
+  if (!assetConfig) {
+    throw new Error(`No fallback asset available for platform: ${platformKey}`);
+  }
+
+  const downloadUrl = `${fallbackConfig.baseUrl}${assetConfig.file}`;
+
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: "Downloading kai-analyzer-rpc",
+      cancellable: false,
+    },
+    async (progress) => {
+      progress.report({ message: "Downloading..." });
+
+      // Create target directory
+      await mkdir(dirname(kaiAnalyzerPath), { recursive: true });
+
+      // Download file
+      const response = await fetch(downloadUrl);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      if (!response.body) {
+        throw new Error("Response body is null");
+      }
+
+      const fileStream = createWriteStream(kaiAnalyzerPath);
+      await pipeline(response.body as any, fileStream);
+
+      progress.report({ message: "Verifying..." });
+
+      // Verify SHA256
+      const hash = createHash("sha256");
+      const verifyStream = createReadStream(kaiAnalyzerPath);
+      await pipeline(verifyStream, hash);
+      const actualSha256 = hash.digest("hex");
+
+      if (actualSha256 !== assetConfig.sha256) {
+        throw new Error(
+          `SHA256 mismatch. Expected: ${assetConfig.sha256}, Actual: ${actualSha256}`,
+        );
+      }
+
+      // Make executable on Unix systems
+      if (platform !== "win32") {
+        await chmod(kaiAnalyzerPath, 0o755);
+      }
+
+      progress.report({ message: "Complete!" });
+      logger.info(`Successfully downloaded kai-analyzer-rpc to: ${kaiAnalyzerPath}`);
+    },
+  );
+}
+
 export async function ensurePaths(
   context: vscode.ExtensionContext,
   logger: winston.Logger,
@@ -89,6 +186,9 @@ export async function ensurePaths(
   for (const key of Object.keys(_paths) as Array<keyof ExtensionPaths>) {
     _fsPaths[key] = _paths[key].fsPath;
   }
+
+  // Ensure kai-analyzer-rpc binary exists
+  await ensureKaiAnalyzerBinary(context, logger);
 
   return _paths;
 }


### PR DESCRIPTION
Fixes #695 

Uploading Screen Recording 2025-08-20 at 13.57.34.mov…


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically downloads, verifies (SHA‑256), and sets up the Kai analyzer binary on first run with UI progress and completion feedback.
  * Cross-platform support for Linux (x64/arm64), macOS (x64/arm64) and Windows (x64).

* **Chores**
  * Added fallback asset definitions and release URL entries (pointing to the Kai v0.8.0-alpha.4 release) to ensure binary availability and integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->