### PR TITLE
:bug: searchFiles should handle rel paths correctly

### DIFF
--- a/agentic/src/tools/filesystem.ts
+++ b/agentic/src/tools/filesystem.ts
@@ -67,7 +67,8 @@ export class FileSystemTools extends KaiWorkflowEventEmitter {
             } else if (
               (entry.isFile() && rPattern.test(entry.name)) ||
               rPattern.test(pathlib.basename(absPath)) ||
-              rPattern.test(relPath)
+              rPattern.test(relPath) ||
+              pattern === relPath
             ) {
               result.push(relPath);
             }

--- a/agentic/tests/tools.test.ts
+++ b/agentic/tests/tools.test.ts
@@ -44,7 +44,7 @@ describe("searchFilesTool", () => {
 
     // ISSUE-806: when a model passes a relative path as pattern, it should match
     const tc5 = await tool.invoke({
-      pattern: "src/main/java/io/example/lib/A.java",
+      pattern: pathlib.join("src", "main", "java", "io", "example", "lib", "A.java"),
     });
     const tc5_expected = pathlib.join("src", "main", "java", "io", "example", "lib", "A.java");
     expect(tc5).toBe(tc5_expected);


### PR DESCRIPTION
Fixes #806 
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File search now also matches patterns against relative paths, ensuring nested or full-path patterns correctly find files.

* **Tests**
  * Added a test validating relative-path pattern matching in the file search tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->