### PR TITLE
:bug: Do not go through solution server restart when disabled

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -482,7 +482,7 @@
         },
         "konveyor.solutionServer": {
           "type": "object",
-          "description": "Configuration for the MCP solution server",
+          "description": "Configuration for the MCP solution server. Set 'enabled: true' to enable, 'url' for server endpoint, and configure 'auth' object with 'enabled: true', 'realm' (default: tackle), and 'insecure: true' to skip SSL verification if needed.",
           "scope": "window",
           "order": 30,
           "properties": {

--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -36,6 +36,7 @@ import {
   getTraceDir,
   getConfigSolutionServerAuth,
   fileUriToPath,
+  getConfigSolutionServer,
 } from "./utilities/configuration";
 import { EXTENSION_NAME } from "./utilities/constants";
 import { promptForCredentials } from "./utilities/auth";
@@ -113,6 +114,12 @@ const commandsMap: (
     },
     [`${EXTENSION_NAME}.restartSolutionServer`]: async () => {
       const solutionServerClient = state.solutionServerClient;
+      const config = getConfigSolutionServer();
+      if (!config.enabled) {
+        logger.info("Solution server is disabled, skipping restart");
+        return;
+      }
+
       try {
         window.showInformationMessage("Restarting solution server...");
         await solutionServerClient.disconnect();


### PR DESCRIPTION
Fixes #828 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents restarting the solution server when it’s disabled in settings, avoiding unnecessary operations and logs.

* **Documentation**
  * Expanded the configuration description for the solution server with practical guidance: how to enable it, set the endpoint URL, and configure authentication (including realm default and optional SSL verification bypass).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->