### PR TITLE
:test_tube: Windows adaptations

### DIFF
--- a/tests/e2e/tests/analyze_coolstore.test.ts
+++ b/tests/e2e/tests/analyze_coolstore.test.ts
@@ -91,8 +91,8 @@ providers.forEach((config) => {
 
     test.afterAll(async () => {
       await vscodeApp.closeVSCode();
-      // Evaluation should be performed just on Linux, on CI by default and only if all tests under this suite passed
-      if (getOSInfo() === 'linux' && allOk && process.env.CI) {
+      // Evaluation should be performed just on CI by default and only if all tests under this suite passed
+      if (allOk && process.env.CI) {
         await prepareEvaluationData(config.model);
         await runEvaluation(
           path.join(TEST_OUTPUT_FOLDER, 'incidents-map.json'),

--- a/tests/e2e/tests/base/configure-and-run-analysis.test.ts
+++ b/tests/e2e/tests/base/configure-and-run-analysis.test.ts
@@ -12,7 +12,7 @@ test.describe(`Configure extension and run analysis`, () => {
   const profileName = `automation-${randomString}`;
 
   test.beforeAll(async ({ testRepoData }) => {
-    test.setTimeout(600000);
+    test.setTimeout(900000);
     const repoInfo = testRepoData['coolstore'];
     vscodeApp = await VSCode.open(repoInfo.repoUrl, repoInfo.repoName);
   });
@@ -32,6 +32,7 @@ test.describe(`Configure extension and run analysis`, () => {
   });
 
   test('Analyze coolstore app', async () => {
+    test.setTimeout(300000);
     await vscodeApp.waitDefault();
     await vscodeApp.runAnalysis();
     await vscodeApp.waitDefault();

--- a/tests/e2e/tests/base/custom-binary-analysis.test.ts
+++ b/tests/e2e/tests/base/custom-binary-analysis.test.ts
@@ -19,7 +19,7 @@ test.describe.serial(`@tier2 Override the analyzer binary and run analysis`, () 
   const profileName = `custom-binary-analysis-${randomString}`;
   let binaryPath: string | undefined;
   test.beforeAll(async ({ testRepoData }) => {
-    test.setTimeout(600000);
+    test.setTimeout(900000);
     const kaiFolderPath = pathlib.join(__dirname, '../../../../downloaded_assets/kai');
     if (!process.env.ANALYZER_BINARY_PATH && !fs.existsSync(kaiFolderPath)) {
       throw new Error(
@@ -71,6 +71,7 @@ test.describe.serial(`@tier2 Override the analyzer binary and run analysis`, () 
   });
 
   test('Analyze coolstore app', async () => {
+    test.setTimeout(600000);
     const configPage = await Configuration.open(vscodeApp);
     await configPage.setInputConfiguration(analyzerPath, binaryPath!);
     await vscodeApp.startServer();

--- a/tests/e2e/tests/base/llm-revert-check_jboss-eap-quickstarts.test.ts
+++ b/tests/e2e/tests/base/llm-revert-check_jboss-eap-quickstarts.test.ts
@@ -65,8 +65,7 @@ getAvailableProviders().forEach((provider) => {
       await vscodeApp.openAnalysisView();
       await vscodeApp.searchViolationAndAcceptAllSolutions(violation);
       await vscodeApp.openAnalysisView();
-      const analysisView = await vscodeApp.getView(KAIViews.analysisView);
-      await vscodeApp.waitForSolutionConfirmation(analysisView);
+      await vscodeApp.waitForSolutionConfirmation();
 
       afterFirstFixMemberFileImports = getFileImports(memberFileUri);
     });
@@ -79,8 +78,7 @@ getAvailableProviders().forEach((provider) => {
       await vscodeApp.openAnalysisView();
       await vscodeApp.searchViolationAndAcceptAllSolutions(violation);
       await vscodeApp.openAnalysisView();
-      const analysisView = await vscodeApp.getView(KAIViews.analysisView);
-      await vscodeApp.waitForSolutionConfirmation(analysisView);
+      await vscodeApp.waitForSolutionConfirmation();
 
       afterSecondFixMemberFileImports = getFileImports(memberFileUri);
     });
@@ -98,9 +96,6 @@ getAvailableProviders().forEach((provider) => {
     test.afterEach(async () => {
       const testName = test.info().title.replace(' ', '-');
       console.log(`Finished ${testName} at ${new Date()}`);
-      await vscodeApp.getWindow().screenshot({
-        path: `${SCREENSHOTS_FOLDER}/after-${testName}-${provider.model.replace(/[.:]/g, '-')}.png`,
-      });
     });
 
     test.afterAll(async () => {


### PR DESCRIPTION
Part of #669

Adapts some tests so they work properly on windows

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved e2e stability: reveal filters when toggles are hidden; use a more reliable click for Delete Profile; added loading guard and cap when accepting all solutions.
  * Added a loading indicator check to determine completion.
  * Extended timeouts for setup and key analysis tests to reduce flakiness.
  * Simplified solution confirmation calls; removed automatic per-test screenshots.
  * Adjusted evaluation gating to run on CI when all tests pass, regardless of OS.

* **Chores**
  * Minor structural locator addition for loading state checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->