### PR TITLE
:test_tube: Revert addition of --force flag when installing extensions

### DIFF
--- a/tests/e2e/utilities/vscode-commands.utils.ts
+++ b/tests/e2e/utilities/vscode-commands.utils.ts
@@ -49,10 +49,7 @@ export async function installExtension(): Promise<void> {
       );
     }
 
-    // Build command with --force flag only when VSIX is explicitly provided
-    const hasExplicitVsix = process.env.VSIX_FILE_PATH || process.env.VSIX_DOWNLOAD_URL;
-    const forceFlag = hasExplicitVsix ? ' --force' : '';
-    const installCommand = `code --install-extension "${extensionPath}"${forceFlag}`;
+    const installCommand = `code --install-extension "${extensionPath}"`;
 
     execSync(installCommand, {
       stdio: 'inherit',


### PR DESCRIPTION
- Fix CI failure seen here https://github.com/konveyor/editor-extensions/actions/runs/18011783664/attempts/1?pr=863 

```Run npx playwright test e2e/tests/base/configure-and-run-analysis.test.ts
Running global setup...
Installing VSIX from /home/runner/work/editor-extensions/editor-extensions/./dist/konveyor-0.4.0-dev.20250925151338.4ee2e70.vsix
Installing extensions...
Extension 'konveyor-0.4.0-dev.20250925151338.4ee2e70.vsix' was successfully installed.
Extension installed/updated successfully.
cleanupRepo: Directory /home/runner/work/editor-extensions/editor-extensions/tests/coolstore does not exist. Skipping cleanup.
Cloning repository from https://github.com/konveyor-ecosystem/coolstore -b main
Cloning into 'coolstore'...
Code command: /usr/share/code/code --disable-workspace-trust --skip-welcome --user-data-dir=test-data-dir /home/runner/work/editor-extensions/editor-extensions/tests/coolstore
VSCode opened
Waiting for Konveyor extension initialization...
Konveyor extension initialized successfully
FATAL ERROR: v8::ToLocalChecked Empty MaybeLocal
----- Native stack trace -----


----- JavaScript stack trace -----

1: getPackageScopeConfig (node:internal/modules/package_json_reader:149:33)
2: getPackageJSONURL (node:internal/modules/package_json_reader:225:25)
3: packageResolve (node:internal/modules/esm/resolve:779:81)
4: moduleResolve (node:internal/modules/esm/resolve:865:18)
5: defaultResolve (node:internal/modules/esm/resolve:995:11)
6: nextResolve (node:internal/modules/esm/hooks:748:28)
7: resolve (data:text/javascript;base64,CglleHBvcnQgYXN5bmMgZnVuY3Rpb24gcmVzb2x2ZShzcGVjaWZpZXIsIGNvbnRleHQsIG5leHRSZXNvbHZlKSB7CgkJaWYgKHNwZWNpZmllciA9PT0gJ2ZzJykgewoJCQlyZXR1cm4gewoJCQkJZm9ybWF0OiAnYnVpbHRpbicsCgkJCQlzaG9ydENpcmN1aXQ6IHRydWUsCgkJCQl1cmw6ICdub2RlOm9yaWdpbmFsLWZzJwoJCQl9OwoJCX0KCgkJLy8gRGVmZXIgdG8gdGhlIG5leHQgaG9vayBpbiB0aGUgY2hhaW4sIHdoaWNoIHdvdWxkIGJlIHRoZQoJCS8vIE5vZGUuanMgZGVmYXVsdCByZXNvbHZlIGlmIHRoaXMgaXMgdGhlIGxhc3QgdXNlci1zcGVjaWZpZWQgbG9hZGVyLgoJCXJldHVybiBuZXh0UmVzb2x2ZShzcGVjaWZpZXIsIGNvbnRleHQpOwoJfQ==:13:10)
8: nextResolve (node:internal/modules/esm/hooks:748:28)
9: resolve (node:internal/modules/esm/hooks:240:30)
10: handleMessage (node:internal/modules/esm/worker:199:24)


Aborted (core dumped)
Error: Command failed: code --list-extensions
FATAL ERROR: v8::ToLocalChecked Empty MaybeLocal
----- Native stack trace -----

```
----- JavaScript stack trace -----

1: getPackageScopeConfig (node:internal/modules/package_json_reader:149:33)
2: getPackageJSONURL (node:internal/modules/package_json_reader:225:25)
3: packageResolve (node:internal/modules/esm/resolve:779:81)
4: moduleResolve (node:internal/modules/esm/resolve:865:18)
5: defaultResolve (node:internal/modules/esm/resolve:995:11)
6: nextResolve (node:internal/modules/esm/hooks:748:28)
7: resolve (data:text/javascript;base64,CglleHBvcnQgYXN5bmMgZnVuY3Rpb24gcmVzb2x2ZShzcGVjaWZpZXIsIGNvbnRleHQsIG5leHRSZXNvbHZlKSB7CgkJaWYgKHNwZWNpZmllciA9PT0gJ2ZzJykgewoJCQlyZXR1cm4gewoJCQkJZm9ybWF0OiAnYnVpbHRpbicsCgkJCQlzaG9ydENpcmN1aXQ6IHRydWUsCgkJCQl1cmw6ICdub2RlOm9yaWdpbmFsLWZzJwoJCQl9OwoJCX0KCgkJLy8gRGVmZXIgdG8gdGhlIG5leHQgaG9vayBpbiB0aGUgY2hhaW4sIHdoaWNoIHdvdWxkIGJlIHRoZQoJCS8vIE5vZGUuanMgZGVmYXVsdCByZXNvbHZlIGlmIHRoaXMgaXMgdGhlIGxhc3QgdXNlci1zcGVjaWZpZWQgbG9hZGVyLgoJCXJldHVybiBuZXh0UmVzb2x2ZShzcGVjaWZpZXIsIGNvbnRleHQpOwoJfQ==:13:10)
8: nextResolve (node:internal/modules/esm/hooks:748:28)
9: resolve (node:internal/modules/esm/hooks:240:30)
10: handleMessage (node:internal/modules/esm/worker:199:24)


Aborted (core dumped)

    at 7: resolve (data:text/javascript;base64,CglleHBvcnQgYXN5bmMgZnVuY3Rpb24gcmVzb2x2ZShzcGVjaWZpZXIsIGNvbnRleHQsIG5leHRSZXNvbHZlKSB7CgkJaWYgKHNwZWNpZmllciA9PT0gJ2ZzJykgewoJCQlyZXR1cm4gewoJCQkJZm9ybWF0OiAnYnVpbHRpbicsCgkJCQlzaG9ydENpcmN1aXQ6IHRydWUsCgkJCQl1cmw6ICdub2RlOm9yaWdpbmFsLWZzJwoJCQl9OwoJCX0KCgkJLy8gRGVmZXIgdG8gdGhlIG5leHQgaG9vayBpbiB0aGUgY2hhaW4sIHdoaWNoIHdvdWxkIGJlIHRoZQoJCS8vIE5vZGUuanMgZGVmYXVsdCByZXNvbHZlIGlmIHRoaXMgaXMgdGhlIGxhc3QgdXNlci1zcGVjaWZpZWQgbG9hZGVyLgoJCXJldHVybiBuZXh0UmVzb2x2ZShzcGVjaWZpZXIsIGNvbnRleHQpOwoJfQ==:13:10)
    at isExtensionInstalled (/home/runner/work/editor-extensions/editor-extensions/tests/e2e/utilities/vscode-commands.utils.ts:7:39)
    at globalSetup (/home/runner/work/editor-extensions/editor-extensions/tests/global.setup.ts:12:28)

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Simplified E2E setup by removing the forced reinstall flag from the VS Code extension installation command, ensuring more predictable installs across environments.
- **Chores**
  - No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->