### PR TITLE
:bug: Fix broken css overrides for svg icons

### DIFF
--- a/webview-ui/src/components/AnalysisPage/ConfigButton/configButton.css
+++ b/webview-ui/src/components/AnalysisPage/ConfigButton/configButton.css
@@ -18,13 +18,9 @@
   right: -8px;
   color: var(--pf-t--global--icon--color--status--warning--default);
   font-size: 14px;
-  background: var(--pf-global--BackgroundColor--100);
-  border-radius: 50%;
   padding: 2px;
-  box-shadow: 0 0 0 2px var(--pf-global--BackgroundColor--100);
-  transition: color 0.2s ease-in-out;
 }
 
 .config-button:hover .config-button__warning-icon {
-  color: var(pf-t--global--icon--color--status--warning--default);
+  color: var(--pf-t--global--icon--color--status--warning--default);
 }

--- a/webview-ui/src/components/ResolutionsPage/ModifiedFile/modifiedFileMessage.css
+++ b/webview-ui/src/components/ResolutionsPage/ModifiedFile/modifiedFileMessage.css
@@ -244,19 +244,6 @@
   background-color: var(--pf-global--BackgroundColor--dark-200);
 }
 
-/* Icon visibility improvements for dark theme - PatternFly v6 */
-.vscode-dark .pf-v6-c-button svg,
-.vscode-dark .pf-v6-c-button .pf-v6-c-button__icon svg {
-  color: var(--vscode-editor-foreground) !important;
-  fill: var(--vscode-editor-foreground) !important;
-}
-
-.vscode-dark .pf-v6-c-button:hover svg,
-.vscode-dark .pf-v6-c-button:hover .pf-v6-c-button__icon svg {
-  color: var(--vscode-editor-foreground) !important;
-  fill: var(--vscode-editor-foreground) !important;
-}
-
 /* Target PatternFly v6 icons specifically */
 .vscode-dark .pf-v6-c-button .pf-v6-c-button__icon {
   color: var(--vscode-editor-foreground) !important;


### PR DESCRIPTION
Fix #867 
<img width="526" height="81" alt="Screenshot 2025-09-25 at 11 14 17 AM" src="https://github.com/user-attachments/assets/f53e4174-06c8-4c29-a6cc-7f05512edd9b" />
<img width="521" height="86" alt="Screenshot 2025-09-25 at 11 14 10 AM" src="https://github.com/user-attachments/assets/244eed4d-900b-4ddf-aa32-5d6929a4eb31" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected hover color for the warning icon using the proper theme variable, fixing inconsistent icon coloring.

* **Style**
  * Simplified warning icon appearance by removing background, rounded corners, shadows, and an unnecessary color transition.
  * Aligned button icon colors with the default theme in dark mode by removing custom overrides, improving visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->