### PR TITLE
:bug: Persist 'no changes' and 'quick response' messages

### DIFF
--- a/shared/src/types/types.ts
+++ b/shared/src/types/types.ts
@@ -159,6 +159,7 @@ export interface ChatMessage {
   extraContent?: React.ReactNode;
   quickResponses?: QuickResponse[];
   isCompact?: boolean;
+  selectedResponse?: string;
 }
 
 export interface ExtensionData {

--- a/vscode/src/utilities/ModifiedFiles/handleFileResponse.ts
+++ b/vscode/src/utilities/ModifiedFiles/handleFileResponse.ts
@@ -182,8 +182,6 @@ export async function handleFileResponse(
         }
       });
     } else if (responseId === "noChanges") {
-      // For noChanges, update the global state to indicate no changes were needed
-      // No file operations or notifications needed
       state.mutateData((draft) => {
         const messageIndex = draft.chatMessages.findIndex(
           (msg) => msg.messageToken === messageToken,
@@ -203,8 +201,6 @@ export async function handleFileResponse(
       } catch (error) {
         logger.error("Error notifying solution server of rejection:", error);
       }
-
-      // Also update the global state
       state.mutateData((draft) => {
         const messageIndex = draft.chatMessages.findIndex(
           (msg) => msg.messageToken === messageToken,

--- a/vscode/src/utilities/ModifiedFiles/handleQuickResponse.ts
+++ b/vscode/src/utilities/ModifiedFiles/handleQuickResponse.ts
@@ -23,6 +23,14 @@ export async function handleQuickResponse(
 
       const msg = state.data.chatMessages[messageIndex];
 
+      // Update the chat message state to include the selected response
+      state.mutateData((draft) => {
+        const message = draft.chatMessages.find((m) => m.messageToken === messageToken);
+        if (message) {
+          message.selectedResponse = responseId;
+        }
+      });
+
       // Create the workflow message with proper typing
       let interactionType = responseId.startsWith("choice-") ? "choice" : "yesNo";
       let responseData: { choice: number } | { yesNo: boolean } | { tasks: any; yesNo: boolean } =

--- a/vscode/src/webviewMessageHandler.ts
+++ b/vscode/src/webviewMessageHandler.ts
@@ -4,7 +4,6 @@ import { executeExtensionCommand } from "./commands";
 import {
   ADD_PROFILE,
   AnalysisProfile,
-  ChatMessageType,
   CONFIGURE_CUSTOM_RULES,
   CONFIGURE_LABEL_SELECTOR,
   CONFIGURE_SOURCES_TARGETS,
@@ -30,7 +29,6 @@ import {
   WebviewActionType,
   ScopeWithKonveyorContext,
   ExtensionData,
-  createConfigError,
   OPEN_RESOLUTION_PANEL,
 } from "@editor-extensions/shared";
 
@@ -277,43 +275,14 @@ const actions: {
       );
       console.log("Continue decision: ", { responseId, hasChanges });
 
-      // Send to solution server and update state
       await handleFileResponse(messageToken, responseId, path, finalContent, state);
       logger.info(`File state continued with response: ${responseId}`, {
         path,
         messageToken,
       });
-
-      // Update the chat message status
-      state.mutateData((draft) => {
-        const messageIndex = draft.chatMessages.findIndex(
-          (msg) => msg.messageToken === messageToken,
-        );
-        if (
-          messageIndex >= 0 &&
-          draft.chatMessages[messageIndex].kind === ChatMessageType.ModifiedFile
-        ) {
-          const modifiedFileMessage = draft.chatMessages[messageIndex].value as any;
-          modifiedFileMessage.status = hasChanges ? "applied" : "rejected";
-        }
-      });
     } catch (error) {
       logger.error("Error handling CONTINUE_WITH_FILE_STATE:", error);
-      // Fallback to reject on error
       await handleFileResponse(messageToken, "reject", path, content, state);
-
-      state.mutateData((draft) => {
-        const messageIndex = draft.chatMessages.findIndex(
-          (msg) => msg.messageToken === messageToken,
-        );
-        if (
-          messageIndex >= 0 &&
-          draft.chatMessages[messageIndex].kind === ChatMessageType.ModifiedFile
-        ) {
-          const modifiedFileMessage = draft.chatMessages[messageIndex].value as any;
-          modifiedFileMessage.status = "rejected";
-        }
-      });
     }
   },
 };

--- a/webview-ui/src/components/ResolutionsPage/ModifiedFile/ModifiedFileMessage.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ModifiedFile/ModifiedFileMessage.tsx
@@ -31,7 +31,7 @@ export const ModifiedFileMessage: React.FC<ModifiedFileMessageProps> = ({
   const [isViewingDiff, setIsViewingDiff] = useState(false);
 
   // Get extension state to check for active decorators
-  const { state } = useExtensionStateContext();
+  const { state, dispatch } = useExtensionStateContext();
   const hasActiveDecorators = !!(state.activeDecorators && state.activeDecorators[messageToken]);
 
   // Get status from global state for this specific message
@@ -58,10 +58,14 @@ export const ModifiedFileMessage: React.FC<ModifiedFileMessageProps> = ({
   >(() => {
     // Don't auto-set no_changes_needed - let user click Continue first
     // Only use status if it's explicitly set for this message
-    if (status === "applied" || status === "rejected") {
+    if (status === "applied" || status === "rejected" || status === "no_changes_needed") {
       return status;
     }
-    if (globalStatus === "applied" || globalStatus === "rejected") {
+    if (
+      globalStatus === "applied" ||
+      globalStatus === "rejected" ||
+      globalStatus === "no_changes_needed"
+    ) {
       return globalStatus;
     }
     return null; // Default to null - no action taken
@@ -78,7 +82,12 @@ export const ModifiedFileMessage: React.FC<ModifiedFileMessageProps> = ({
   // Update local state ONLY when global state changes for this specific message
   useEffect(() => {
     // Only update if we found the exact message and it has a status
-    if (currentMessage && (globalStatus === "applied" || globalStatus === "rejected")) {
+    if (
+      currentMessage &&
+      (globalStatus === "applied" ||
+        globalStatus === "rejected" ||
+        globalStatus === "no_changes_needed")
+    ) {
       console.log(
         `[ModifiedFileMessage] Updating actionTaken to ${globalStatus} for messageToken: ${messageToken}, path: ${path}`,
       );

--- a/webview-ui/src/components/ResolutionsPage/ReceivedMessage.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ReceivedMessage.tsx
@@ -1,5 +1,5 @@
 import "./receivedMessage.css";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Message } from "@patternfly/chatbot";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
@@ -7,8 +7,9 @@ import avatar from "../../../public/avatarIcons/avatar.svg?inline";
 import { QuickResponse } from "../../../../shared/src/types/types";
 import { getBrandName } from "../../utils/branding";
 
-interface QuickResponseWithToken extends QuickResponse {
+interface QuickResponseWithState extends QuickResponse {
   messageToken: string;
+  isSelected?: boolean;
 }
 
 interface ReceivedMessageProps {
@@ -16,7 +17,7 @@ interface ReceivedMessageProps {
   extraContent?: React.ReactNode;
   isLoading?: boolean;
   timestamp?: string | Date;
-  quickResponses?: QuickResponseWithToken[];
+  quickResponses?: QuickResponseWithState[];
   isProcessing?: boolean;
 }
 
@@ -33,7 +34,20 @@ export const ReceivedMessage: React.FC<ReceivedMessageProps> = ({
   if (!content && !extraContent && !quickResponses?.length) {
     return null;
   }
-  const [selectedResponse, setSelectedResponse] = useState<string | null>(null);
+
+  // Check if there's already a selectedResponse from the message data (restored from persistence)
+  const initialSelectedResponse =
+    quickResponses?.find((response) => response.isSelected === true)?.id || null;
+
+  const [selectedResponse, setSelectedResponse] = useState<string | null>(initialSelectedResponse);
+
+  // Update selectedResponse if initialSelectedResponse changes (e.g., when persistence data loads)
+  useEffect(() => {
+    if (initialSelectedResponse && selectedResponse !== initialSelectedResponse) {
+      setSelectedResponse(initialSelectedResponse);
+    }
+  }, [initialSelectedResponse]);
+
   const formatTimestamp = (time: string | Date): string => {
     const date = typeof time === "string" ? new Date(time) : time;
     return date.toLocaleTimeString("en-US", {

--- a/webview-ui/src/components/ResolutionsPage/ResolutionsPage.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ResolutionsPage.tsx
@@ -174,6 +174,7 @@ const ResolutionPage: React.FC = () => {
 
       if (msg.kind === ChatMessageType.String) {
         const message = msg.value?.message as string;
+        const selectedResponse = msg.selectedResponse;
         return (
           <MessageWrapper key={msg.messageToken}>
             <ReceivedMessage
@@ -185,6 +186,7 @@ const ResolutionPage: React.FC = () => {
                       ...response,
                       messageToken: msg.messageToken,
                       isDisabled: response.id === "run-analysis" && isAnalyzing,
+                      isSelected: selectedResponse === response.id,
                     }))
                   : undefined
               }


### PR DESCRIPTION
Resolves https://github.com/konveyor/editor-extensions/issues/713
Accept and reject persistence already added [here]( https://github.com/konveyor/editor-extensions/commit/fe4f48e5a7f19db095230c4c5a8bff8bc1032287). This PR adds resolution panel session persistence for the new 'continue / no changes required' status and for the 'quick response' selections.