### PR TITLE
:bug: Incorrect nesting of settings no longer requires auth to be enabled for insecure TLS

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -423,7 +423,7 @@
           "scope": "window",
           "order": 4
         },
-        "konveyor.solutionServer.auth": {
+        "konveyor.solutionServer.auth.enabled": {
           "type": "boolean",
           "default": false,
           "description": "Enable authentication for the solution server.",

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -465,7 +465,7 @@ class VsCodeExtension {
           if (
             event.affectsConfiguration(`${EXTENSION_NAME}.solutionServer.url`) ||
             event.affectsConfiguration(`${EXTENSION_NAME}.solutionServer.enabled`) ||
-            event.affectsConfiguration(`${EXTENSION_NAME}.solutionServer.auth`)
+            event.affectsConfiguration(`${EXTENSION_NAME}.solutionServer.auth.enabled`)
           ) {
             this.state.logger.info("Solution server configuration modified!");
 

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -22,7 +22,7 @@ export const getConfigSolutionServerUrl = (): string =>
 export const getConfigSolutionServerEnabled = (): boolean =>
   getConfigValue<boolean>("solutionServer.enabled") ?? false;
 export const getConfigSolutionServerAuth = (): boolean =>
-  getConfigValue<boolean>("solutionServer.auth") ?? false;
+  getConfigValue<boolean>("solutionServer.auth.enabled") ?? false;
 export const getConfigSolutionServerRealm = (): string =>
   getConfigValue<string>("solutionServer.auth.realm") || "tackle";
 export const getConfigSolutionServerInsecure = (): boolean =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Renamed the VS Code setting that enables Solution Server authentication to a new key; description and default (false) are unchanged.
  - If you manage settings.json manually, update the key; the Settings UI will reflect the new name automatically.
  - Configuration change detection now watches the renamed flag so updates trigger as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->