### PR TITLE
:bug: Fix line ending diff display showing entire files as changed

### DIFF
--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -2,3 +2,4 @@ export * from "./types/index";
 export * from "./transformation";
 export * from "./labelSelector";
 export * from "./utils/languageMapping";
+export * from "./utils/diffUtils";

--- a/shared/src/utils/diffUtils.ts
+++ b/shared/src/utils/diffUtils.ts
@@ -1,0 +1,143 @@
+/**
+ * Utility functions for diff processing and line ending normalization
+ */
+
+/**
+ * Normalize line endings to LF (\n) for consistent diff processing
+ */
+export function normalizeLineEndings(content: string): string {
+  return content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+/**
+ * Check if the only differences in a unified diff are line endings
+ */
+export function isOnlyLineEndingDiff(unifiedDiff: string): boolean {
+  const lines = unifiedDiff.split("\n");
+  const changeLines: string[] = [];
+
+  // Collect all +/- lines
+  for (const line of lines) {
+    // Skip diff headers and context markers
+    if (
+      line.startsWith("diff ") ||
+      line.startsWith("index ") ||
+      line.startsWith("--- ") ||
+      line.startsWith("+++ ") ||
+      line.startsWith("@@") ||
+      line.startsWith(" ")
+    ) {
+      continue;
+    }
+
+    // Collect actual change lines
+    if (line.startsWith("+") || line.startsWith("-")) {
+      changeLines.push(line);
+    }
+  }
+
+  // If no changes, not a line ending diff
+  if (changeLines.length === 0) {
+    return false;
+  }
+
+  // Check if changes come in pairs where the only difference is line endings
+  for (let i = 0; i < changeLines.length; i += 2) {
+    if (i + 1 >= changeLines.length) {
+      return false; // Unpaired change
+    }
+
+    const removedLine = changeLines[i];
+    const addedLine = changeLines[i + 1];
+
+    // Must be a - followed by a +
+    if (!removedLine.startsWith("-") || !addedLine.startsWith("+")) {
+      return false;
+    }
+
+    const removedContent = removedLine.substring(1);
+    const addedContent = addedLine.substring(1);
+
+    // Check if they're the same after normalizing line endings
+    if (normalizeLineEndings(removedContent) !== normalizeLineEndings(addedContent)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Normalize a unified diff by removing line-ending-only changes
+ */
+export function normalizeUnifiedDiff(
+  unifiedDiff: string,
+  originalContent: string,
+  newContent: string,
+): string {
+  // First normalize line endings in both contents
+  const normalizedOriginal = normalizeLineEndings(originalContent);
+  const normalizedNew = normalizeLineEndings(newContent);
+
+  // If contents are identical after normalization, return empty diff
+  if (normalizedOriginal === normalizedNew) {
+    return "";
+  }
+
+  // Otherwise, return the original diff (it has real content changes)
+  return unifiedDiff;
+}
+
+/**
+ * Filter out diff lines that only differ in line endings
+ */
+export function filterLineEndingOnlyChanges(diffLines: string[]): string[] {
+  const filtered: string[] = [];
+  let i = 0;
+
+  while (i < diffLines.length) {
+    const line = diffLines[i];
+
+    // Keep headers and context markers
+    if (
+      line.startsWith("diff ") ||
+      line.startsWith("index ") ||
+      line.startsWith("--- ") ||
+      line.startsWith("+++ ") ||
+      line.startsWith("@@") ||
+      line.startsWith(" ")
+    ) {
+      filtered.push(line);
+      i++;
+      continue;
+    }
+
+    // Check for paired +/- lines that only differ in line endings
+    if (line.startsWith("-") && i + 1 < diffLines.length) {
+      const nextLine = diffLines[i + 1];
+
+      if (nextLine.startsWith("+")) {
+        const removedContent = normalizeLineEndings(line.substring(1));
+        const addedContent = normalizeLineEndings(nextLine.substring(1));
+
+        // If they're the same after normalization, skip both lines
+        if (removedContent === addedContent) {
+          i += 2; // Skip both lines
+          continue;
+        } else {
+          // They're different - keep both lines
+          filtered.push(line);
+          filtered.push(nextLine);
+          i += 2;
+          continue;
+        }
+      }
+    }
+
+    // Keep the line if it's not just a line ending change
+    filtered.push(line);
+    i++;
+  }
+
+  return filtered;
+}


### PR DESCRIPTION
- Add diffUtils module with line ending normalization functions
- Filter out CRLF vs LF only changes in StaticDiffAdapter
- Update ModifiedFileDiffPreview to handle line-ending-only diffs
- Prevent showing entire files as modified when only line endings differ
- Improve cross-platform diff experience (Windows vs Unix line endings)

Fixes #764
