### PR TITLE
:bug: Fix local tests not able to run due to wrong command name

### DIFF
--- a/tests/e2e/pages/vscode.page.ts
+++ b/tests/e2e/pages/vscode.page.ts
@@ -166,7 +166,7 @@ export class VSCode extends BasePage {
   public async openAnalysisView(): Promise<void> {
     // Try using command palette first - this works reliably when extension is hidden due to too many extensions
     try {
-      await this.executeQuickCommand(`${COMMAND_CATEGORY}: Open Analysis View`);
+      await this.executeQuickCommand(`${COMMAND_CATEGORY}: Open ${COMMAND_CATEGORY} Analysis View`);
       return;
     } catch (error) {
       console.log('Command palette approach failed:', error);


### PR DESCRIPTION
<img width="720" height="302" alt="image" src="https://github.com/user-attachments/assets/a42ab52c-52d3-482f-885d-399fd72dad1f" />

Command is not found when running tests locally after branding changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the VS Code command palette label for opening the Analysis View to include the category name (e.g., “Konveyor: Open Konveyor Analysis View”). This improves clarity, consistency, and discoverability, helping distinguish it from similarly named commands. No behavioral changes; the view opens as before. Aligns naming with the activity bar for a more coherent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->