### PR TITLE
:bug: make solution server client aware of refresh windows

### DIFF
--- a/agentic/src/clients/solutionServerClient.ts
+++ b/agentic/src/clients/solutionServerClient.ts
@@ -6,6 +6,12 @@ import {
   SolutionServerConfig,
 } from "@editor-extensions/shared";
 import { Logger } from "winston";
+import { Resource, Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export interface SolutionServerCapabilities {
+  tools: Tool[];
+  resources: Resource[];
+}
 
 export interface SolutionFile {
   uri: string;
@@ -293,17 +299,23 @@ export class SolutionServerClient {
     return this.currentClientId;
   }
 
-  public async getServerCapabilities(): Promise<any> {
+  public async getServerCapabilities(): Promise<SolutionServerCapabilities> {
     if (!this.enabled) {
       this.logger.info("Solution server is disabled, returning empty capabilities");
-      return;
+      return {
+        tools: [],
+        resources: [],
+      };
     }
     if (!this.mcpClient || !this.isConnected) {
       throw new SolutionServerClientError("Solution server is not connected");
     }
     if (this.isRefreshingTokens) {
       this.logger.info("Solution server is refreshing tokens, returning empty capabilities");
-      return;
+      return {
+        tools: [],
+        resources: [],
+      };
     }
 
     try {


### PR DESCRIPTION
Adds flags for when we are in the process of refreshing tokens to prevent polling errors.

Fixes #686
Fixes #798


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server capabilities now surface available tools and resources.

* **Bug Fixes**
  * Prevented overlapping token refreshes; capabilities return empty while a refresh is underway to avoid intermittent incorrect results.

* **Performance & Reliability**
  * Added controlled retry with exponential backoff and max attempts for token refreshes, standardized token-expiry handling and re-auth delays, improved refresh scheduling, and reset retry state on success for more robust sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->