### PR TITLE
:test_tube: Use command palette to open analysis view when too many extensions

### DIFF
--- a/tests/e2e/pages/vscode.page.ts
+++ b/tests/e2e/pages/vscode.page.ts
@@ -147,7 +147,14 @@ export class VSCode extends BasePage {
   }
 
   public async openAnalysisView(): Promise<void> {
-    await this.openLeftBarElement(LeftBarItems.Konveyor);
+    // Try using command palette first - this works reliably when extension is hidden due to too many extensions
+    try {
+      await this.executeQuickCommand('Konveyor: Open Konveyor Analysis View');
+      return;
+    } catch (error) {
+      // Fallback to activity bar approach
+      await this.openLeftBarElement(LeftBarItems.Konveyor);
+    }
 
     await this.window.getByText('Konveyor Issues').dblclick();
 


### PR DESCRIPTION
When too many extensions are installed, the Konveyor extension may be hidden in the Additional Views overflow menu, making it inaccessible via activity bar selectors. This fix prioritizes using the command palette to open the analysis view, which works reliably regardless of extension visibility.

Changes:
- Modified openAnalysisView() to try command palette first
- Falls back to existing activity bar approach if command palette fails
- Fixed logic flow to only run fallback when needed


https://github.com/user-attachments/assets/eb37cfc7-51a1-4508-be3b-1f166f1de692



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test robustness for opening the Konveyor Analysis View by attempting the command palette first with automatic fallback to the activity bar.
  * Preserved the existing interaction flow (navigating issues and opening the analysis view link) to validate user paths.
  * Reduces flakiness across environments and stabilizes CI behavior.
  * No user-facing changes or API adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->