### PR TITLE
:bug: normalize paths

### DIFF
--- a/vscode/src/client/analyzerClient.ts
+++ b/vscode/src/client/analyzerClient.ts
@@ -12,6 +12,7 @@ import {
   Violation,
 } from "@editor-extensions/shared";
 import { paths, ignoresToExcludedPaths } from "../paths";
+import { normalizeFilePath } from "../utilities/pathUtils";
 import { Extension } from "../helpers/Extension";
 import { buildAssetPaths, AssetPaths } from "./paths";
 import { getConfigAnalyzerPath, getConfigKaiDemoMode, isAnalysisResponse } from "../utilities";
@@ -418,9 +419,12 @@ export class AnalyzerClient {
 
           const requestParams = {
             label_selector: activeProfile.labelSelector,
-            included_paths: filePaths?.map((uri) => uri.fsPath),
+            included_paths: filePaths?.map((uri) => normalizeFilePath(uri.fsPath)),
             reset_cache: !(filePaths && filePaths.length > 0),
-            excluded_paths: ignoresToExcludedPaths(),
+            excluded_paths: ignoresToExcludedPaths().flatMap((path) => [
+              path,
+              normalizeFilePath(path),
+            ]),
           };
           this.logger.info(
             `Sending 'analysis_engine.Analyze' request with params: ${JSON.stringify(

--- a/vscode/src/utilities/pathUtils.ts
+++ b/vscode/src/utilities/pathUtils.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import { fileURLToPath } from "url";
 
 export function fileUriToPath(path: string): string {
@@ -5,4 +6,19 @@ export function fileUriToPath(path: string): string {
   return process.platform === "win32" && cleanPath.match(/^\/[A-Za-z]:\//)
     ? cleanPath.substring(1)
     : cleanPath;
+}
+
+/**
+ * Normalize a filesystem path by removing redundant . and \ chars. Capitalizes Windows drive letters.
+ */
+export function normalizeFilePath(inputPath: string): string {
+  if (!inputPath) {
+    return inputPath;
+  }
+  const fsPath = fileUriToPath(inputPath);
+  let normalized = path.normalize(fsPath);
+  if (process.platform === "win32") {
+    normalized = normalized.replace(/^([a-z]):/, (m, p1) => `${p1.toUpperCase()}:`);
+  }
+  return normalized;
 }


### PR DESCRIPTION
Fixes #800 

Depends on https://github.com/konveyor/kai/pull/864
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
