### PR TITLE
:ghost: use changelog-path on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
           echo "Publishing ${{ steps.vsix_info.outputs.vsix_path }}"
           if [ -f "./artifacts/release.md" ]; then
             echo "Publishing with changelog"
-            npx vsce publish --packagePath "${{ steps.vsix_info.outputs.vsix_path }}" --releaseNotes "./artifacts/release.md"
+            npx vsce publish --packagePath "${{ steps.vsix_info.outputs.vsix_path }}" --changelog-path "./artifacts/release.md"
           else
             echo "Publishing without changelog (file not found)"
             npx vsce publish --packagePath "${{ steps.vsix_info.outputs.vsix_path }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release publishing to automatically include release notes from a local changelog file when available; publishes without a changelog if not present.
  * Ensures marketplace listings display consistent, file-based release notes for new versions.
  * No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->