### PR TITLE
:test_tube: Adapt evaluation

### DIFF
--- a/tests/e2e/fixtures/provider-configs.fixture.ts
+++ b/tests/e2e/fixtures/provider-configs.fixture.ts
@@ -1,4 +1,5 @@
 import { LLMProviders } from '../enums/llm-providers.enum';
+import { isAWSConfigured } from '../../kai-evaluator/utils/s3.utils';
 
 export interface ProviderConfig {
   model: string;
@@ -74,11 +75,7 @@ export function getAvailableProviders(): ProviderConfig[] {
     providers.push(OPENAI_GPT4OMINI_PROVIDER);
   }
 
-  if (
-    process.env.AWS_ACCESS_KEY_ID &&
-    process.env.AWS_SECRET_ACCESS_KEY &&
-    process.env.AWS_DEFAULT_REGION
-  ) {
+  if (isAWSConfigured()) {
     providers.push(AWS_PROVIDER);
   }
 

--- a/tests/e2e/pages/vscode.page.ts
+++ b/tests/e2e/pages/vscode.page.ts
@@ -600,7 +600,7 @@ export class VSCode extends BasePage {
     const MAX_FIXES = 500;
 
     for (let i = 0; i < MAX_FIXES; i++) {
-      await expect(fixLocator.first()).toBeVisible({ timeout: 30000 });
+      await expect(fixLocator.first()).toBeVisible({ timeout: 60000 });
       // Ensures the button is clicked even if there are notifications overlaying it due to screen size
       await fixLocator.first().dispatchEvent('click');
       await this.waitDefault();

--- a/tests/e2e/tests/analyze_coolstore.test.ts
+++ b/tests/e2e/tests/analyze_coolstore.test.ts
@@ -17,6 +17,7 @@ providers.forEach((config) => {
     let allOk = true;
     const randomString = generateRandomString();
     let profileName = '';
+
     test.beforeAll(async ({ testRepoData }, testInfo) => {
       test.setTimeout(1600000);
       const repoName = getRepoName(testInfo);
@@ -81,26 +82,25 @@ providers.forEach((config) => {
 
     test.afterAll(async ({ testRepoData }, testInfo) => {
       await vscodeApp.closeVSCode();
-      if (!isAWSConfigured()) {
-        throw new Error(
-          "Evaluation can't be performed because AWS credentials are not configured."
-        );
-      }
       // Evaluation should be performed only if all tests under this suite passed
       if (allOk && process.env.CI) {
-        const repoInfo = testRepoData[getRepoName(testInfo)];
-        await prepareEvaluationData(config.model);
-        await runEvaluation(
-          path.join(TEST_OUTPUT_FOLDER, 'incidents-map.json'),
-          TEST_OUTPUT_FOLDER,
-          {
-            model: config.model,
-            sources: repoInfo.sources,
-            targets: repoInfo.targets,
-          },
-          `${TEST_OUTPUT_FOLDER}/coolstore-${config.model.replace(/[.:]/g, '-')}`
-        );
+        if (!isAWSConfigured()) {
+          console.warn('Skipping evaluation: AWS credentials are not configured.');
+          return;
+        }
       }
+      const repoInfo = testRepoData[getRepoName(testInfo)];
+      await prepareEvaluationData(config.model);
+      await runEvaluation(
+        path.join(TEST_OUTPUT_FOLDER, 'incidents-map.json'),
+        TEST_OUTPUT_FOLDER,
+        {
+          model: config.model,
+          sources: repoInfo.sources,
+          targets: repoInfo.targets,
+        },
+        `${TEST_OUTPUT_FOLDER}/coolstore-${config.model.replace(/[.:]/g, '-')}`
+      );
     });
   });
 });

--- a/tests/e2e/tests/analyze_coolstore.test.ts
+++ b/tests/e2e/tests/analyze_coolstore.test.ts
@@ -1,14 +1,15 @@
 import { expect, test } from '../fixtures/test-repo-fixture';
 import { VSCode } from '../pages/vscode.page';
 import { SCREENSHOTS_FOLDER, TEST_OUTPUT_FOLDER } from '../utilities/consts';
-import { getOSInfo, getRepoName, generateRandomString } from '../utilities/utils';
-import { DEFAULT_PROVIDER, providerConfigs } from '../fixtures/provider-configs.fixture';
+import { getRepoName, generateRandomString } from '../utilities/utils';
+import { DEFAULT_PROVIDER, getAvailableProviders } from '../fixtures/provider-configs.fixture';
 import path from 'path';
 import { runEvaluation } from '../../kai-evaluator/core';
 import { prepareEvaluationData, saveOriginalAnalysisFile } from '../utilities/evaluation.utils';
 import { KAIViews } from '../enums/views.enum';
+import { isAWSConfigured } from '../../kai-evaluator/utils/s3.utils';
 
-const providers = process.env.CI ? providerConfigs : [DEFAULT_PROVIDER];
+const providers = process.env.CI ? getAvailableProviders() : [DEFAULT_PROVIDER];
 
 providers.forEach((config) => {
   test.describe(`Coolstore app tests | ${config.model}`, () => {
@@ -63,19 +64,8 @@ providers.forEach((config) => {
       await vscodeApp.openAnalysisView();
       const analysisView = await vscodeApp.getView(KAIViews.analysisView);
       await analysisView.locator('button#get-solution-button').first().click({ timeout: 300000 });
-      const resolutionView = await vscodeApp.getView(KAIViews.resolutionDetails);
-      const fixLocator = resolutionView.locator('button[aria-label="Accept all changes"]');
-      await vscodeApp.waitDefault();
-      await expect(fixLocator.first()).toBeVisible({ timeout: 3600000 });
-      const fixesNumber = await fixLocator.count();
-      let fixesCounter = await fixLocator.count();
-      for (let i = 0; i < fixesNumber; i++) {
-        await expect(fixLocator.first()).toBeVisible({ timeout: 30000 });
-        // Ensures the button is clicked even if there are notifications overlaying it due to screen size
-        await fixLocator.first().dispatchEvent('click');
-        await vscodeApp.waitDefault();
-        expect(await fixLocator.count()).toEqual(--fixesCounter);
-      }
+
+      await vscodeApp.acceptAllSolutions();
     });
 
     test.afterEach(async () => {
@@ -89,15 +79,25 @@ providers.forEach((config) => {
       });
     });
 
-    test.afterAll(async () => {
+    test.afterAll(async ({ testRepoData }, testInfo) => {
       await vscodeApp.closeVSCode();
-      // Evaluation should be performed just on CI by default and only if all tests under this suite passed
+      if (!isAWSConfigured()) {
+        throw new Error(
+          "Evaluation can't be performed because AWS credentials are not configured."
+        );
+      }
+      // Evaluation should be performed only if all tests under this suite passed
       if (allOk && process.env.CI) {
+        const repoInfo = testRepoData[getRepoName(testInfo)];
         await prepareEvaluationData(config.model);
         await runEvaluation(
           path.join(TEST_OUTPUT_FOLDER, 'incidents-map.json'),
           TEST_OUTPUT_FOLDER,
-          config.model,
+          {
+            model: config.model,
+            sources: repoInfo.sources,
+            targets: repoInfo.targets,
+          },
           `${TEST_OUTPUT_FOLDER}/coolstore-${config.model.replace(/[.:]/g, '-')}`
         );
       }

--- a/tests/e2e/tests/analyze_coolstore.test.ts
+++ b/tests/e2e/tests/analyze_coolstore.test.ts
@@ -88,19 +88,20 @@ providers.forEach((config) => {
           console.warn('Skipping evaluation: AWS credentials are not configured.');
           return;
         }
+
+        const repoInfo = testRepoData[getRepoName(testInfo)];
+        await prepareEvaluationData(config.model);
+        await runEvaluation(
+          path.join(TEST_OUTPUT_FOLDER, 'incidents-map.json'),
+          TEST_OUTPUT_FOLDER,
+          {
+            model: config.model,
+            sources: repoInfo.sources,
+            targets: repoInfo.targets,
+          },
+          `${TEST_OUTPUT_FOLDER}/coolstore-${config.model.replace(/[.:]/g, '-')}`
+        );
       }
-      const repoInfo = testRepoData[getRepoName(testInfo)];
-      await prepareEvaluationData(config.model);
-      await runEvaluation(
-        path.join(TEST_OUTPUT_FOLDER, 'incidents-map.json'),
-        TEST_OUTPUT_FOLDER,
-        {
-          model: config.model,
-          sources: repoInfo.sources,
-          targets: repoInfo.targets,
-        },
-        `${TEST_OUTPUT_FOLDER}/coolstore-${config.model.replace(/[.:]/g, '-')}`
-      );
     });
   });
 });

--- a/tests/kai-evaluator/README.md
+++ b/tests/kai-evaluator/README.md
@@ -32,7 +32,7 @@ contains the visualizer interface.
 ## Usage
 
 ```bash
-  npx ts-node main.ts ../test-output/incidents-map.json ../test-output
+  npx ts-node main.ts ../test-output/incidents-map.json ../test-output "eap" "jakarta-ee8,jakarta-ee9" "meta.llama3-70b-instruct-v1:0"
 ```
 
 ## Expected file input format

--- a/tests/kai-evaluator/agents/evaluation.agent.ts
+++ b/tests/kai-evaluator/agents/evaluation.agent.ts
@@ -2,10 +2,12 @@ import { createEvaluationChain } from '../chains/evaluation.chain';
 import { FileEvaluationResult } from '../model/evaluation-result.model';
 import { FileEvaluationInput } from '../model/evaluation-input.model';
 import { isSyntaxValid } from '../utils/build.utils';
+import { KaiEvaluatorOptions } from '../core';
 
 export async function evaluateFile(
   file: string,
-  input: FileEvaluationInput
+  input: FileEvaluationInput,
+  evaluatorOptions: KaiEvaluatorOptions
 ): Promise<FileEvaluationResult> {
   const chain = await createEvaluationChain();
 
@@ -18,11 +20,10 @@ export async function evaluateFile(
 
   const query = `Original content: \n\`\`\`\n${input.originalContent}\n\`\`\`\n Incidents: ${incidentDescriptions}\n UpdatedContent: \n\`\`\`\n${input.updatedContent}\n\`\`\``;
 
-  // TODO support multiple targets and fetch them from a different place
   const evalResult = await chain.invoke({
     query,
-    source: 'java-ee',
-    target: 'quarkus',
+    sources: evaluatorOptions.sources.join(', '),
+    targets: evaluatorOptions.targets.join(', '),
   });
 
   return {

--- a/tests/kai-evaluator/chains/evaluation.chain.ts
+++ b/tests/kai-evaluator/chains/evaluation.chain.ts
@@ -3,6 +3,7 @@ import { StructuredOutputParser } from 'langchain/output_parsers';
 import { z } from 'zod';
 import { BedrockChat } from '@langchain/community/chat_models/bedrock';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
+import { isAWSConfigured } from '../utils/s3.utils';
 
 const outputSchema = z.object({
   specificity: z.number().min(0).max(10),
@@ -15,16 +16,11 @@ const outputSchema = z.object({
 const outputParser = StructuredOutputParser.fromZodSchema(outputSchema);
 
 export async function createEvaluationChain() {
-  if (
-    !process.env.AWS_ACCESS_KEY_ID ||
-    !process.env.AWS_SECRET_ACCESS_KEY ||
-    !process.env.AWS_REGION
-  ) {
+  if (!isAWSConfigured()) {
     throw new Error(
       'Required AWS environment variables are not set: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION'
     );
   }
-
   const model = new BedrockChat({
     model: 'meta.llama3-70b-instruct-v1:0',
     region: process.env.AWS_REGION,

--- a/tests/kai-evaluator/main.ts
+++ b/tests/kai-evaluator/main.ts
@@ -16,7 +16,7 @@ const fullOutputPath = path.resolve(outputPath);
 const targets = targetsArg.split(',').map((t) => t.trim());
 const sources = sourcesArg.split(',').map((s) => s.trim());
 
-runEvaluation(fullInputPath, fullOutputPath, { targets, sources, model })
+runEvaluation(fullInputPath, fullOutputPath, { targets, sources, model: model.trim() })
   .then(() => console.log('Evaluation finished'))
   .catch((error) => {
     console.error('Evaluation failed:', error);

--- a/tests/kai-evaluator/main.ts
+++ b/tests/kai-evaluator/main.ts
@@ -1,16 +1,22 @@
 import * as path from 'path';
 import { runEvaluation } from './core';
 
-const [, , inputFilePath, outputPath] = process.argv;
+const [, , inputFilePath, outputPath, targetsArg, sourcesArg, model] = process.argv;
 
-if (!inputFilePath || !outputPath) {
-  console.error('Usage: evaluate <input_file_path> <output_folder_path>');
+if (!inputFilePath || !outputPath || !targetsArg || !sourcesArg || !model) {
+  console.error(
+    'Usage: evaluate <input_file_path> <output_folder_path> <targets(comma-separated)> <sources(comma-separated)> <model>'
+  );
   process.exit(1);
 }
 
 const fullInputPath = path.resolve(inputFilePath);
 const fullOutputPath = path.resolve(outputPath);
-runEvaluation(fullInputPath, fullOutputPath)
+
+const targets = targetsArg.split(',').map((t) => t.trim());
+const sources = sourcesArg.split(',').map((s) => s.trim());
+
+runEvaluation(fullInputPath, fullOutputPath, { targets, sources, model })
   .then(() => console.log('Evaluation finished'))
   .catch((error) => {
     console.error('Evaluation failed:', error);

--- a/tests/kai-evaluator/prompts/evaluation.prompt.ts
+++ b/tests/kai-evaluator/prompts/evaluation.prompt.ts
@@ -1,17 +1,17 @@
 export const LANGCHAIN_PROMPT_TEMPLATE = `
 You are a senior engineer overseeing the migration of a large enterprise Java
-project from {source} to {target}. Your engineering team has been using the Konveyor code analysis tool to identify 
+project from {sources} to {targets}. Your engineering team has been using the Konveyor code analysis tool to identify
 problem spots in the code that must be changed in order to migrate successfully. An LLM assistant was assigned to follow
 the recommendations from Konveyor and apply them to the files in your codebase. Your current job is to review the
 changes made by the LLM, and evaluate how effective the changes are on four metrics:
 
 1) How well the changes match the recommendations made by Konveyor.
-2) How well the changes follow Java and {target} best practice.
-3) How well the changes do at successfully migrating the file from {source} to {target}. 
+2) How well the changes follow Java and {targets} best practice.
+3) How well the changes do at successfully migrating the file from {sources} to {targets}.
 
-It is also critically important that the LLM makes the minimum number of changes necessary to correct the problem 
-identified by Konveyor, have avoided making unnecessary or superfluous changes, and the code must remain 
-syntactically valid and able to be compiled. The LLM may be deceptive. Compare the original and changed files 
+It is also critically important that the LLM makes the minimum number of changes necessary to correct the problem
+identified by Konveyor, have avoided making unnecessary or superfluous changes, and the code must remain
+syntactically valid and able to be compiled. The LLM may be deceptive. Compare the original and changed files
 carefully to be sure that the LLM did what it said.
 
 The LLM assistant will provide you with the original, unchanged file it was working on,

--- a/tests/kai-evaluator/utils/build.utils.ts
+++ b/tests/kai-evaluator/utils/build.utils.ts
@@ -5,11 +5,15 @@ import Java from 'tree-sitter-java';
 export function isBuildable(path: string): Promise<boolean> {
   return new Promise((resolve) => {
     exec(`cd ${path} && mvn clean install`, (error, stdout, stderr) => {
-      console.log('MVN CLEAN INSTALL output: ');
-      console.log(stdout);
+      if (process.env.CI) {
+        console.log('MVN CLEAN INSTALL output: ');
+        console.log(stdout);
+      }
       if (error) {
-        console.error('MVN CLEAN INSTALL error: ');
-        console.error(stderr);
+        if (process.env.CI) {
+          console.error('MVN CLEAN INSTALL error: ');
+          console.error(stderr);
+        }
         resolve(false);
       } else {
         resolve(true);

--- a/tests/kai-evaluator/utils/s3.utils.ts
+++ b/tests/kai-evaluator/utils/s3.utils.ts
@@ -4,7 +4,7 @@ export async function uploadObject(file: string, path: string, contentType = 'ap
   if (!file || !path) {
     throw new Error('File content and path are required');
   }
-  if (!process.env.AWS_DEFAULT_REGION || !process.env.KAI_QE_S3_BUCKET_NAME) {
+  if (!isAWSConfigured() || !process.env.KAI_QE_S3_BUCKET_NAME) {
     throw new Error(
       'AWS_DEFAULT_REGION and KAI_QE_S3_BUCKET_NAME environment variables are required'
     );
@@ -21,6 +21,7 @@ export async function uploadObject(file: string, path: string, contentType = 'ap
       })
     );
   } catch (error: any) {
+    console.error(error);
     throw new Error(`Failed to upload object to S3: ${error.message}`);
   }
 }
@@ -47,4 +48,12 @@ export async function downloadObject(path: string) {
   } catch (error: any) {
     throw new Error(`Failed to download object from S3: ${error.message}`);
   }
+}
+
+export function isAWSConfigured(): boolean {
+  return (
+    !!process.env.AWS_ACCESS_KEY_ID &&
+    !!process.env.AWS_SECRET_ACCESS_KEY &&
+    !!process.env.AWS_DEFAULT_REGION
+  );
 }


### PR DESCRIPTION
Part of #669 

Adapts the evaluation to latest extension version and ensures it works on Windows

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluations now accept explicit model, sources, and targets; reports include average effectiveness and average score.

* **Improvements**
  * More reliable "accept all solutions" flow with increased timeout.
  * Smarter provider auto-detection with graceful skipping when cloud credentials are missing.
  * Evaluation reports uploaded when cloud storage is available; upload errors logged more clearly.
  * Reduced local console noise; full logs retained in CI.
  * Prompt text refined for clearer evaluation guidance.

* **Documentation**
  * CLI usage updated to show targets, sources, and model arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->