### PR TITLE
:sparkles: Enable migration profiles to select a programming language for the workspace

### DIFF
--- a/shared/src/types/actions.ts
+++ b/shared/src/types/actions.ts
@@ -24,6 +24,7 @@ export const UPDATE_PROFILE = "UPDATE_PROFILE";
 export const QUICK_RESPONSE = "QUICK_RESPONSE";
 export const OPEN_FILE_IN_EDITOR = "OPEN_FILE_IN_EDITOR";
 export const TOGGLE_AGENT_MODE = "TOGGLE_AGENT_MODE";
+export const DETECT_LANGUAGE = "DETECT_LANGUAGE";
 
 export type WebviewActionType =
   | typeof SET_STATE
@@ -52,7 +53,8 @@ export type WebviewActionType =
   | typeof OPEN_PROFILE_MANAGER
   | typeof QUICK_RESPONSE
   | typeof OPEN_FILE_IN_EDITOR
-  | typeof TOGGLE_AGENT_MODE;
+  | typeof TOGGLE_AGENT_MODE
+  | typeof DETECT_LANGUAGE;
 export interface WebviewAction<S, T> {
   type: S;
   payload: T;

--- a/shared/src/types/types.ts
+++ b/shared/src/types/types.ts
@@ -295,6 +295,7 @@ export interface AnalysisProfile {
   useDefaultRules: boolean;
   labelSelector: string;
   readOnly?: boolean;
+  language?: string;
 }
 
 export type ToolMessageValue = { toolName: string; toolStatus: string };

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -51,6 +51,10 @@ import { MessageQueueManager } from "./utilities/ModifiedFiles/queueManager";
 import { VerticalDiffCodeLensProvider } from "./diff/verticalDiffCodeLens";
 import type { Logger } from "winston";
 import { parseModelConfig, getProviderConfigKeys } from "./modelProvider/config";
+import {
+  getProgrammingLanguage,
+  detectLanguageFromBuildFiles,
+} from "./utilities/profiles/profileService";
 
 const isWindows = process.platform === "win32";
 
@@ -274,7 +278,7 @@ const commandsMap: (
           const input: KaiInteractiveWorkflowInput = {
             incidents,
             migrationHint: profileName,
-            programmingLanguage: "Java",
+            programmingLanguage: getProgrammingLanguage(state),
             enableAgentMode: agentMode,
           };
 
@@ -997,6 +1001,18 @@ const commandsMap: (
         await executeExtensionCommand("acceptDiff", filePath);
       } else if (action?.value === "reject") {
         await executeExtensionCommand("rejectDiff", filePath);
+      }
+    },
+
+    [`${EXTENSION_NAME}.detectLanguage`]: async () => {
+      const detectedLanguage = await detectLanguageFromBuildFiles();
+
+      const profilesProvider = state.webviewProviders.get("profiles");
+      if (profilesProvider) {
+        profilesProvider.sendMessageToWebview({
+          type: "LANGUAGE_DETECTED",
+          detectedLanguage,
+        });
       }
     },
   };

--- a/vscode/src/utilities/profiles/profileService.ts
+++ b/vscode/src/utilities/profiles/profileService.ts
@@ -85,3 +85,40 @@ export function updateActiveProfile(
     }
   });
 }
+
+export function getProgrammingLanguage(state: ExtensionState): string {
+  return getActiveProfile(state)?.language ?? "Java";
+}
+
+export async function detectLanguageFromBuildFiles(): Promise<string | null> {
+  const buildFileToLanguage: { [pattern: string]: string } = {
+    "**/pom.xml": "Java",
+    "**/build.gradle": "Java",
+    "**/build.gradle.kts": "Java",
+    "**/go.mod": "Go",
+    "**/package.json": "JavaScript",
+    "**/requirements.txt": "Python",
+    "**/setup.py": "Python",
+    "**/pyproject.toml": "Python",
+    "**/Cargo.toml": "Rust",
+    "**/composer.json": "PHP",
+    "**/Gemfile": "Ruby",
+  };
+
+  for (const [pattern, language] of Object.entries(buildFileToLanguage)) {
+    try {
+      const files = await vscode.workspace.findFiles(pattern, null, 1);
+      if (files.length > 0) {
+        return language;
+      }
+    } catch (error) {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+export function getSupportedLanguages(): string[] {
+  return ["Java", "Go", "Python", "JavaScript", "TypeScript", "C#", "C++", "Rust", "PHP", "Ruby"];
+}

--- a/vscode/src/webviewMessageHandler.ts
+++ b/vscode/src/webviewMessageHandler.ts
@@ -9,6 +9,7 @@ import {
   CONFIGURE_LABEL_SELECTOR,
   CONFIGURE_SOURCES_TARGETS,
   DELETE_PROFILE,
+  DETECT_LANGUAGE,
   GET_SOLUTION,
   GET_SOLUTION_WITH_KONVEYOR_CONTEXT,
   GET_SUCCESS_RATE,
@@ -156,6 +157,9 @@ const actions: {
   },
   [CONFIGURE_CUSTOM_RULES]: async ({ profileId }, state) => {
     executeExtensionCommand("configureCustomRules", profileId);
+  },
+  [DETECT_LANGUAGE]: async (_payload, _state) => {
+    executeExtensionCommand("detectLanguage");
   },
 
   [OVERRIDE_ANALYZER_BINARIES]() {


### PR DESCRIPTION
fixes https://github.com/konveyor/editor-extensions/issues/521 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically detects your project’s programming language from workspace build files and pre-fills the profile.
  - Adds a Programming Language field in the Profile Editor with selectable options (Java, Go, Python, JavaScript, TypeScript, C#, C++, Rust, PHP, Ruby).
  - Shows contextual helper text when the language was auto-detected.
  - Uses the selected/detected language dynamically in workflows (no longer fixed to Java).
  - You can override the auto-detected language at any time via the dropdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->