### PR TITLE
:seedling: Fix collect-assets:dev mode releaseTag undefined issue

### DIFF
--- a/scripts/_util.js
+++ b/scripts/_util.js
@@ -129,7 +129,7 @@ export function parseCli(
   const ruleset = {
     rulesetOrg: values["ruleset-org"],
     rulesetRepo: values["ruleset-repo"],
-    rulesetReleaseTag: values["ruleset-release-tag"],
+    releaseTag: values["release-tag"],
   };
 
   if (values["use-workflow-artifacts"] && values.workflow && values.pr) {
@@ -150,7 +150,6 @@ export function parseCli(
       repo: values.repo,
       workflow: values.workflow,
       branch: values.branch,
-      releaseTag: values["release-tag"],
       ...ruleset,
     };
   }

--- a/scripts/_util.js
+++ b/scripts/_util.js
@@ -150,6 +150,7 @@ export function parseCli(
       repo: values.repo,
       workflow: values.workflow,
       branch: values.branch,
+      releaseTag: values["release-tag"],
       ...ruleset,
     };
   }


### PR DESCRIPTION
The workflow artifacts path in parseCli was missing releaseTag in the returned object, causing cli.releaseTag to be undefined when running collect-assets:dev. This resulted in 404 errors when downloading rulesets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added in this release.
- Refactor
  - Updated internal handling of release tags in CLI parsing for consistency. No changes to commands, flags, or expected output.
- Chores
  - Maintenance updates to script utilities with no impact on user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->