### PR TITLE
:bug:  Handle new line and empty diffs gracefully

### DIFF
--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -2,3 +2,4 @@ export * from "./types/index";
 export * from "./transformation";
 export * from "./labelSelector";
 export * from "./utils/languageMapping";
+export * from "./utils/diffUtils";

--- a/shared/src/utils/diffUtils.ts
+++ b/shared/src/utils/diffUtils.ts
@@ -1,0 +1,180 @@
+/**
+ * Utility functions for diff processing and line ending normalization
+ */
+
+/**
+ * Normalize line endings to LF (\n) for consistent diff processing
+ */
+export function normalizeLineEndings(content: string): string {
+  return content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+/**
+ * Check if the only differences in a unified diff are line endings
+ */
+export function isOnlyLineEndingDiff(unifiedDiff: string): boolean {
+  const lines = unifiedDiff.split("\n");
+  const changeLines: string[] = [];
+
+  // Collect all +/- lines
+  for (const line of lines) {
+    // Skip diff headers and context markers
+    if (
+      line.startsWith("diff ") ||
+      line.startsWith("index ") ||
+      line.startsWith("--- ") ||
+      line.startsWith("+++ ") ||
+      line.startsWith("@@") ||
+      line.startsWith(" ")
+    ) {
+      continue;
+    }
+
+    // Collect actual change lines
+    if (line.startsWith("+") || line.startsWith("-")) {
+      changeLines.push(line);
+    }
+  }
+
+  // If no changes, not a line ending diff
+  if (changeLines.length === 0) {
+    return false;
+  }
+
+  // Check if changes come in pairs where the only difference is line endings
+  for (let i = 0; i < changeLines.length; i += 2) {
+    if (i + 1 >= changeLines.length) {
+      return false; // Unpaired change
+    }
+
+    const removedLine = changeLines[i];
+    const addedLine = changeLines[i + 1];
+
+    // Must be a - followed by a +
+    if (!removedLine.startsWith("-") || !addedLine.startsWith("+")) {
+      return false;
+    }
+
+    const removedContent = removedLine.substring(1);
+    const addedContent = addedLine.substring(1);
+
+    // Check if they're the same after normalizing line endings
+    if (normalizeLineEndings(removedContent) !== normalizeLineEndings(addedContent)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Normalize a unified diff by removing line-ending-only changes
+ */
+export function normalizeUnifiedDiff(
+  unifiedDiff: string,
+  originalContent: string,
+  newContent: string,
+): string {
+  // First normalize line endings in both contents
+  const normalizedOriginal = normalizeLineEndings(originalContent);
+  const normalizedNew = normalizeLineEndings(newContent);
+
+  // If contents are identical after normalization, return empty diff
+  if (normalizedOriginal === normalizedNew) {
+    return "";
+  }
+
+  // Otherwise, return the original diff (it has real content changes)
+  return unifiedDiff;
+}
+
+/**
+ * Check if a unified diff has no meaningful content after processing
+ */
+export function hasNoMeaningfulDiffContent(unifiedDiff: string): boolean {
+  if (!unifiedDiff || unifiedDiff.trim() === "") {
+    return true;
+  }
+
+  const lines = unifiedDiff.split("\n");
+  const filteredLines = filterLineEndingOnlyChanges(lines);
+
+  let formattedDiff = "";
+  let inHunk = false;
+
+  for (const line of filteredLines) {
+    if (line.startsWith("diff ")) {
+      continue;
+    }
+
+    if (line.startsWith("index ") || line.startsWith("--- ") || line.startsWith("+++ ")) {
+      continue;
+    }
+
+    if (line.startsWith("@@")) {
+      inHunk = true;
+      formattedDiff += line + "\n";
+      continue;
+    }
+
+    if (inHunk) {
+      formattedDiff += line + "\n";
+    }
+  }
+
+  return !formattedDiff.trim();
+}
+
+/**
+ * Filter out diff lines that only differ in line endings
+ */
+export function filterLineEndingOnlyChanges(diffLines: string[]): string[] {
+  const filtered: string[] = [];
+  let i = 0;
+
+  while (i < diffLines.length) {
+    const line = diffLines[i];
+
+    // Keep headers and context markers
+    if (
+      line.startsWith("diff ") ||
+      line.startsWith("index ") ||
+      line.startsWith("--- ") ||
+      line.startsWith("+++ ") ||
+      line.startsWith("@@") ||
+      line.startsWith(" ")
+    ) {
+      filtered.push(line);
+      i++;
+      continue;
+    }
+
+    // Check for paired +/- lines that only differ in line endings
+    if (line.startsWith("-") && i + 1 < diffLines.length) {
+      const nextLine = diffLines[i + 1];
+
+      if (nextLine.startsWith("+")) {
+        const removedContent = normalizeLineEndings(line.substring(1));
+        const addedContent = normalizeLineEndings(nextLine.substring(1));
+
+        // If they're the same after normalization, skip both lines
+        if (removedContent === addedContent) {
+          i += 2; // Skip both lines
+          continue;
+        } else {
+          // They're different - keep both lines
+          filtered.push(line);
+          filtered.push(nextLine);
+          i += 2;
+          continue;
+        }
+      }
+    }
+
+    // Keep the line if it's not just a line ending change
+    filtered.push(line);
+    i++;
+  }
+
+  return filtered;
+}

--- a/vscode/src/utilities/ModifiedFiles/handleFileResponse.ts
+++ b/vscode/src/utilities/ModifiedFiles/handleFileResponse.ts
@@ -181,6 +181,21 @@ export async function handleFileResponse(
           modifiedFileMessage.status = "applied";
         }
       });
+    } else if (responseId === "noChanges") {
+      // For noChanges, update the global state to indicate no changes were needed
+      // No file operations or notifications needed
+      state.mutateData((draft) => {
+        const messageIndex = draft.chatMessages.findIndex(
+          (msg) => msg.messageToken === messageToken,
+        );
+        if (
+          messageIndex >= 0 &&
+          draft.chatMessages[messageIndex].kind === ChatMessageType.ModifiedFile
+        ) {
+          const modifiedFileMessage = draft.chatMessages[messageIndex].value as any;
+          modifiedFileMessage.status = "no_changes_needed";
+        }
+      });
     } else {
       // For reject, also update the global state
       state.mutateData((draft) => {

--- a/webview-ui/src/components/ResolutionsPage/ModifiedFile/ModifiedFileActions.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ModifiedFile/ModifiedFileActions.tsx
@@ -11,19 +11,25 @@ import { NormalizedFileData } from "./useModifiedFileData";
 import "./modifiedFileActions.css";
 
 interface ModifiedFileActionsProps {
-  actionTaken: "applied" | "rejected" | "processing" | null;
+  actionTaken: "applied" | "rejected" | "processing" | "no_changes_needed" | null;
   normalizedData: NormalizedFileData;
   onApply: () => void;
   onReject: () => void;
   onViewWithDecorations?: (path: string, diff: string) => void;
   isViewingDiff?: boolean;
   onContinue?: () => void;
-  onSetActionTaken?: (action: "applied" | "rejected" | "processing" | null) => void;
+  onSetActionTaken?: (
+    action: "applied" | "rejected" | "processing" | "no_changes_needed" | null,
+  ) => void;
   hasActiveDecorators?: boolean;
+  shouldShowNoChangesNeeded?: boolean;
+  onHandleNoChangesNeeded?: () => void;
 }
 
 // Status Display Component
-const StatusDisplay: React.FC<{ status: "applied" | "rejected" | "processing" }> = ({ status }) => (
+const StatusDisplay: React.FC<{
+  status: "applied" | "rejected" | "processing" | "no_changes_needed";
+}> = ({ status }) => (
   <Flex className="modified-file-actions">
     <FlexItem>
       <span>
@@ -34,6 +40,10 @@ const StatusDisplay: React.FC<{ status: "applied" | "rejected" | "processing" }>
         ) : status === "rejected" ? (
           <>
             <TimesCircleIcon color="red" /> Changes rejected
+          </>
+        ) : status === "no_changes_needed" ? (
+          <>
+            <CheckCircleIcon color="green" /> No changes needed - code already compatible
           </>
         ) : (
           <>
@@ -101,10 +111,34 @@ const DiffStatusBanner: React.FC<{
   );
 };
 
+// No Changes Needed Actions Component
+const NoChangesNeededActions: React.FC<{
+  onHandleNoChangesNeeded: () => void;
+}> = ({ onHandleNoChangesNeeded }) => (
+  <Flex className="modified-file-actions" justifyContent={{ default: "justifyContentCenter" }}>
+    <FlexItem>
+      <div className="no-changes-info">
+        <Icon status="success">
+          <CheckCircleIcon color="#3e8635" />
+        </Icon>
+        <span>No additional changes are needed at this time. The code is already compatible.</span>
+        <Button
+          variant="link"
+          icon={<CheckCircleIcon />}
+          onClick={onHandleNoChangesNeeded}
+          className="continue-button"
+        >
+          Continue
+        </Button>
+      </div>
+    </FlexItem>
+  </Flex>
+);
+
 // Primary Action Buttons Component
 const PrimaryActionButtons: React.FC<{
   isNew: boolean;
-  actionTaken: "applied" | "rejected" | "processing" | null;
+  actionTaken: "applied" | "rejected" | "processing" | "no_changes_needed" | null;
   onViewWithDecorations?: () => void;
   onApply: () => void;
   onReject: () => void;
@@ -176,12 +210,19 @@ const ModifiedFileActions: React.FC<ModifiedFileActionsProps> = ({
   onContinue,
   onSetActionTaken,
   hasActiveDecorators,
+  shouldShowNoChangesNeeded,
+  onHandleNoChangesNeeded,
 }) => {
   const { isNew } = normalizedData;
 
   // If action already taken or processing, show status
   if (actionTaken) {
     return <StatusDisplay status={actionTaken} />;
+  }
+
+  // If no meaningful changes needed, show special handling
+  if (shouldShowNoChangesNeeded && onHandleNoChangesNeeded) {
+    return <NoChangesNeededActions onHandleNoChangesNeeded={onHandleNoChangesNeeded} />;
   }
 
   if (isViewingDiff && actionTaken === null) {

--- a/webview-ui/src/components/ResolutionsPage/ModifiedFile/ModifiedFileDiffPreview.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ModifiedFile/ModifiedFileDiffPreview.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
-import { getLanguageFromExtension } from "@editor-extensions/shared";
+import { getLanguageFromExtension, filterLineEndingOnlyChanges } from "@editor-extensions/shared";
 
 interface ModifiedFileDiffPreviewProps {
   diff: string;
@@ -19,10 +19,14 @@ export const ModifiedFileDiffPreview: React.FC<ModifiedFileDiffPreviewProps> = (
   const formatDiffForMarkdown = (diffContent: string, fileName: string) => {
     try {
       const lines = diffContent.split("\n");
+
+      // Filter out line-ending-only changes
+      const filteredLines = filterLineEndingOnlyChanges(lines);
+
       let formattedDiff = "";
       let inHunk = false;
 
-      for (const line of lines) {
+      for (const line of filteredLines) {
         if (line.startsWith("diff ")) {
           formattedDiff += "# " + line.substring(5) + "\n\n";
           continue;
@@ -44,7 +48,7 @@ export const ModifiedFileDiffPreview: React.FC<ModifiedFileDiffPreviewProps> = (
       }
 
       if (!formattedDiff) {
-        formattedDiff = `// No diff content available for ${fileName}`;
+        formattedDiff = `// No meaningful diff content available for ${fileName}`;
       }
 
       return "```diff\n" + formattedDiff + "\n```";

--- a/webview-ui/src/components/ResolutionsPage/ModifiedFile/modifiedFileActions.css
+++ b/webview-ui/src/components/ResolutionsPage/ModifiedFile/modifiedFileActions.css
@@ -81,3 +81,29 @@
 .pf-v6-c-tooltip__content {
   text-align: left !important;
 }
+
+/* No changes needed info styling */
+.no-changes-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background-color: var(--vscode-editor-lineHighlightBackground);
+  border: 1px solid var(--vscode-editorGutter-addedBackground);
+  border-radius: 4px;
+  width: 100%;
+}
+
+.no-changes-info .pf-c-icon {
+  color: var(--vscode-editorGutter-addedBackground);
+}
+
+.no-changes-info span {
+  font-weight: 500;
+  color: var(--vscode-editor-foreground);
+}
+
+.no-changes-info .continue-button {
+  margin-left: auto;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Fixes #764
Fixes #769
<img width="916" height="700" alt="Screenshot 2025-09-04 at 8 24 45 PM" src="https://github.com/user-attachments/assets/2d875119-a225-44e5-9160-cace9c360b0b" />
<img width="828" height="460" alt="Screenshot 2025-09-04 at 8 24 26 PM" src="https://github.com/user-attachments/assets/076056b0-47fd-480a-8192-8cb56ec41b98" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “No changes needed” status and action to the Modified File flow, including a dedicated continue path and status display.
  - Diff viewer now filters out line-ending-only changes and clarifies when no meaningful diff content exists.

- Bug Fixes
  - Prevents applying diffs that only change line endings, improving accuracy of diff application and preview.

- Style
  - Introduced new styles for the “No changes needed” banner with themed colors and improved layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->