### PR TITLE
:bug: do not attempt to getServerCapabilities when disconnected

### DIFF
--- a/agentic/src/clients/solutionServerClient.ts
+++ b/agentic/src/clients/solutionServerClient.ts
@@ -287,8 +287,12 @@ export class SolutionServerClient {
   }
 
   public async getServerCapabilities(): Promise<any> {
+    if (!this.isConnected) {
+      this.logger.info("Solution server is not connected, returning empty capabilities");
+      return;
+    }
     if (!this.enabled) {
-      this.logger.info("Solution server is disabled, returning incidents without success rate");
+      this.logger.info("Solution server is disabled, returning empty capabilities");
       return;
     }
     if (!this.mcpClient || !this.isConnected) {


### PR DESCRIPTION
Fixes #798 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - When the solution server is disabled or not connected, the app now returns no capabilities instead of showing partial or misleading information, improving consistency for users.
- Chores
  - Improved log messages to clearly indicate when the solution server is not connected or disabled, aiding troubleshooting.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->