### PR TITLE
:seedling: drop demo mode from user facing config

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -554,13 +554,6 @@
           "description": "Enable debug logging for webview message handling",
           "scope": "window",
           "order": 40
-        },
-        "konveyor.kai.demoMode": {
-          "type": "boolean",
-          "default": false,
-          "description": "Whether to run Kai in demo mode i.e. use cached LLM responses",
-          "scope": "window",
-          "order": 41
         }
       }
     },


### PR DESCRIPTION
Fixes #747 

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the “Demo Mode” setting from the VS Code extension settings; running with cached responses is no longer supported.
  * Streamlined the settings panel; only the debug webview option remains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->