### PR TITLE
:bug: Fix auto-analysis trigger and config key mismatch

### DIFF
--- a/vscode/src/utilities/ModifiedFiles/handleFileResponse.ts
+++ b/vscode/src/utilities/ModifiedFiles/handleFileResponse.ts
@@ -1,7 +1,7 @@
 import { ExtensionState } from "../../extensionState";
 import * as vscode from "vscode";
 import { ChatMessageType } from "@editor-extensions/shared";
-import { getConfigAgentMode } from "../configuration";
+import { getConfigAgentMode, getConfigAnalyzeOnSave } from "../configuration";
 
 /**
  * Creates a new file with the specified content
@@ -137,9 +137,9 @@ export async function handleFileResponse(
           await updateExistingFile(uri, path, fileContent, state);
         }
 
-        // Trigger analysis after file changes are applied in agentic mode
+        // Trigger analysis after file changes are applied in agentic mode or when analyze on save is enabled
         // This ensures that the tasks interaction can detect new diagnostic issues
-        if (getConfigAgentMode()) {
+        if (getConfigAgentMode() || getConfigAnalyzeOnSave()) {
           try {
             await state.analyzerClient.runAnalysis([uri]);
           } catch (analysisError) {


### PR DESCRIPTION
- Fix configuration key mismatch: use "konveyor.diff.autoAcceptOnSave" to match package.json setting definition
- Fix analysis not triggering after file changes: now triggers when either agent mode OR analyze on save is enabled
- Previously analysis only triggered in agent mode, causing manual save requirement in non-agent scenarios



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Analyze on Save” setting to automatically trigger analysis after file changes/saves.
  * Analysis now runs on save even when Agent Mode is off, if the new setting is enabled.
* **Settings**
  * New toggle available in preferences to control “Analyze on Save.”
* **Improvements**
  * Clarified in-app messaging/comments to reflect the expanded analysis trigger condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->