### PR TITLE
:seedling: release 0.2.0-pre.2

### DIFF
--- a/agentic/package.json
+++ b/agentic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editor-extensions/agentic",
-  "version": "0.2.0-pre.1",
+  "version": "0.2.0-pre.2",
   "private": true,
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "editor-extensions",
-  "version": "0.2.0-pre.1",
+  "version": "0.2.0-pre.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "editor-extensions",
-      "version": "0.2.0-pre.1",
+      "version": "0.2.0-pre.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -89,7 +89,7 @@
     },
     "agentic": {
       "name": "@editor-extensions/agentic",
-      "version": "0.2.0-pre.1",
+      "version": "0.2.0-pre.2",
       "dependencies": {
         "@langchain/core": "^0.3.50",
         "@langchain/langgraph": "^0.2.67",
@@ -23174,11 +23174,11 @@
     },
     "shared": {
       "name": "@editor-extensions/shared",
-      "version": "0.2.0-pre.1"
+      "version": "0.2.0-pre.2"
     },
     "vscode": {
       "name": "konveyor",
-      "version": "0.2.0-pre.1",
+      "version": "0.2.0-pre.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
@@ -23237,7 +23237,7 @@
     },
     "webview-ui": {
       "name": "@editor-extensions/webview-ui",
-      "version": "0.2.0-pre.1",
+      "version": "0.2.0-pre.2",
       "dependencies": {
         "@patternfly/chatbot": "^6.3.0",
         "@patternfly/patternfly": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editor-extensions",
-  "version": "0.2.0-pre.1",
+  "version": "0.2.0-pre.2",
   "private": true,
   "displayName": "Konveyor",
   "description": "VSCode Extension for Konveyor to assist in migrating and modernizing applications.",

--- a/scripts/collect-assets.js
+++ b/scripts/collect-assets.js
@@ -13,7 +13,7 @@ const cli = parseCli(
   {
     org: "konveyor",
     repo: "kai",
-    releaseTag: "v0.2.0-pre.1",
+    releaseTag: "v0.2.0-pre.2",
     branch: "main",
     workflow: "build-and-push-binaries.yml",
     rulesetOrg: "konveyor",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editor-extensions/shared",
-  "version": "0.2.0-pre.1",
+  "version": "0.2.0-pre.2",
   "private": true,
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -5,7 +5,7 @@
   "author": "Konveyor",
   "icon": "resources/konveyor-icon-color.png",
   "license": "Apache-2.0",
-  "version": "0.2.0-pre.1",
+  "version": "0.2.0-pre.2",
   "main": "./out/extension.js",
   "publisher": "konveyor",
   "repository": {
@@ -581,7 +581,7 @@
     "rulesets": "../downloaded_assets/rulesets"
   },
   "konveyor.fallbackAssets": {
-    "baseUrl": "https://github.com/konveyor/kai/releases/download/v0.8.0-alpha.4/",
+    "baseUrl": "https://github.com/konveyor/kai/releases/download/v0.2.0-pre.2/",
     "assets": {
       "linux-x64": {
         "file": "kai-analyzer-rpc-linux-x86_64",

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editor-extensions/webview-ui",
-  "version": "0.2.0-pre.1",
+  "version": "0.2.0-pre.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped pre-release version to 0.2.0-pre.2 across packages (root, agentic, shared, webview-ui, VS Code extension).
  * Updated default release tag for asset collection to v0.2.0-pre.2 to ensure consistent pre-release asset retrieval.
  * Adjusted VS Code extension fallback asset base URL to reference v0.2.0-pre.2 for fetching the latest pre-release assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->