### PR TITLE
:bug: handle creds better in solution server

### DIFF
--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -36,8 +36,6 @@ import {
   getTraceDir,
   getConfigSolutionServerAuth,
   fileUriToPath,
-  updateSolutionServerConfig,
-  getConfigSolutionServer,
 } from "./utilities/configuration";
 import { EXTENSION_NAME } from "./utilities/constants";
 import { promptForCredentials } from "./utilities/auth";
@@ -792,13 +790,11 @@ const commandsMap: (
         return;
       }
 
-      await updateSolutionServerConfig({
-        auth: {
-          ...getConfigSolutionServer().auth,
-          ...credentials,
-        },
-      });
+      // Update the solution server client with new credentials
+      // (credentials are already stored by promptForCredentials)
+      await state.solutionServerClient.authenticate(credentials.username, credentials.password);
 
+      // Restart the connection with new credentials
       await executeExtensionCommand("restartSolutionServer");
       logger.info("Solution server credentials updated successfully.");
     },

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -613,7 +613,8 @@ class VsCodeExtension {
     }
 
     this.state.solutionServerClient
-      .connect(username, password)
+      .authenticate(username, password)
+      .then(() => this.state.solutionServerClient.connect())
       .then(() => {
         // Update state to reflect successful connection
         this.state.mutateData((draft) => {


### PR DESCRIPTION
Fixes #798 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated sign-in step (authenticate) to store credentials before connecting.
  * Connections can use an existing bearer token; tokens are exchanged and refreshed automatically.
  * VS Code: entering credentials triggers a solution server restart to apply them.

* **Bug Fixes**
  * More reliable reconnect/refresh handling that stops after failed attempts.
  * Clear error when connecting without prior sign-in.
  * Authentication-disabled mode now clears auth state and behaves correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->