### PR TITLE
:bug: update logger transports when log level changes

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -470,6 +470,16 @@ class VsCodeExtension {
             }
           }
 
+          if (event.affectsConfiguration(`${EXTENSION_NAME}.logLevel`)) {
+            this.state.logger.info("Log level configuration modified!");
+            const newLogLevel = getConfigLogLevel();
+            this.state.logger.level = newLogLevel;
+            for (const transport of this.state.logger.transports) {
+              transport.level = newLogLevel;
+            }
+            this.state.logger.info(`Log level changed to ${newLogLevel}`);
+          }
+
           if (event.affectsConfiguration("konveyor.analyzerPath")) {
             this.state.logger.info("Analyzer path configuration modified!");
 


### PR DESCRIPTION
Fixes #784 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Changing the extension's log level now updates logging immediately across the extension and its outputs, with clear informational messages showing the new level.
  * The previous restart prompt remains available when applicable, but most log-level changes take effect without requiring a reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->