### PR TITLE
:bug: do not load saved analysis results in startup

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { EventEmitter } from "events";
 import { KonveyorGUIWebviewViewProvider } from "./KonveyorGUIWebviewViewProvider";
-import { registerAllCommands as registerAllCommands, executeExtensionCommand } from "./commands";
+import { registerAllCommands as registerAllCommands } from "./commands";
 import { ExtensionState } from "./extensionState";
 import { ConfigError, createConfigError, ExtensionData } from "@editor-extensions/shared";
 import { ViolationCodeActionProvider } from "./ViolationCodeActionProvider";
@@ -546,7 +546,6 @@ class VsCodeExtension {
         }),
       );
 
-      executeExtensionCommand("loadResultsFromDataFolder");
       this.state.logger.info("Extension initialized");
 
       // Setup diff status bar item


### PR DESCRIPTION
Fixes #765 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Adjusted startup behavior: the extension no longer auto-loads previously saved results on activation. This reduces unnecessary work during launch and may improve startup responsiveness. If you rely on those results, load them manually from the command palette when needed.
  - No changes to existing commands, settings, or UI components. Day-to-day workflows remain the same aside from manual loading when desired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->