### PR TITLE
Add environment-based branding system for MTA/Konveyor switching

### DIFF
--- a/webview-ui/index.html
+++ b/webview-ui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Konveyor</title>
+    <title></title>
   </head>
   <body>
     <div id="root"></div>

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -6,11 +6,15 @@ import ResolutionPage from "./components/ResolutionsPage/ResolutionsPage";
 import { WebviewType } from "@editor-extensions/shared";
 import { ExtensionStateProvider } from "./context/ExtensionStateContext";
 import { ProfileManagerPage } from "./components/ProfileManager/ProfileManagerPage";
+import { getBrandName } from "./utils/branding";
 
 const App: React.FC = () => {
   const [currentView, setCurrentView] = useState<WebviewType>(viewType);
 
   useEffect(() => {
+    // Set document title based on brand
+    document.title = getBrandName();
+    
     // Update the view when viewType changes
     setCurrentView(viewType);
   }, [viewType]);

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -14,7 +14,7 @@ const App: React.FC = () => {
   useEffect(() => {
     // Set document title based on brand
     document.title = getBrandName();
-    
+
     // Update the view when viewType changes
     setCurrentView(viewType);
   }, [viewType]);

--- a/webview-ui/src/components/GetSolutionDropdown.tsx
+++ b/webview-ui/src/components/GetSolutionDropdown.tsx
@@ -11,7 +11,6 @@ import { EnhancedIncident } from "@editor-extensions/shared";
 import { useExtensionStateContext } from "../context/ExtensionStateContext";
 import { getSolution, getSolutionWithKonveyorContext } from "../hooks/actions";
 import { EllipsisVIcon, WrenchIcon } from "@patternfly/react-icons";
-import { Tooltip } from "@patternfly/react-core";
 import { getBrandName, isKonveyor } from "../utils/branding";
 
 type GetSolutionDropdownProps = {
@@ -85,14 +84,17 @@ const GetSolutionDropdown: React.FC<GetSolutionDropdownProps> = ({ incidents, sc
           <DropdownItem key="get-rag-solution" onClick={() => onGetSolution(incidents)}>
             Get solution
           </DropdownItem>
-          {scope === "incident" && incidents.length === 1 && state.isContinueInstalled && isKonveyor() && (
-            <DropdownItem
-              key="ask-continue-konveyor"
-              onClick={() => onGetSolutionWithKonveyorContext(incidents[0])}
-            >
-              Ask Continue with {getBrandName()} Context
-            </DropdownItem>
-          )}
+          {scope === "incident" &&
+            incidents.length === 1 &&
+            state.isContinueInstalled &&
+            isKonveyor() && (
+              <DropdownItem
+                key="ask-continue-konveyor"
+                onClick={() => onGetSolutionWithKonveyorContext(incidents[0])}
+              >
+                Ask Continue with {getBrandName()} Context
+              </DropdownItem>
+            )}
         </DropdownGroup>
       </DropdownList>
     </Dropdown>

--- a/webview-ui/src/components/GetSolutionDropdown.tsx
+++ b/webview-ui/src/components/GetSolutionDropdown.tsx
@@ -12,6 +12,7 @@ import { useExtensionStateContext } from "../context/ExtensionStateContext";
 import { getSolution, getSolutionWithKonveyorContext } from "../hooks/actions";
 import { EllipsisVIcon, WrenchIcon } from "@patternfly/react-icons";
 import { Tooltip } from "@patternfly/react-core";
+import { getBrandName, isKonveyor } from "../utils/branding";
 
 type GetSolutionDropdownProps = {
   incidents: EnhancedIncident[];
@@ -84,12 +85,12 @@ const GetSolutionDropdown: React.FC<GetSolutionDropdownProps> = ({ incidents, sc
           <DropdownItem key="get-rag-solution" onClick={() => onGetSolution(incidents)}>
             Get solution
           </DropdownItem>
-          {scope === "incident" && incidents.length === 1 && state.isContinueInstalled && (
+          {scope === "incident" && incidents.length === 1 && state.isContinueInstalled && isKonveyor() && (
             <DropdownItem
               key="ask-continue-konveyor"
               onClick={() => onGetSolutionWithKonveyorContext(incidents[0])}
             >
-              Ask Continue with Konveyor Context
+              Ask Continue with {getBrandName()} Context
             </DropdownItem>
           )}
         </DropdownGroup>

--- a/webview-ui/src/components/ProfileManager/ProfileEditorForm.tsx
+++ b/webview-ui/src/components/ProfileManager/ProfileEditorForm.tsx
@@ -32,6 +32,7 @@ import { AnalysisProfile, CONFIGURE_CUSTOM_RULES } from "@editor-extensions/shar
 import { ConfirmDialog } from "../ConfirmDialog/ConfirmDialog";
 import { CreatableMultiSelectField } from "./CreatableMultiSelectField";
 import { buildLabelSelector } from "@editor-extensions/shared";
+import { getBrandName } from "../../utils/branding";
 
 function useDebouncedCallback(callback: (...args: any[]) => void, delay: number) {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -267,7 +268,7 @@ export const ProfileEditorForm: React.FC<{
         <FormHelperText>
           <HelperText>
             <HelperTextItem icon={<InfoCircleIcon />}>
-              Include Konveyor&apos;s built-in migration rules
+              Include {getBrandName()}&apos;s built-in migration rules
             </HelperTextItem>
           </HelperText>
         </FormHelperText>

--- a/webview-ui/src/components/ResolutionsPage/ReceivedMessage.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ReceivedMessage.tsx
@@ -5,6 +5,7 @@ import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
 import botAv from "./bot_avatar.svg?inline";
 import { QuickResponse } from "../../../../shared/src/types/types";
+import { getBrandName } from "../../utils/branding";
 
 interface QuickResponseWithToken extends QuickResponse {
   messageToken: string;
@@ -58,7 +59,7 @@ export const ReceivedMessage: React.FC<ReceivedMessageProps> = ({
   return (
     <Message
       timestamp={formatTimestamp(timestamp)}
-      name="Konveyor"
+      name={getBrandName()}
       role="bot"
       avatar={botAv}
       content={content}

--- a/webview-ui/src/components/ResolutionsPage/ReceivedMessage.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ReceivedMessage.tsx
@@ -23,7 +23,7 @@ interface ReceivedMessageProps {
 export const ReceivedMessage: React.FC<ReceivedMessageProps> = ({
   content,
   extraContent,
-  isLoading,
+  isLoading: _isLoading,
   timestamp = new Date(),
   quickResponses,
   isProcessing = false,

--- a/webview-ui/src/utils/branding.ts
+++ b/webview-ui/src/utils/branding.ts
@@ -1,0 +1,19 @@
+export const getPublisher = (): string => {
+  return __PUBLISHER__;
+};
+
+export const isKonveyor = (): boolean => {
+  return getPublisher() === "konveyor";
+};
+
+export const isMTA = (): boolean => {
+  return getPublisher() === "mta";
+};
+
+export const getBrandName = (): string => {
+  return __BRAND_NAME__;
+};
+
+export const getBrandNameLowercase = (): string => {
+  return getBrandName().toLowerCase();
+};

--- a/webview-ui/src/vite-env.d.ts
+++ b/webview-ui/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+declare const __PUBLISHER__: string;
+declare const __BRAND_NAME__: string;

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig(() => {
   try {
     const rootPackageJson = JSON.parse(fs.readFileSync(rootPackageJsonPath, "utf-8"));
     publisher = rootPackageJson.publisher?.toLowerCase() || "konveyor";
-  } catch (error) {
+  } catch {
     console.warn("Could not read root package.json, using default publisher:", publisher);
   }
 

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -1,23 +1,42 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import checker from "vite-plugin-checker";
+import fs from "fs";
+import path from "path";
 
-export default defineConfig({
-  plugins: [react(), checker({ typescript: true })],
-  build: {
-    outDir: "build",
-    sourcemap: true,
-    chunkSizeWarningLimit: 1024,
-    rollupOptions: {
-      output: {
-        entryFileNames: `assets/[name].js`,
-        chunkFileNames: `assets/[name].js`,
-        assetFileNames: `assets/[name].[ext]`,
+export default defineConfig(() => {
+  // Read the root package.json to get publisher info
+  const rootPackageJsonPath = path.resolve(__dirname, "../package.json");
+  let publisher = "konveyor"; // default fallback
+
+  try {
+    const rootPackageJson = JSON.parse(fs.readFileSync(rootPackageJsonPath, "utf-8"));
+    publisher = rootPackageJson.publisher?.toLowerCase() || "konveyor";
+  } catch (error) {
+    console.warn("Could not read root package.json, using default publisher:", publisher);
+  }
+
+  return {
+    plugins: [react(), checker({ typescript: true })],
+    define: {
+      __PUBLISHER__: JSON.stringify(publisher),
+      __BRAND_NAME__: JSON.stringify(publisher === "konveyor" ? "Konveyor" : "MTA"),
+    },
+    build: {
+      outDir: "build",
+      sourcemap: true,
+      chunkSizeWarningLimit: 1024,
+      rollupOptions: {
+        output: {
+          entryFileNames: `assets/[name].js`,
+          chunkFileNames: `assets/[name].js`,
+          assetFileNames: `assets/[name].[ext]`,
+        },
       },
     },
-  },
-  base: "/out/webview", // this should match where the build files land after `npm run dist`
-  server: {
-    cors: true,
-  },
+    base: "/out/webview", // this should match where the build files land after `npm run dist`
+    server: {
+      cors: true,
+    },
+  };
 });


### PR DESCRIPTION
## Summary
- Implement dynamic branding in webview-ui that switches between "MTA" and "Konveyor" based on the publisher field in package.json
- Allow the same codebase to be built with different branding without code changes
- Add conditional features based on brand (e.g., Continue integration only for Konveyor)

## Changes Made
- Enhanced `vite.config.ts` to read publisher from `package.json` and define build-time environment variables
- Created `src/utils/branding.ts` with brand detection and helper utilities  
- Updated UI components to use dynamic brand names instead of hardcoded "Konveyor"
- Added TypeScript definitions for new global variables (`__PUBLISHER__`, `__BRAND_NAME__`)
- Made Konveyor-specific features conditional on brand detection
- Set document title dynamically based on brand

## Test plan
- [x] Build succeeds with default Konveyor publisher
- [x] Build succeeds when publisher changed to "MTA" 
- [x] UI components use dynamic branding
- [x] Konveyor-specific features only appear for Konveyor brand
- [x] TypeScript compilation passes
- [x] Lint checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Dynamic branding across the UI: window title, bot name, helper text, and dropdown labels now reflect the active product brand.
  - The “Ask Continue with [Brand] Context” option is shown only when supported for the current distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->