### PR TITLE
:bug: analyzer and genai config fixes

### DIFF
--- a/shared/src/types/actions.ts
+++ b/shared/src/types/actions.ts
@@ -3,6 +3,7 @@ export const RUN_ANALYSIS = "RUN_ANALYSIS";
 export const START_SERVER = "START_SERVER";
 export const STOP_SERVER = "STOP_SERVER";
 export const RESTART_SOLUTION_SERVER = "RESTART_SOLUTION_SERVER";
+export const ENABLE_GENAI = "ENABLE_GENAI";
 export const CANCEL_SOLUTION = "CANCEL_SOLUTION";
 export const GET_SOLUTION = "GET_SOLUTION";
 export const GET_SUCCESS_RATE = "GET_SUCCESS_RATE";
@@ -30,6 +31,7 @@ export type WebviewActionType =
   | typeof START_SERVER
   | typeof STOP_SERVER
   | typeof RESTART_SOLUTION_SERVER
+  | typeof ENABLE_GENAI
   | typeof CANCEL_SOLUTION
   | typeof GET_SOLUTION
   | typeof GET_SUCCESS_RATE

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -30,6 +30,7 @@ import {
   updateAnalyzerPath,
   getConfigAgentMode,
   getAllConfigurationValues,
+  enableGenAI,
   getWorkspaceRelativePath,
   getTraceEnabled,
   getTraceDir,
@@ -788,6 +789,17 @@ const commandsMap: (
 
       await executeExtensionCommand("restartSolutionServer");
       logger.info("Solution server credentials updated successfully.");
+    },
+
+    [`${EXTENSION_NAME}.enableGenAI`]: async () => {
+      logger.info("Enabling GenAI functionality");
+      try {
+        await enableGenAI();
+        window.showInformationMessage("GenAI functionality has been enabled.");
+      } catch (error) {
+        logger.error("Error enabling GenAI:", error);
+        window.showErrorMessage(`Failed to enable GenAI: ${error}`);
+      }
     },
 
     [`${EXTENSION_NAME}.showDiffWithDecorations`]: async (

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -101,6 +101,10 @@ export const toggleAgentMode = async (): Promise<void> => {
   await updateConfigValue("kai.agentMode", !currentValue, vscode.ConfigurationTarget.Workspace);
 };
 
+export const enableGenAI = async (): Promise<void> => {
+  await updateConfigValue("genai.enabled", true, vscode.ConfigurationTarget.Workspace);
+};
+
 export const updateUseDefaultRuleSets = async (value: boolean): Promise<void> => {
   await updateConfigValue(
     "analysis.useDefaultRulesets",

--- a/vscode/src/webviewMessageHandler.ts
+++ b/vscode/src/webviewMessageHandler.ts
@@ -22,6 +22,7 @@ import {
   START_SERVER,
   STOP_SERVER,
   RESTART_SOLUTION_SERVER,
+  ENABLE_GENAI,
   TOGGLE_AGENT_MODE,
   UPDATE_PROFILE,
   WEBVIEW_READY,
@@ -236,6 +237,9 @@ const actions: {
   },
   [RESTART_SOLUTION_SERVER]() {
     vscode.commands.executeCommand("konveyor.restartSolutionServer");
+  },
+  [ENABLE_GENAI]() {
+    executeExtensionCommand("enableGenAI");
   },
   [GET_SUCCESS_RATE]() {
     executeExtensionCommand("getSuccessRate");

--- a/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
+++ b/webview-ui/src/components/AnalysisPage/AnalysisPage.tsx
@@ -218,9 +218,7 @@ const AnalysisPage: React.FC = () => {
               configErrors={rawConfigErrors}
               solutionServerEnabled={solutionServerEnabled}
               solutionServerConnected={solutionServerConnected}
-              onOpenProfileManager={() =>
-                dispatch({ type: "OPEN_PROFILE_MANAGER", payload: {} })
-              }
+              onOpenProfileManager={() => dispatch({ type: "OPEN_PROFILE_MANAGER", payload: {} })}
               dispatch={dispatch}
             />
             {selectedProfile && (

--- a/webview-ui/src/components/AnalysisPage/ConfigAlerts.tsx
+++ b/webview-ui/src/components/AnalysisPage/ConfigAlerts.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Alert, AlertActionLink, PageSection, Card } from "@patternfly/react-core";
 import { ConfigError } from "@editor-extensions/shared";
-import { restartSolutionServer } from "../../hooks/actions";
+import { restartSolutionServer, enableGenAI } from "../../hooks/actions";
 
 interface ConfigAlertsProps {
   configErrors: ConfigError[];
@@ -41,6 +41,10 @@ const ConfigAlerts: React.FC<ConfigAlertsProps> = ({
                   error.type === "no-active-profile" ? (
                     <AlertActionLink onClick={onOpenProfileManager}>
                       Manage Profiles
+                    </AlertActionLink>
+                  ) : error.type === "genai-disabled" ? (
+                    <AlertActionLink onClick={() => dispatch(enableGenAI())}>
+                      Enable GenAI
                     </AlertActionLink>
                   ) : undefined
                 }

--- a/webview-ui/src/components/GetSolutionDropdown.tsx
+++ b/webview-ui/src/components/GetSolutionDropdown.tsx
@@ -11,7 +11,6 @@ import { EnhancedIncident } from "@editor-extensions/shared";
 import { useExtensionStateContext } from "../context/ExtensionStateContext";
 import { getSolution, getSolutionWithKonveyorContext } from "../hooks/actions";
 import { EllipsisVIcon, WrenchIcon } from "@patternfly/react-icons";
-import { Tooltip } from "@patternfly/react-core";
 
 type GetSolutionDropdownProps = {
   incidents: EnhancedIncident[];

--- a/webview-ui/src/hooks/actions.ts
+++ b/webview-ui/src/hooks/actions.ts
@@ -35,6 +35,11 @@ export const restartSolutionServer = (): WebviewAction<WebviewActionType, unknow
   payload: {},
 });
 
+export const enableGenAI = (): WebviewAction<WebviewActionType, unknown> => ({
+  type: "ENABLE_GENAI",
+  payload: {},
+});
+
 export const cancelSolution = (): WebviewAction<WebviewActionType, unknown> => ({
   type: "CANCEL_SOLUTION",
   payload: {},


### PR DESCRIPTION
This addresses a few issues:

1. #720 - updated the ensureKaiAnalyzerBinary to handle the user configured and throw vscode error if invalid (and reset)...use it for startup and config changes
2. Only prompt for ss stuff if auth is enabled AND solution server is enabled
3. Fix UX for disabled gen ai case.
Fixes #720 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enable GenAI directly from alerts, the walkthrough step, or via a new command.
- Improvements
  - Clear “GenAI is disabled” status with guided actions to enable.
  - Analyzer path setting now validates user-provided paths, falls back to bundled binary if invalid, and restarts the analyzer when the path changes.
  - Solution server connects only when enabled, reducing noise.
- Bug Fixes
  - Prevents unnecessary credential prompts when the solution server is disabled.
- Chores
  - Minor UI cleanup and formatting; removed an unused import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->