### PR TITLE
:bug: hide agent button when genAI disabled

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -372,10 +372,16 @@ class VsCodeExtension {
             this.setupModelProvider(paths().settingsYaml)
               .then((configError) => {
                 this.state.mutateData((draft) => {
+                  // Clear all GenAI-related config errors
+                  draft.configErrors = draft.configErrors.filter(
+                    (e) =>
+                      e.type !== "genai-disabled" &&
+                      e.type !== "provider-not-configured" &&
+                      e.type !== "provider-connection-failed",
+                  );
+
+                  // Add new config error if one exists
                   if (configError) {
-                    draft.configErrors = draft.configErrors.filter(
-                      (e) => e.type !== configError.type,
-                    );
                     draft.configErrors.push(configError);
                   }
                 });
@@ -383,14 +389,18 @@ class VsCodeExtension {
               .catch((error) => {
                 this.state.logger.error("Error setting up model provider:", error);
                 this.state.mutateData((draft) => {
-                  if (error) {
-                    const configError = createConfigError.providerConnnectionFailed();
-                    draft.configErrors = draft.configErrors.filter(
-                      (e) => e.type !== configError.type,
-                    );
-                    configError.error = error instanceof Error ? error.message : String(error);
-                    draft.configErrors.push(configError);
-                  }
+                  // Clear all GenAI-related config errors
+                  draft.configErrors = draft.configErrors.filter(
+                    (e) =>
+                      e.type !== "genai-disabled" &&
+                      e.type !== "provider-not-configured" &&
+                      e.type !== "provider-connection-failed",
+                  );
+
+                  // Add connection failed error
+                  const configError = createConfigError.providerConnnectionFailed();
+                  configError.error = error instanceof Error ? error.message : String(error);
+                  draft.configErrors.push(configError);
                 });
               });
           }

--- a/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
+++ b/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
@@ -88,6 +88,7 @@ const AnalysisPage: React.FC = () => {
   const hasViolations = violations.length > 0;
   const hasAnalysisResults = !!analysisResults;
   const serverRunning = serverState === "running";
+  const isGenAIDisabled = rawConfigErrors.some((error) => error.type === "genai-disabled");
 
   const drawerRef = React.useRef<HTMLDivElement>(null);
 
@@ -151,20 +152,22 @@ const AnalysisPage: React.FC = () => {
                             hasWarning={configInvalid}
                           />
                         </ToolbarItem>
-                        <ToolbarItem>
-                          <div>
-                            <div className="agent-mode-wrapper">
-                              <Switch
-                                id="agent-mode-switch"
-                                isChecked={isAgentMode}
-                                label="Agent Mode"
-                                onChange={(_event) => handleAgentModeToggle()}
-                                aria-label="Toggle Agent Mode"
-                                isReversed
-                              />
+                        {!isGenAIDisabled && (
+                          <ToolbarItem>
+                            <div>
+                              <div className="agent-mode-wrapper">
+                                <Switch
+                                  id="agent-mode-switch"
+                                  isChecked={isAgentMode}
+                                  label="Agent Mode"
+                                  onChange={(_event) => handleAgentModeToggle()}
+                                  aria-label="Toggle Agent Mode"
+                                  isReversed
+                                />
+                              </div>
                             </div>
-                          </div>
-                        </ToolbarItem>
+                          </ToolbarItem>
+                        )}
                         <ToolbarItem>
                           <ConfigButton
                             onClick={() => setIsConfigOpen(true)}


### PR DESCRIPTION
Fixes #716
Fixes #719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated GenAI configuration error handling to display only the most recent relevant error, preventing duplicates or lingering messages during initialization and configuration updates.
  * Improved reliability of error updates when provider connectivity issues occur, replacing outdated errors with the latest status.
  * Updated the Analysis page to hide the Agent Mode toggle when GenAI is disabled, preventing interaction with unavailable features and reducing confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->