### PR TITLE
:test_tube: wait for extension to initialize

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -507,6 +507,11 @@ class VsCodeExtension {
 
       // Setup diff status bar item
       this.setupDiffStatusBar();
+
+      // Signal completion for E2E tests
+      if (process.env.__TEST_EXTENSION_END_TO_END__) {
+        vscode.window.showInformationMessage("__EXTENSION_INITIALIZED__");
+      }
     } catch (error) {
       this.state.logger.error("Error initializing extension", error);
       vscode.window.showErrorMessage(`Failed to initialize Konveyor extension: ${error}`);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end stability by waiting for the editor extension to fully initialize before proceeding.
  - Added a readiness signal during test launches to synchronize test execution with the editor environment.
  - Added a wait-with-timeout that logs and surfaces initialization failures promptly.
  - Automatically dismisses transient UI shown during initialization in test runs to reduce flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->