### PR TITLE
:sparkles: Add MTA branding scripts for downstream repo

### DIFF
--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+console.log("🔄 Running MTA postbuild script...");
+
+// Optional: Copy MTA-specific assets
+const assetsDir = path.join(__dirname, "../assets/mta");
+const resourcesDir = path.join(__dirname, "../vscode/resources");
+
+if (fs.existsSync(assetsDir)) {
+  // Copy MTA icon if it exists
+  const mtaIcon = path.join(assetsDir, "mta-icon-color.png");
+  const targetIcon = path.join(resourcesDir, "mta-icon-color.png");
+
+  if (fs.existsSync(mtaIcon)) {
+    fs.copyFileSync(mtaIcon, targetIcon);
+    console.log("✅ Copied MTA icon assets");
+  }
+}
+
+// Optional: Generate MTA-specific documentation
+const docsDir = path.join(__dirname, "../docs/mta");
+if (fs.existsSync(docsDir)) {
+  console.log("✅ MTA documentation ready");
+}
+
+// Optional: Package validation
+const packagePath = path.join(__dirname, "../vscode/package.json");
+const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+
+if (packageJson.publisher === "mta" && packageJson.name === "mta") {
+  console.log("✅ MTA package configuration validated");
+} else {
+  console.error("❌ Package configuration validation failed");
+  process.exit(1);
+}
+
+console.log("✅ MTA postbuild complete");

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Determine branding from environment or default to konveyor
+const brandingName = process.env.BRANDING || "konveyor";
+
+console.log(`🔄 Running prebuild script with branding: ${brandingName}`);
+
+// Read branding strings from package.json
+const packagePath = path.join(__dirname, "../vscode/package.json");
+const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+
+let brandingStrings;
+try {
+  brandingStrings = packageJson.branding[brandingName];
+  if (!brandingStrings) {
+    throw new Error(`Branding configuration '${brandingName}' not found in package.json`);
+  }
+} catch (error) {
+  console.error(
+    `❌ Could not read branding configuration '${brandingName}' from package.json:`,
+    error,
+  );
+  process.exit(1);
+}
+
+console.log(`📦 Transforming package.json for ${brandingStrings.productName}...`);
+
+// Apply core branding transformations
+Object.assign(packageJson, {
+  name: brandingStrings.extensionName,
+  displayName: brandingStrings.displayName,
+  description: brandingStrings.description,
+  publisher: brandingStrings.publisher,
+  author: brandingStrings.author,
+  icon: brandingStrings.icon,
+});
+
+// Transform configuration properties
+if (packageJson.contributes?.configuration?.properties) {
+  const props = packageJson.contributes.configuration.properties;
+  const newProps = {};
+
+  Object.keys(props).forEach((key) => {
+    const newKey = key.replace(/^[^.]+\./, `${brandingStrings.configPrefix}.`);
+    newProps[newKey] = props[key];
+  });
+
+  packageJson.contributes.configuration.properties = newProps;
+  packageJson.contributes.configuration.title = brandingStrings.productName;
+}
+
+// Transform commands
+if (packageJson.contributes?.commands) {
+  // Categories that should not be transformed by branding
+  const preservedCategories = ["diffEditor"];
+
+  packageJson.contributes.commands = packageJson.contributes.commands.map((cmd) => ({
+    ...cmd,
+    command: cmd.command.replace(/^[^.]+\./, `${brandingStrings.commandPrefix}.`),
+    // Only transform category if it's not in the preserved list
+    category: preservedCategories.includes(cmd.category) ? cmd.category : brandingStrings.category,
+    // Handle bidirectional transformation for titles
+    title: cmd.title?.replace(/(Konveyor|MTA)/g, brandingStrings.productName) || cmd.title,
+  }));
+}
+
+// Transform views and containers
+if (packageJson.contributes?.viewsContainers?.activitybar) {
+  packageJson.contributes.viewsContainers.activitybar =
+    packageJson.contributes.viewsContainers.activitybar.map((container) => ({
+      ...container,
+      id: brandingStrings.viewPrefix,
+      title: brandingStrings.productName,
+      icon: brandingStrings.icon,
+    }));
+}
+
+if (packageJson.contributes?.views) {
+  const newViews = {};
+  Object.keys(packageJson.contributes.views).forEach((viewKey) => {
+    newViews[brandingStrings.viewPrefix] = packageJson.contributes.views[viewKey].map((view) => ({
+      ...view,
+      id: view.id.replace(/^[^.]+\./, `${brandingStrings.viewPrefix}.`),
+      name: view.name.replace(/\b\w+/, brandingStrings.productName),
+    }));
+  });
+  packageJson.contributes.views = newViews;
+}
+
+// Transform menus
+if (packageJson.contributes?.menus) {
+  const transformMenuCommands = (menuItems) => {
+    return menuItems.map((item) => ({
+      ...item,
+      command: item.command?.replace(/^[^.]+\./, `${brandingStrings.commandPrefix}.`),
+      when: item.when
+        // Handle bidirectional transformation for any existing branding
+        ?.replace(/(konveyor|mta)\.issueView/g, `${brandingStrings.viewPrefix}.issueView`)
+        .replace(/(konveyor|mta)(?=\s|$)/g, brandingStrings.viewPrefix),
+      submenu: item.submenu?.replace(/^(konveyor|mta)\./, `${brandingStrings.viewPrefix}.`),
+    }));
+  };
+
+  const newMenus = {};
+  Object.keys(packageJson.contributes.menus).forEach((menuKey) => {
+    // Handle bidirectional transformation for menu keys
+    const newMenuKey =
+      menuKey.includes("konveyor") || menuKey.includes("mta")
+        ? menuKey.replace(/(konveyor|mta)/g, brandingStrings.viewPrefix)
+        : menuKey;
+    newMenus[newMenuKey] = transformMenuCommands(packageJson.contributes.menus[menuKey]);
+  });
+  packageJson.contributes.menus = newMenus;
+}
+
+// Transform submenus
+if (packageJson.contributes?.submenus) {
+  packageJson.contributes.submenus = packageJson.contributes.submenus.map((submenu) => ({
+    ...submenu,
+    id: submenu.id.replace(/^(konveyor|mta)/, `${brandingStrings.viewPrefix}`),
+    label: `${brandingStrings.productName} Actions`,
+  }));
+}
+
+// Skip activation events transformation - not needed for MTA branding
+
+// Write the transformed package.json
+fs.writeFileSync(packagePath, JSON.stringify(packageJson, null, 2));
+
+console.log(`✅ ${brandingStrings.productName} branding transformations complete`);

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,19 +1,35 @@
 {
-  "name": "konveyor",
-  "displayName": "Konveyor Extension for VSCode",
-  "description": "Open-source migration and modernization tool",
-  "author": "Konveyor",
-  "icon": "resources/konveyor-icon-color.png",
+  "name": "mta",
+  "displayName": "MTA Extension for VSCode",
+  "description": "Migration Toolkit for Applications - Enterprise migration and modernization tool",
+  "author": "Red Hat",
+  "icon": "resources/mta-icon-color.png",
   "license": "Apache-2.0",
   "version": "0.2.0-pre.1",
   "main": "./out/extension.js",
-  "publisher": "konveyor",
+  "publisher": "mta",
   "repository": {
     "type": "git",
     "url": "https://github.com/konveyor/editor-extensions"
   },
   "bugs": "https://github.com/konveyor/editor-extensions/issues",
   "preview": false,
+  "branding": {
+    "mta": {
+      "productName": "MTA",
+      "productNameLowercase": "mta",
+      "extensionName": "mta",
+      "publisher": "mta",
+      "displayName": "MTA Extension for VSCode",
+      "description": "Migration Toolkit for Applications - Enterprise migration and modernization tool",
+      "author": "Red Hat",
+      "category": "MTA",
+      "icon": "resources/mta-icon-color.png",
+      "commandPrefix": "mta",
+      "configPrefix": "mta",
+      "viewPrefix": "mta"
+    }
+  },
   "categories": [
     "Programming Languages",
     "Machine Learning",
@@ -48,345 +64,345 @@
     ],
     "commands": [
       {
-        "command": "konveyor.openProfilesPanel",
+        "command": "mta.openProfilesPanel",
         "title": "Manage Analysis Profile",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(settings-gear)"
       },
       {
-        "command": "konveyor.modelProviderSettingsOpen",
+        "command": "mta.modelProviderSettingsOpen",
         "title": "Open the GenAI model provider configuration file",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(gear)"
       },
       {
-        "command": "konveyor.modelProviderSettingsBackupReset",
+        "command": "mta.modelProviderSettingsBackupReset",
         "title": "Open the default the GenAI model provider configuration file and backup the current file",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(gear)"
       },
       {
-        "command": "konveyor.showAnalysisPanel",
-        "title": "Open Konveyor Analysis View",
-        "category": "Konveyor",
+        "command": "mta.showAnalysisPanel",
+        "title": "Open MTA Analysis View",
+        "category": "MTA",
         "icon": "$(book)"
       },
       {
-        "command": "konveyor.showResolutionPanel",
-        "title": "Open Konveyor Resolution View",
-        "category": "Konveyor",
+        "command": "mta.showResolutionPanel",
+        "title": "Open MTA Resolution View",
+        "category": "MTA",
         "icon": "$(beaker)"
       },
       {
-        "command": "konveyor.expandAllIssues",
+        "command": "mta.expandAllIssues",
         "title": "Expand All",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(expand-all)"
       },
       {
-        "command": "konveyor.expandSingleIssue",
+        "command": "mta.expandSingleIssue",
         "title": "Expand All",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(expand-all)"
       },
       {
-        "command": "konveyor.fixGroupOfIncidents",
+        "command": "mta.fixGroupOfIncidents",
         "title": "Resolve incidents",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(debug-console)"
       },
       {
-        "command": "konveyor.fixIncident",
+        "command": "mta.fixIncident",
         "title": "Resolve incident",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(debug-console)"
       },
       {
-        "command": "konveyor.openAnalysisDetails",
+        "command": "mta.openAnalysisDetails",
         "title": "Open Details",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(book)"
       },
       {
-        "command": "konveyor.overrideAnalyzerBinaries",
+        "command": "mta.overrideAnalyzerBinaries",
         "title": "Override Analyzer Binary",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(gear)"
       },
       {
-        "command": "konveyor.configureCustomRules",
+        "command": "mta.configureCustomRules",
         "title": "Configure Custom Rules",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(gear)"
       },
       {
-        "command": "konveyor.configureSourcesTargets",
+        "command": "mta.configureSourcesTargets",
         "title": "Configure Analysis Sources and Targets",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(gear)"
       },
       {
-        "command": "konveyor.configureLabelSelector",
+        "command": "mta.configureLabelSelector",
         "title": "Configure Analysis LabelSelector",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(gear)"
       },
       {
-        "command": "konveyor.startServer",
+        "command": "mta.startServer",
         "title": "Start Server",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(play)"
       },
       {
-        "command": "konveyor.stopServer",
+        "command": "mta.stopServer",
         "title": "Stop Server",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(stop)"
       },
       {
-        "command": "konveyor.restartServer",
+        "command": "mta.restartServer",
         "title": "Restart Server",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(restart)"
       },
       {
-        "command": "konveyor.restartSolutionServer",
+        "command": "mta.restartSolutionServer",
         "title": "Restart Solution Server",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(restart)"
       },
       {
-        "command": "konveyor.runAnalysis",
+        "command": "mta.runAnalysis",
         "title": "Run Analysis",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(play)"
       },
       {
-        "command": "konveyor.loadStaticResults",
+        "command": "mta.loadStaticResults",
         "title": "Load results from files",
-        "category": "Konveyor"
+        "category": "MTA"
       },
       {
-        "command": "konveyor.loadResultsFromDataFolder",
+        "command": "mta.loadResultsFromDataFolder",
         "title": "Reload results",
-        "category": "Konveyor"
+        "category": "MTA"
       },
       {
-        "command": "konveyor.cleanRuleSets",
+        "command": "mta.cleanRuleSets",
         "title": "Reset analysis results",
-        "category": "Konveyor"
+        "category": "MTA"
       },
       {
-        "command": "konveyor.loadRuleSets",
+        "command": "mta.loadRuleSets",
         "title": "Load analysis results",
-        "category": "Konveyor"
+        "category": "MTA"
       },
       {
-        "command": "konveyor.applyAll",
+        "command": "mta.applyAll",
         "title": "Apply All",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(check)"
       },
       {
-        "command": "konveyor.discardAll",
+        "command": "mta.discardAll",
         "title": "Discard All",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(discard)"
       },
       {
-        "command": "konveyor.applyFile",
+        "command": "mta.applyFile",
         "title": "Apply",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(check)"
       },
       {
-        "command": "konveyor.discardFile",
+        "command": "mta.discardFile",
         "title": "Discard",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(discard)"
       },
       {
-        "command": "konveyor.copyDiff",
-        "category": "Konveyor",
+        "command": "mta.copyDiff",
+        "category": "MTA",
         "title": "Copy Diff"
       },
       {
-        "command": "konveyor.copyPath",
-        "category": "Konveyor",
+        "command": "mta.copyPath",
+        "category": "MTA",
         "title": "Copy Path"
       },
       {
-        "command": "konveyor.diffView.next",
-        "category": "Konveyor",
+        "command": "mta.diffView.next",
+        "category": "MTA",
         "title": "Go to Next File"
       },
       {
-        "command": "konveyor.diffView.prev",
-        "category": "Konveyor",
+        "command": "mta.diffView.prev",
+        "category": "MTA",
         "title": "Go to Previous File"
       },
       {
-        "command": "konveyor.diffView.viewFix",
-        "category": "Konveyor",
+        "command": "mta.diffView.viewFix",
+        "category": "MTA",
         "title": "View suggested fix"
       },
       {
-        "command": "konveyor.diffView.applyBlockInline",
+        "command": "mta.diffView.applyBlockInline",
         "icon": "$(check)",
         "category": "diffEditor",
         "title": "Apply Block"
       },
       {
-        "command": "konveyor.diffView.applySelectionInline",
+        "command": "mta.diffView.applySelectionInline",
         "icon": "$(check)",
         "category": "diffEditor",
         "title": "Apply Selection"
       },
       {
-        "command": "konveyor.diffView.applyBlock",
+        "command": "mta.diffView.applyBlock",
         "icon": "$(arrow-left)",
         "category": "diffEditor",
         "title": "Apply Block"
       },
       {
-        "command": "konveyor.diffView.applySelection",
+        "command": "mta.diffView.applySelection",
         "icon": "$(arrow-left)",
         "category": "diffEditor",
         "title": "Apply Selection"
       },
       {
-        "command": "konveyor.generateDebugArchive",
+        "command": "mta.generateDebugArchive",
         "title": "Generate Debug Archive",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(bug)"
       },
       {
-        "command": "konveyor.configureSolutionServerCredentials",
+        "command": "mta.configureSolutionServerCredentials",
         "title": "Configure Solution Server Credentials",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(key)"
       },
       {
-        "command": "konveyor.showDiffActions",
+        "command": "mta.showDiffActions",
         "title": "Show Diff Actions",
-        "category": "Konveyor",
+        "category": "MTA",
         "icon": "$(diff)"
       }
     ],
     "submenus": [
       {
-        "id": "konveyor.submenu",
-        "label": "Konveyor Actions"
+        "id": "mta.submenu",
+        "label": "MTA Actions"
       }
     ],
     "viewsContainers": {
       "activitybar": [
         {
-          "id": "konveyor",
-          "title": "Konveyor",
-          "icon": "resources/konveyor-icon-color.png"
+          "id": "mta",
+          "title": "MTA",
+          "icon": "resources/mta-icon-color.png"
         }
       ]
     },
     "views": {
-      "konveyor": [
+      "mta": [
         {
-          "id": "konveyor.issueView",
-          "name": "Konveyor Issues"
+          "id": "mta.issueView",
+          "name": "MTA Issues"
         }
       ]
     },
     "menus": {
       "view/title": [
         {
-          "command": "konveyor.showAnalysisPanel",
+          "command": "mta.showAnalysisPanel",
           "group": "navigation@1",
-          "when": "view == konveyor.issueView"
+          "when": "view == mta.issueView"
         },
         {
-          "command": "konveyor.showResolutionPanel",
+          "command": "mta.showResolutionPanel",
           "group": "navigation@2",
-          "when": "view == konveyor.issueView"
+          "when": "view == mta.issueView"
         },
         {
-          "command": "konveyor.expandAllIssues",
+          "command": "mta.expandAllIssues",
           "group": "navigation@3",
-          "when": "view == konveyor.issueView"
+          "when": "view == mta.issueView"
         }
       ],
       "view/item/context": [
         {
-          "command": "konveyor.fixGroupOfIncidents",
+          "command": "mta.fixGroupOfIncidents",
           "group": "inline@3",
-          "when": "view == konveyor.issueView && viewItem == incident-type-item"
+          "when": "view == mta.issueView && viewItem == incident-type-item"
         },
         {
-          "command": "konveyor.fixIncident",
+          "command": "mta.fixIncident",
           "group": "inline@1",
-          "when": "view == konveyor.issueView && viewItem == reference-item"
+          "when": "view == mta.issueView && viewItem == reference-item"
         },
         {
-          "command": "konveyor.expandSingleIssue",
+          "command": "mta.expandSingleIssue",
           "group": "inline@2",
-          "when": "view == konveyor.issueView && viewItem == incident-type-item"
+          "when": "view == mta.issueView && viewItem == incident-type-item"
         },
         {
-          "command": "konveyor.openAnalysisDetails",
+          "command": "mta.openAnalysisDetails",
           "group": "inline@1",
-          "when": "view == konveyor.issueView && viewItem == incident-type-item"
+          "when": "view == mta.issueView && viewItem == incident-type-item"
         }
       ],
       "explorer/context": [
         {
-          "submenu": "konveyor.submenu",
+          "submenu": "mta.submenu",
           "group": "navigation@1"
         }
       ],
-      "konveyor.submenu": [],
+      "mta.submenu": [],
       "commandPalette": [
         {
-          "command": "konveyor.expandSingleIssue",
+          "command": "mta.expandSingleIssue",
           "when": "never"
         },
         {
-          "command": "konveyor.loadRuleSets",
+          "command": "mta.loadRuleSets",
           "when": "never"
         },
         {
-          "command": "konveyor.applyFile",
+          "command": "mta.applyFile",
           "when": "never"
         },
         {
-          "command": "konveyor.discardFile",
+          "command": "mta.discardFile",
           "when": "never"
         },
         {
-          "command": "konveyor.copyDiff",
+          "command": "mta.copyDiff",
           "when": "never"
         },
         {
-          "command": "konveyor.copyPath",
+          "command": "mta.copyPath",
           "when": "never"
         },
         {
-          "command": "konveyor.diffView.next",
+          "command": "mta.diffView.next",
           "when": "never"
         },
         {
-          "command": "konveyor.diffView.prev",
+          "command": "mta.diffView.prev",
           "when": "never"
         },
         {
-          "command": "konveyor.diffView.viewFix",
+          "command": "mta.diffView.viewFix",
           "when": "never"
         }
       ]
     },
     "configuration": {
       "type": "object",
-      "title": "Konveyor",
+      "title": "MTA",
       "properties": {
-        "konveyor.logLevel": {
+        "mta.logLevel": {
           "type": "string",
           "enum": [
             "error",
@@ -402,63 +418,63 @@
           "scope": "window",
           "order": 0
         },
-        "konveyor.analyzerPath": {
+        "mta.analyzerPath": {
           "type": "string",
           "default": "",
           "description": "Path to the analyzer binary. If not set, the extension will use the bundled binary.",
           "scope": "resource",
           "order": 2
         },
-        "konveyor.kaiRpcServerPath": {
+        "mta.kaiRpcServerPath": {
           "type": "string",
           "default": "",
           "description": "Path to the rpc-server binary. If not set, the extension will use the bundled binary.",
           "scope": "resource",
           "order": 1
         },
-        "konveyor.solutionServer.url": {
+        "mta.solutionServer.url": {
           "type": "string",
           "default": "http://localhost:8000",
           "description": "URL for the MCP solution server endpoint.",
           "scope": "window",
           "order": 3
         },
-        "konveyor.solutionServer.enabled": {
+        "mta.solutionServer.enabled": {
           "type": "boolean",
           "default": false,
           "description": "Enable the MCP solution server client.",
           "scope": "window",
           "order": 4
         },
-        "konveyor.solutionServer.auth": {
+        "mta.solutionServer.auth": {
           "type": "boolean",
           "default": false,
           "description": "Enable authentication for the solution server.",
           "scope": "window",
           "order": 5
         },
-        "konveyor.solutionServer.auth.realm": {
+        "mta.solutionServer.auth.realm": {
           "type": "string",
           "default": "tackle",
           "description": "Keycloak realm for authentication.",
           "scope": "window",
           "order": 6
         },
-        "konveyor.solutionServer.auth.insecure": {
+        "mta.solutionServer.auth.insecure": {
           "type": "boolean",
           "default": false,
           "description": "Skip SSL certificate verification for the solution server.",
           "scope": "window",
           "order": 7
         },
-        "konveyor.analysis.analyzeOnSave": {
+        "mta.analysis.analyzeOnSave": {
           "type": "boolean",
           "default": true,
           "description": "Should analysis of file be run when it is saved? (Automatically enabled when Agent Mode is active)",
           "scope": "window",
           "order": 8
         },
-        "konveyor.diffEditorType": {
+        "mta.diffEditorType": {
           "type": "string",
           "enum": [
             "diff",
@@ -469,28 +485,28 @@
           "scope": "window",
           "order": 9
         },
-        "konveyor.genai.enabled": {
+        "mta.genai.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Enable GenAI functionality for solution generation.",
           "scope": "window",
           "order": 10
         },
-        "konveyor.diff.autoAcceptOnSave": {
+        "mta.diff.autoAcceptOnSave": {
           "type": "boolean",
           "default": true,
           "description": "Automatically apply diff changes when saving files.",
           "scope": "window",
           "order": 11
         },
-        "konveyor.kai.agentMode": {
+        "mta.kai.agentMode": {
           "type": "boolean",
           "default": false,
           "description": "(Experimental) Use agentic flow when getting solution. Requires automatic analysis.",
           "scope": "window",
           "order": 11
         },
-        "konveyor.kai.excludedDiagnosticSources": {
+        "mta.kai.excludedDiagnosticSources": {
           "type": "array",
           "default": [
             "trunk"
@@ -499,7 +515,7 @@
           "scope": "window",
           "order": 12
         },
-        "konveyor.kai.getSolutionMaxPriority": {
+        "mta.kai.getSolutionMaxPriority": {
           "type": [
             "number",
             "null"
@@ -509,7 +525,7 @@
           "scope": "window",
           "order": 40
         },
-        "konveyor.kai.getSolutionMaxEffort": {
+        "mta.kai.getSolutionMaxEffort": {
           "type": "string",
           "enum": [
             "Low",
@@ -522,7 +538,7 @@
           "scope": "window",
           "order": 40
         },
-        "konveyor.kai.getSolutionMaxLLMQueries": {
+        "mta.kai.getSolutionMaxLLMQueries": {
           "type": [
             "number",
             "null"
@@ -533,7 +549,7 @@
           "scope": "window",
           "order": 40
         },
-        "konveyor.kai.cacheDir": {
+        "mta.kai.cacheDir": {
           "type": [
             "string",
             "null"
@@ -543,7 +559,7 @@
           "scope": "window",
           "order": 50
         },
-        "konveyor.kai.traceDir": {
+        "mta.kai.traceDir": {
           "type": [
             "string",
             "null"
@@ -553,56 +569,56 @@
           "scope": "window",
           "order": 50
         },
-        "konveyor.kai.traceEnabled": {
+        "mta.kai.traceEnabled": {
           "type": "boolean",
           "default": false,
           "description": "Whether to create traces of the communication with the model",
           "scope": "window",
           "order": 50
         },
-        "konveyor.debug.webview": {
+        "mta.debug.webview": {
           "type": "boolean",
           "default": false,
           "description": "Enable debug logging for webview message handling",
           "scope": "window",
           "order": 51
         },
-        "konveyor.kai.demoMode": {
+        "mta.kai.demoMode": {
           "type": "boolean",
           "default": false,
           "description": "Whether to run Kai in demo mode i.e. use cached LLM responses",
           "scope": "window",
           "order": 50
         },
-        "konveyor.analysis.incidentLimit": {
+        "mta.analysis.incidentLimit": {
           "type": "number",
           "default": 10000,
           "description": "Maximum number of incidents to report",
           "scope": "window",
           "order": 99
         },
-        "konveyor.analysis.contextLines": {
+        "mta.analysis.contextLines": {
           "type": "number",
           "default": 10,
           "description": "Number of lines of context to include in incident reports.",
           "scope": "window",
           "order": 99
         },
-        "konveyor.analysis.codeSnipLimit": {
+        "mta.analysis.codeSnipLimit": {
           "type": "number",
           "default": 10,
           "description": "Number of lines of code to include in incident reports.",
           "scope": "window",
           "order": 99
         },
-        "konveyor.analysis.analyzeKnownLibraries": {
+        "mta.analysis.analyzeKnownLibraries": {
           "type": "boolean",
           "default": false,
           "description": "Should the analyzer analyze known open-source libraries?",
           "scope": "window",
           "order": 99
         },
-        "konveyor.analysis.analyzeDependencies": {
+        "mta.analysis.analyzeDependencies": {
           "type": "boolean",
           "default": true,
           "description": "Should the analyzer analyze project dependencies?",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Extension categories expanded to include Snippets and Linters in the Marketplace.
- Refactor
  - Rebranded the VS Code extension from Konveyor to MTA: updated name, display name, description, icon, publisher, and all UI labels (views, menus, titles).
  - Migrated all command, view, and configuration identifiers from konveyor.* to mta.*; update any custom keybindings or settings accordingly.
- Chores
  - Added build steps to enforce MTA branding and package required assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->