### PR TITLE
:seedling: bump to v0.8.0-beta.5 for kai+rulesets

### DIFF
--- a/scripts/collect-assets.js
+++ b/scripts/collect-assets.js
@@ -17,7 +17,7 @@ const cli = parseCli(
     workflow: "build-and-push-binaries.yml",
     rulesetOrg: "konveyor",
     rulesetRepo: "rulesets",
-    releaseTag: "v0.8.0-beta.4",
+    releaseTag: "v0.8.0-beta.5",
   },
   "release",
 );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release target to v0.8.0-beta.5 for CLI-driven asset collection.
  * Ensures seed rulesets are fetched from the latest beta release.
  * Aligns bundled content with the current beta version.
  * Other download, artifact extraction, and unpack steps remain unchanged.
  * No expected impact to user workflows beyond using updated beta assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->