### PR TITLE
:bug: Clear auth config when authentication is disabled

### DIFF
--- a/agentic/src/clients/solutionServerClient.ts
+++ b/agentic/src/clients/solutionServerClient.ts
@@ -78,6 +78,13 @@ export class SolutionServerClient {
 
   public setAuthConfig(authConfig: SolutionServerAuthConfig | null): void {
     this.authConfig = authConfig;
+
+    // Clear auth tokens and timers when auth is disabled
+    if (!authConfig) {
+      this.clearTokenRefreshTimer();
+      this.bearerToken = null;
+      this.tokenExpiresAt = null;
+    }
   }
 
   public async connect(): Promise<void> {

--- a/agentic/src/clients/solutionServerClient.ts
+++ b/agentic/src/clients/solutionServerClient.ts
@@ -91,13 +91,7 @@ export class SolutionServerClient {
       this.sslBypassCleanup = this.applySSLBypass();
     }
 
-    if (this.authEnabled) {
-      if (!this.authConfig) {
-        throw new SolutionServerClientError(
-          "Authentication is enabled but no auth config provided",
-        );
-      }
-
+    if (this.authConfig) {
       // Always get fresh tokens on startup/connect
       try {
         if (!this.bearerToken) {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -270,6 +270,9 @@ class VsCodeExtension {
             draft.configErrors.push(createConfigError.missingAuthCredentials());
           });
         }
+      } else {
+        // Clear auth config when auth is disabled to prevent realm from being passed
+        this.state.solutionServerClient.setAuthConfig(null);
       }
 
       this.state.mutateData((draft) => {


### PR DESCRIPTION
Fix issue where realm parameter was still passed to solution server connection even when auth is turned off. Now explicitly clears the auth configuration when authentication is disabled.

Resolves #773 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clears solution-server authentication settings when authentication is disabled or the server is turned off.
  * Stops sending authentication data or headers when no auth configuration or token is available.
  * Ensures token exchange and related auth steps only run when auth configuration is present.
  * Preserves existing behavior when valid credentials are supplied: configuration is set on success and errors are reported on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->