### PR TITLE
:bug: improve additional info prompt and remove unused options

### DIFF
--- a/agentic/src/nodes/analysisIssueFix.ts
+++ b/agentic/src/nodes/analysisIssueFix.ts
@@ -145,8 +145,8 @@ export class AnalysisIssueFix extends BaseNode {
       const accumulated = [...state.outputAllResponses, ...nextState.outputAllResponses].reduce(
         (acc, val) => {
           return {
-            reasoning: `${acc.reasoning}\n${val.outputReasoning}`,
-            additionalInfo: `${acc.additionalInfo}\n${val.outputAdditionalInfo}`,
+            reasoning: `${acc.reasoning}\n\n\n#### Changes made in ${relative(this.workspaceDir, val.outputUpdatedFileUri ?? "")}\n\n${val.outputReasoning}`,
+            additionalInfo: `${acc.additionalInfo}\n\n\n#### Additional changes from ${relative(this.workspaceDir, val.outputUpdatedFileUri ?? "")}\n\n${val.outputAdditionalInfo}`,
             uris: val.outputUpdatedFileUri
               ? acc.uris.concat([relative(this.workspaceDir, val.outputUpdatedFileUri)])
               : acc.uris,
@@ -302,30 +302,45 @@ If you have any additional details or steps that need to be performed, put it he
     }
 
     const sys_message = new SystemMessage(
-      `You are an experienced ${state.programmingLanguage} programmer, specializing in migrating source code to ${state.migrationHint}. You are overlooking migration of a project.`,
+      `You are an experienced ${state.programmingLanguage} programmer, specializing in migrating source code to ${state.migrationHint}. Your job is to read migration notes and output only the additional changes that are still needed elsewhere in the project.`,
     );
     const human_message = new HumanMessage(
-      `During the migration to ${state.migrationHint}, we captured notes detailing changes made to existing files.\
-The notes contain a summary of changes we already made and additional changes that may be required in other files elsewhere in the project.\
-They also contain a list of files we changed.
-Your task is to carefully analyze the notes, compare them with files that are changed, understand any additional changes needed to complete the migration and provide a concise summary *solely* of the additional changes required elsewhere in the project.\
-**It is essential that your summary includes only the additional changes needed. Do not include changes already made.**\
+      `During the migration to ${state.migrationHint}, we captured notes that include:
+- A list of files we modified
+- Reasoning behind changes made to existing files
+- Additional information that may contain even more changes needed
+
+* Your task:
+Carefully analyze the reasoning and additional information for each file, and determine if there are any additional changes needed to complete the migration. \
+Provide a concise summary *solely* of the additional changes required elsewhere in the project. \
+**It is essential that your summary includes only the additional changes needed. Do not include changes already made.** \
 Make sure you output all the details about the changes including any relevant code snippets and instructions.
-**Do not omit any additional changes needed.**
-If there are no additional changes needed to complete the migration, respond with text "NO-CHANGE".\
-Here is the summary: \
-${
-  state.inputAllReasoning && state.inputAllReasoning.length > 0
-    ? `### Summary of changes made\n${state.inputAllReasoning}`
-    : ""
-}
-### Additional information about changes
-${state.inputAllAdditionalInfo}
+**Do not omit any additional changes needed. Be exhaustive and specific.**
+
+* Rules:
+- Only the files listed under MODIFIED_FILES are already changed. Any file **not** in MODIFIED_FILES is unmodified.
+- Treat sections named “Summary of changes made” as implemented changes only for the files listed in MODIFIED_FILES.
+- Treat “Additional information / notes / rationale” as proposed work, not-yet-applied.
+- If there are no additional changes needed, respond with exactly:
+NO-CHANGE: <one-sentence reason>
+
+Here is your input:
+
 ${
   state.inputAllModifiedFiles
-    ? `### List of modified files\n${state.inputAllModifiedFiles?.join("\n")}`
+    ? `### MODIFIED_FILES\n\n${state.inputAllModifiedFiles?.join("\n")}`
     : ""
 }
+
+${
+  state.inputAllReasoning && state.inputAllReasoning.length > 0
+    ? `### Summary of changes made\n\n${state.inputAllReasoning}`
+    : ""
+}
+
+### Additional information about changes
+
+${state.inputAllAdditionalInfo}
 `,
     );
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -423,44 +423,6 @@
           "scope": "window",
           "order": 10
         },
-        "konveyor.analysis.incidentLimit": {
-          "type": "integer",
-          "default": 10000,
-          "description": "Maximum number of incidents to report",
-          "scope": "window",
-          "order": 11,
-          "minimum": 1
-        },
-        "konveyor.analysis.contextLines": {
-          "type": "integer",
-          "default": 10,
-          "description": "Number of lines of context to include in incident reports.",
-          "scope": "window",
-          "order": 12,
-          "minimum": 1
-        },
-        "konveyor.analysis.codeSnipLimit": {
-          "type": "integer",
-          "default": 10,
-          "description": "Number of lines of code to include in incident reports.",
-          "scope": "window",
-          "order": 13,
-          "minimum": 1
-        },
-        "konveyor.analysis.analyzeKnownLibraries": {
-          "type": "boolean",
-          "default": false,
-          "description": "Should the analyzer analyze known open-source libraries?",
-          "scope": "window",
-          "order": 14
-        },
-        "konveyor.analysis.analyzeDependencies": {
-          "type": "boolean",
-          "default": true,
-          "description": "Should the analyzer analyze project dependencies?",
-          "scope": "window",
-          "order": 15
-        },
         "konveyor.genai.enabled": {
           "type": "boolean",
           "default": true,

--- a/vscode/src/utilities/configuration.ts
+++ b/vscode/src/utilities/configuration.ts
@@ -28,20 +28,8 @@ export const getConfigSolutionServerRealm = (): string =>
 export const getConfigSolutionServerInsecure = (): boolean =>
   getConfigValue<boolean>("solutionServer.auth.insecure") ?? false;
 export const getConfigLogLevel = (): string => getConfigValue<string>("logLevel") || "debug";
-export const getConfigIncidentLimit = (): number =>
-  getConfigValue<number>("analysis.incidentLimit") || 10000;
-export const getConfigContextLines = (): number =>
-  getConfigValue<number>("analysis.contextLines") || 10;
-
-export const getConfigCodeSnipLimit = (): number =>
-  getConfigValue<number>("analysis.codeSnipLimit") || 10;
-
 export const getConfigLabelSelector = (): string =>
   getConfigValue<string>("analysis.labelSelector") || "discovery";
-export const getConfigAnalyzeKnownLibraries = (): boolean =>
-  getConfigValue<boolean>("analysis.analyzeKnownLibraries") ?? false;
-export const getConfigAnalyzeDependencies = (): boolean =>
-  getConfigValue<boolean>("analysis.analyzeDependencies") ?? true;
 export const getConfigAnalyzeOnSave = (): boolean => {
   const agentMode = getConfigAgentMode();
   const analyzeOnSave = getConfigValue<boolean>("analysis.analyzeOnSave") ?? true;


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
