### PR TITLE
:test_tube: Llm revert check #620

### DIFF
--- a/tests/e2e/fixtures/test-repos.json
+++ b/tests/e2e/fixtures/test-repos.json
@@ -28,5 +28,12 @@
     "sources": [],
     "targets": ["openjdk21"],
     "customRulesFolder": "ehr_viewer/rules"
+  },
+  "jboss-eap-quickstarts": {
+    "repoUrl": "https://github.com/jboss-developer/jboss-eap-quickstarts",
+    "repoName": "jboss-eap-quickstarts",
+    "branch": "7.4.x",
+    "sources": [],
+    "targets": ["eap7", "eap8"]
   }
 }

--- a/tests/e2e/pages/vscode.page.ts
+++ b/tests/e2e/pages/vscode.page.ts
@@ -27,7 +27,7 @@ export class VSCode extends BasePage {
     super(app, window);
   }
 
-  public static async open(repoUrl?: string, repoDir?: string, branch?: string) {
+  public static async open(repoUrl?: string, repoDir?: string, branch = 'main') {
     /**
      * user-data-dir is passed to force opening a new instance avoiding the process to couple with an existing vscode instance
      * so Playwright doesn't detect that the process has finished
@@ -43,14 +43,8 @@ export class VSCode extends BasePage {
         if (repoDir) {
           await cleanupRepo(repoDir);
         }
-        console.log(`Cloning repository from ${repoUrl}${branch ? ` (branch: ${branch})` : ''}`);
-
-        if (branch) {
-          execSync(`git clone -b ${branch} ${repoUrl}`);
-        } else {
-          // Clone default branch
-          execSync(`git clone ${repoUrl}`);
-        }
+        console.log(`Cloning repository from ${repoUrl} -b ${branch}`);
+        execSync(`git clone ${repoUrl} -b ${branch}`);
       }
     } catch (error: any) {
       throw new Error('Failed to clone the repository');
@@ -352,6 +346,7 @@ export class VSCode extends BasePage {
     const modifier = getOSInfo() === 'macOS' ? 'Meta' : 'Control';
     await this.window.keyboard.press(`${modifier}+a+Delete`);
     await this.pasteContent(config);
+    await this.waitDefault();
     await this.window.keyboard.press(`${modifier}+s`, { delay: 500 });
   }
 
@@ -571,6 +566,39 @@ export class VSCode extends BasePage {
     } catch (error) {
       console.error('Error writing VSCode settings:', error);
       throw error;
+    }
+  }
+  public async waitForSolutionConfirmation(view: FrameLocator): Promise<void> {
+    const solutionButton = view.locator('button#get-solution-button');
+    const backdrop = view.locator('div.pf-v6-c-backdrop');
+
+    // Wait for both conditions to be true concurrently
+    await Promise.all([
+      // 1. Wait for the button to be enabled (color is back to default)
+      expect(solutionButton.first()).not.toBeDisabled({ timeout: 3600000 }),
+
+      // 2. Wait for the blocking overlay to disappear
+      expect(backdrop).not.toBeVisible({ timeout: 3600000 }),
+    ]);
+  }
+
+  public async searchViolationAndacceptAllSolutions(violation: string) {
+    await this.searchAndRequestFix(violation, 1);
+
+    const resolutionView = await this.getView(KAIViews.resolutionDetails);
+    const fixLocator = resolutionView.locator('button[aria-label="Accept all changes"]');
+
+    await this.waitDefault();
+    await expect(fixLocator.first()).toBeVisible({ timeout: 3600000 });
+
+    const fixesNumber = await fixLocator.count();
+    let fixesCounter = await fixLocator.count();
+    for (let i = 0; i < fixesNumber; i++) {
+      await expect(fixLocator.first()).toBeVisible({ timeout: 30000 });
+      // Ensures the button is clicked even if there are notifications overlaying it due to screen size
+      await fixLocator.first().dispatchEvent('click');
+      await this.waitDefault();
+      expect(await fixLocator.count()).toEqual(--fixesCounter);
     }
   }
 }

--- a/tests/e2e/pages/vscode.page.ts
+++ b/tests/e2e/pages/vscode.page.ts
@@ -346,7 +346,6 @@ export class VSCode extends BasePage {
     const modifier = getOSInfo() === 'macOS' ? 'Meta' : 'Control';
     await this.window.keyboard.press(`${modifier}+a+Delete`);
     await this.pasteContent(config);
-    await this.waitDefault();
     await this.window.keyboard.press(`${modifier}+s`, { delay: 500 });
   }
 

--- a/tests/e2e/pages/vscode.page.ts
+++ b/tests/e2e/pages/vscode.page.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { execSync } from 'child_process';
 import { _electron as electron, FrameLocator } from 'playwright';
 import { ElectronApplication, expect, Page } from '@playwright/test';
-import { MIN, SEC, MAX_ISSUES_TO_FIX } from '../utilities/consts';
+import { MIN, SEC } from '../utilities/consts';
 import { createZip, extractZip } from '../utilities/archive';
 import { cleanupRepo, generateRandomString, getOSInfo } from '../utilities/utils';
 import { LeftBarItems } from '../enums/left-bar-items.enum';
@@ -588,7 +588,8 @@ export class VSCode extends BasePage {
     const window = this.getWindow();
     await expect(fixLocator.first()).toBeVisible({ timeout: 10 * MIN });
 
-    for (let i = 0; i <= MAX_ISSUES_TO_FIX; i++) {
+    let llmHasMoreSolutins = true;
+    while(llmHasMoreSolutins){
       await expect(fixLocator.first()).toBeVisible({ timeout: 5 * MIN });
       await fixLocator.first().dispatchEvent('click');
       const successNotification = window.locator('.notification-list-item', {
@@ -609,7 +610,7 @@ export class VSCode extends BasePage {
 
       const count = await lastMessageWithButton.count();
       if (count > 0) {
-        break;
+        llmHasMoreSolutins = false;
       }
     }
   }

--- a/tests/e2e/pages/vscode.page.ts
+++ b/tests/e2e/pages/vscode.page.ts
@@ -567,9 +567,10 @@ export class VSCode extends BasePage {
       throw error;
     }
   }
-  public async waitForSolutionConfirmation(view: FrameLocator): Promise<void> {
-    const solutionButton = view.locator('button#get-solution-button');
-    const backdrop = view.locator('div.pf-v6-c-backdrop');
+  public async waitForSolutionConfirmation(): Promise<void> {
+    const analysisView = await this.getView(KAIViews.analysisView);
+    const solutionButton = analysisView.locator('button#get-solution-button');
+    const backdrop = analysisView.locator('div.pf-v6-c-backdrop');
 
     // Wait for both conditions to be true concurrently
     await Promise.all([
@@ -584,38 +585,23 @@ export class VSCode extends BasePage {
   public async acceptAllSolutions() {
     const resolutionView = await this.getView(KAIViews.resolutionDetails);
     const fixLocator = resolutionView.locator('button[aria-label="Accept all changes"]');
-    const window = this.getWindow();
-    await expect(fixLocator.first()).toBeVisible({ timeout: 10 * MIN });
 
-    let llmHasMoreSolutins = true;
-    while(llmHasMoreSolutins){
-      await expect(fixLocator.first()).toBeVisible({ timeout: 5 * MIN });
+    await this.waitDefault();
+    await expect(fixLocator.first()).toBeVisible({ timeout: 3600000 });
+
+    const fixesNumber = await fixLocator.count();
+    let fixesCounter = await fixLocator.count();
+    for (let i = 0; i < fixesNumber; i++) {
+      await expect(fixLocator.first()).toBeVisible({ timeout: 30000 });
+      // Ensures the button is clicked even if there are notifications overlaying it due to screen size
       await fixLocator.first().dispatchEvent('click');
-      const successNotification = window.locator('.notification-list-item', {
-        hasText: 'Analysis completed successfully!',
-      });
-      await expect(successNotification).toBeVisible({ timeout: 2 * MIN });
-      await successNotification.hover();
-      await successNotification
-        .getByRole('button', { name: 'Clear Notification (Delete)' })
-        .click();
-      await window.waitForTimeout(10 * SEC);
-      const openInEditorButtonLocator = resolutionView.getByRole('button', {
-        name: 'Open in Editor',
-      });
-      const lastMessageWithButton = resolutionView.locator('.message-wrapper').last().filter({
-        has: openInEditorButtonLocator,
-      });
-
-      const count = await lastMessageWithButton.count();
-      if (count > 0) {
-        llmHasMoreSolutins = false;
-      }
+      await this.waitDefault();
+      expect(await fixLocator.count()).toEqual(--fixesCounter);
     }
   }
 
-  public async searchViolationAndacceptAllSolutions(violation: string) {
-    await this.searchAndRequestFix(violation, 1);
+  public async searchViolationAndAcceptAllSolutions(violation: string) {
+    await this.searchAndRequestFix(violation, FixTypes.Issue);
     await this.acceptAllSolutions();
   }
 }

--- a/tests/e2e/tests/base/llm-revert-check_jboss-eap-quickstarts.test.ts
+++ b/tests/e2e/tests/base/llm-revert-check_jboss-eap-quickstarts.test.ts
@@ -1,0 +1,114 @@
+import { expect, test } from '../../fixtures/test-repo-fixture';
+import { VSCode } from '../../pages/vscode.page';
+import { SCREENSHOTS_FOLDER, MIN } from '../../utilities/consts';
+import { getAvailableProviders } from '../../fixtures/provider-configs.fixture';
+import { getRepoName, generateRandomString } from '../../utilities/utils';
+
+import path from 'path';
+import { KAIViews } from '../../enums/views.enum';
+import { getFileImports } from '../../utilities/file.utils';
+/**
+ * Automates https://github.com/konveyor/kai/issues/798
+ * Tests that fixes applied by the LLM do not unintentionally revert .
+ *
+ * - Runs migration analysis and applies two specific fixes.
+ * - Captures and compares import statements before and after fixes.
+ * - Ensures earlier fixes are not reverted by later ones.
+ */
+getAvailableProviders().forEach((provider) => {
+  test.describe(`@tier1 LLM Revertion tests | ${provider.model}`, () => {
+    let vscodeApp: VSCode;
+    const randomString = generateRandomString();
+    let profileName = `llm-reversion-${randomString}`;
+
+    const kitchenRepoPath = 'jboss-eap-quickstarts/kitchensink';
+    const memberFileUri = path.resolve(
+      kitchenRepoPath,
+      'src/main/java/org/jboss/as/quickstarts/kitchensink/model/Member.java'
+    );
+    let beforeTestMemberFileImports: string[];
+    let afterFirstFixMemberFileImports: string[];
+    let afterSecondFixMemberFileImports: string[];
+
+    test.beforeAll(async ({ testRepoData }, testInfo) => {
+      test.setTimeout(15 * MIN);
+      const repoName = getRepoName(testInfo);
+      const repoInfo = testRepoData[repoName];
+
+      vscodeApp = await VSCode.open(repoInfo.repoUrl, repoInfo.repoName, repoInfo.branch);
+      await vscodeApp.closeVSCode();
+      // Only analyzing kitchensink to save time vs. full jboss repo
+      vscodeApp = await VSCode.open(undefined, kitchenRepoPath, undefined);
+      await vscodeApp.createProfile(repoInfo.sources, repoInfo.targets, profileName);
+      await vscodeApp.configureGenerativeAI(provider.config);
+      await vscodeApp.startServer();
+    });
+
+    test.beforeEach(async () => {
+      const testName = test.info().title.replace(' ', '-');
+      console.log(`Starting ${testName} at ${new Date()}`);
+    });
+
+    test('Analyze jboss-eap-quickstarts', async () => {
+      test.setTimeout(30 * MIN);
+      await vscodeApp.waitDefault();
+      await vscodeApp.runAnalysis();
+
+      console.log(new Date().toLocaleTimeString(), 'Analysis started');
+      await vscodeApp.waitDefault();
+      await expect(vscodeApp.getWindow().getByText('Analysis completed').first()).toBeVisible({
+        timeout: 15 * MIN,
+      });
+    });
+
+    test('Fix "The package javax has been replaced by jakarta"', async () => {
+      test.setTimeout(15 * MIN);
+      beforeTestMemberFileImports = getFileImports(memberFileUri);
+      const violation = "The package 'javax' has been replaced by 'jakarta'";
+
+      await vscodeApp.openAnalysisView();
+      await vscodeApp.searchViolationAndacceptAllSolutions(violation);
+      await vscodeApp.openAnalysisView();
+      const analysisView = await vscodeApp.getView(KAIViews.analysisView);
+      await vscodeApp.waitForSolutionConfirmation(analysisView);
+
+      afterFirstFixMemberFileImports = getFileImports(memberFileUri);
+    });
+
+    test('Fix "Implicit name determination for sequences and tables associated with identifier generation has changed"', async () => {
+      test.setTimeout(15 * MIN);
+      const violation =
+        'Implicit name determination for sequences and tables associated with identifier generation has changed';
+
+      await vscodeApp.openAnalysisView();
+      await vscodeApp.searchViolationAndacceptAllSolutions(violation);
+      await vscodeApp.openAnalysisView();
+      const analysisView = await vscodeApp.getView(KAIViews.analysisView);
+      await vscodeApp.waitForSolutionConfirmation(analysisView);
+
+      afterSecondFixMemberFileImports = getFileImports(memberFileUri);
+    });
+
+    test('Checking For Reverted Imports', async () => {
+      //checks that imports removed by the first fix were not reintroduced by the second fix.
+      const revertedImports = beforeTestMemberFileImports.filter(
+        (line) =>
+          !afterFirstFixMemberFileImports.includes(line) &&
+          afterSecondFixMemberFileImports.includes(line)
+      );
+      expect(revertedImports).toHaveLength(0);
+    });
+
+    test.afterEach(async () => {
+      const testName = test.info().title.replace(' ', '-');
+      console.log(`Finished ${testName} at ${new Date()}`);
+      await vscodeApp.getWindow().screenshot({
+        path: `${SCREENSHOTS_FOLDER}/after-${testName}-${provider.model.replace(/[.:]/g, '-')}.png`,
+      });
+    });
+
+    test.afterAll(async () => {
+      await vscodeApp.closeVSCode();
+    });
+  });
+});

--- a/tests/e2e/tests/base/llm-revert-check_jboss-eap-quickstarts.test.ts
+++ b/tests/e2e/tests/base/llm-revert-check_jboss-eap-quickstarts.test.ts
@@ -18,8 +18,7 @@ import { getFileImports } from '../../utilities/file.utils';
 getAvailableProviders().forEach((provider) => {
   test.describe(`@tier1 LLM Revertion tests | ${provider.model}`, () => {
     let vscodeApp: VSCode;
-    const randomString = generateRandomString();
-    let profileName = `llm-reversion-${randomString}`;
+    const profileName = `llm-reversion-${generateRandomString()}`;
 
     const kitchenRepoPath = 'jboss-eap-quickstarts/kitchensink';
     const memberFileUri = path.resolve(
@@ -53,9 +52,6 @@ getAvailableProviders().forEach((provider) => {
       test.setTimeout(30 * MIN);
       await vscodeApp.waitDefault();
       await vscodeApp.runAnalysis();
-
-      console.log(new Date().toLocaleTimeString(), 'Analysis started');
-      await vscodeApp.waitDefault();
       await expect(vscodeApp.getWindow().getByText('Analysis completed').first()).toBeVisible({
         timeout: 15 * MIN,
       });
@@ -67,7 +63,7 @@ getAvailableProviders().forEach((provider) => {
       const violation = "The package 'javax' has been replaced by 'jakarta'";
 
       await vscodeApp.openAnalysisView();
-      await vscodeApp.searchViolationAndacceptAllSolutions(violation);
+      await vscodeApp.searchViolationAndAcceptAllSolutions(violation);
       await vscodeApp.openAnalysisView();
       const analysisView = await vscodeApp.getView(KAIViews.analysisView);
       await vscodeApp.waitForSolutionConfirmation(analysisView);
@@ -81,7 +77,7 @@ getAvailableProviders().forEach((provider) => {
         'Implicit name determination for sequences and tables associated with identifier generation has changed';
 
       await vscodeApp.openAnalysisView();
-      await vscodeApp.searchViolationAndacceptAllSolutions(violation);
+      await vscodeApp.searchViolationAndAcceptAllSolutions(violation);
       await vscodeApp.openAnalysisView();
       const analysisView = await vscodeApp.getView(KAIViews.analysisView);
       await vscodeApp.waitForSolutionConfirmation(analysisView);

--- a/tests/e2e/utilities/consts.ts
+++ b/tests/e2e/utilities/consts.ts
@@ -2,3 +2,5 @@ export const TEST_OUTPUT_FOLDER = 'test-output';
 export const SCREENSHOTS_FOLDER = 'test-output/screenshots';
 export const ORIGINAL_ANALYSIS_FILENAME = 'original_analysis.json';
 export const TEST_DATA_DIR = 'test-data-dir';
+export const SEC = 1000;
+export const MIN = 60 * SEC;

--- a/tests/e2e/utilities/consts.ts
+++ b/tests/e2e/utilities/consts.ts
@@ -4,4 +4,3 @@ export const ORIGINAL_ANALYSIS_FILENAME = 'original_analysis.json';
 export const TEST_DATA_DIR = 'test-data-dir';
 export const SEC = 1000;
 export const MIN = 60 * SEC;
-export const MAX_ISSUES_TO_FIX = 300;

--- a/tests/e2e/utilities/consts.ts
+++ b/tests/e2e/utilities/consts.ts
@@ -4,3 +4,4 @@ export const ORIGINAL_ANALYSIS_FILENAME = 'original_analysis.json';
 export const TEST_DATA_DIR = 'test-data-dir';
 export const SEC = 1000;
 export const MIN = 60 * SEC;
+export const MAX_ISSUES_TO_FIX = 300;

--- a/tests/e2e/utilities/file.utils.ts
+++ b/tests/e2e/utilities/file.utils.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+
+export function getFileImports(absoluteFilePath: string): string[] {
+  if (!fs.existsSync(absoluteFilePath)) {
+    return [];
+  }
+  const importsData: string[] = [];
+  const data = fs.readFileSync(absoluteFilePath, 'utf-8');
+  const lines = data.split(/\r?\n/);
+  for (const line of lines) {
+    if (line.startsWith('import')) {
+      importsData.push(line);
+    }
+  }
+  return importsData;
+}

--- a/tests/e2e/utilities/file.utils.ts
+++ b/tests/e2e/utilities/file.utils.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import * as fs from 'fs';
 
 export function getFileImports(absoluteFilePath: string): string[] {
   if (!fs.existsSync(absoluteFilePath)) {

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -43,10 +43,5 @@ export default defineConfig({
       name: 'agent-flow-tests',
       testMatch: /.*agent_flow.+\.test\.ts/,
     },
-    {
-      name: 'llm-checks',
-      testMatch: /llm-revert-check_jboss-eap-quickstarts\.test\.ts/,
-      dependencies: ['base'],
-    },
   ],
 });

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -43,5 +43,10 @@ export default defineConfig({
       name: 'agent-flow-tests',
       testMatch: /.*agent_flow.+\.test\.ts/,
     },
+    {
+      name: 'llm-checks',
+      testMatch: /llm-revert-check_jboss-eap-quickstarts\.test\.ts/,
+      dependencies: ['base'],
+    },
   ],
 });


### PR DESCRIPTION
### Summary

This PR introduces a new end-to-end test suite (`llm-revert-check`) to validate the consistency of sequential fixes. It ensures that applying a new fix does not revert or conflict with previously applied fixes.

To support this new test, several enhancements and utilities have been added to the testing infrastructure.

### Key Changes

- **New LLM Revert-Check Test:**
  - A dedicated test that analyzes the `jboss-eap-quickstarts` repository.
  - It applies a `javax` to `jakarta` fix, then applies another fix, and finally asserts that the initial fix was not undone.

- **Test Infrastructure Enhancements:**
  - **Branch-Specific Cloning:** The `VSCode.open` method now supports cloning a specific repository branch.
  - **New Test Utilities:**
    - `file.utils.ts`: A new utility with a `getFileImports` function to extract import statements from a file for comparison.
    - `evaluation.utils.ts`: Modified to handle analysis file paths for different repositories, not just the hardcoded `coolstore` path.
  - **New Page Object Method:** Added `closeAllOtherEditors` to the `VSCode` page object to ensure a clean and predictable UI state during tests.

- **Configuration Updates:**
  - The `jboss-eap-quickstarts` repository has been added to the test data fixtures.
  - A new `llm-checks` project has been added to `playwright.config.ts` to run the new test suite.

This collection of changes provides a robust framework for testing the reliability of the LLM remediation feature over multiple interactions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added an end-to-end scenario validating AI-assisted fixes on JBoss EAP quickstarts to prevent import regressions.
  - Expanded test repositories to include JBoss EAP quickstarts (branch 7.4.x) targeting eap7 and eap8.

- **New Features**
  - Improved test automation to search violations, accept suggested fixes iteratively, and use more resilient waits/timeouts.
  - Added a utility to extract file imports and standardized time constants for more reliable test timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->