### PR TITLE
:bug: Adding ability for the successRateMetrics to be gotten after actions.

### DIFF
--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -493,6 +493,8 @@ const commandsMap: (
 
       try {
         await state.solutionServerClient.acceptFile(path, finalContent);
+        // After we accept a file, we should update the success rates.
+        await executeExtensionCommand("getSuccessRate");
       } catch (error: any) {
         logger.error("Error notifying solution server of file acceptance", { error, path });
       }

--- a/vscode/src/data/loadResults.ts
+++ b/vscode/src/data/loadResults.ts
@@ -6,7 +6,9 @@ import { RULE_SET_DATA_FILE_PREFIX } from "../utilities";
 
 export const loadRuleSets = async (state: ExtensionState, receivedRuleSets: RuleSet[]) => {
   await writeDataFile(receivedRuleSets, RULE_SET_DATA_FILE_PREFIX);
-  const enhancedIncidents = enhanceIncidentsFromRuleSets(receivedRuleSets);
+  let enhancedIncidents = enhanceIncidentsFromRuleSets(receivedRuleSets);
+
+  enhancedIncidents = await state.solutionServerClient.getSuccessRate(enhancedIncidents);
 
   state.mutateData((draft) => {
     draft.ruleSets = receivedRuleSets;


### PR DESCRIPTION
* After analysis is run, we should make sure to update them
* After a soltuion is accepted we should also update them

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
