### PR TITLE
:ghost: improve logs

### DIFF
--- a/agentic/src/nodes/analysisIssueFix.ts
+++ b/agentic/src/nodes/analysisIssueFix.ts
@@ -32,9 +32,9 @@ export class AnalysisIssueFix extends BaseNode {
     private readonly fsCache: InMemoryCacheWithRevisions<string, string>,
     private readonly workspaceDir: string,
     private readonly solutionServerClient: SolutionServerClient,
-    private readonly logger: Logger,
+    logger: Logger,
   ) {
-    super("AnalysisIssueFix", modelProvider, tools);
+    super("AnalysisIssueFix", modelProvider, tools, logger);
 
     this.fixAnalysisIssue = this.fixAnalysisIssue.bind(this);
     this.summarizeHistory = this.summarizeHistory.bind(this);

--- a/agentic/src/nodes/base.ts
+++ b/agentic/src/nodes/base.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { Logger } from "winston";
 import zodToJsonSchema from "zod-to-json-schema";
 import { type BaseLanguageModelInput } from "@langchain/core/language_models/base";
 import {
@@ -26,6 +27,7 @@ export abstract class BaseNode extends KaiWorkflowEventEmitter {
     private readonly name: string,
     protected readonly modelProvider: KaiModelProvider,
     private readonly tools: DynamicStructuredTool[],
+    protected readonly logger: Logger,
   ) {
     super();
 
@@ -116,7 +118,7 @@ export abstract class BaseNode extends KaiWorkflowEventEmitter {
         await runnable.stream(processedInput, options),
       );
     } catch (err) {
-      console.error("Error callling stream()", err);
+      this.logger.error("Error callling stream()", err);
       if (emitResponseChunks) {
         this.emitWorkflowMessage({
           id: messageId,

--- a/agentic/src/nodes/diagnosticsIssueFix.ts
+++ b/agentic/src/nodes/diagnosticsIssueFix.ts
@@ -42,9 +42,9 @@ export class DiagnosticsIssueFix extends BaseNode {
     fsTools: DynamicStructuredTool[],
     dependencyTools: DynamicStructuredTool[],
     private readonly workspaceDir: string,
-    private readonly logger: Logger,
+    logger: Logger,
   ) {
-    super("DiagnosticsIssueFix", modelProvider, [...fsTools, ...dependencyTools]);
+    super("DiagnosticsIssueFix", modelProvider, [...fsTools, ...dependencyTools], logger);
     this.diagnosticsPromises = new Map<string, PendingUserInteraction>();
 
     this.planFixes = this.planFixes.bind(this);

--- a/vscode/src/modelProvider/modelProvider.ts
+++ b/vscode/src/modelProvider/modelProvider.ts
@@ -175,7 +175,7 @@ export class BaseModelProvider implements KaiModelProvider {
           }
           controller.close();
         } catch (error) {
-          logger.error(`Error streaming: ${error}`);
+          logger.error("Error streaming", error);
           controller.error(error);
         }
       },


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
