### PR TITLE
:bug: handle custom rule changes

### DIFF
--- a/webview-ui/src/components/ProfileManager/CreatableMultiSelectField.tsx
+++ b/webview-ui/src/components/ProfileManager/CreatableMultiSelectField.tsx
@@ -21,6 +21,7 @@ interface CreatableMultiSelectFieldProps {
   initialOptions: string[];
   placeholder?: string;
   fieldId: string;
+  isDisabled?: boolean;
 }
 
 export const CreatableMultiSelectField: React.FC<CreatableMultiSelectFieldProps> = ({
@@ -29,6 +30,7 @@ export const CreatableMultiSelectField: React.FC<CreatableMultiSelectFieldProps>
   initialOptions,
   placeholder = "Select or create item",
   fieldId,
+  isDisabled = false,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [inputValue, setInputValue] = useState("");
@@ -136,6 +138,7 @@ export const CreatableMultiSelectField: React.FC<CreatableMultiSelectFieldProps>
       innerRef={toggleRef}
       isExpanded={isOpen}
       isFullWidth
+      isDisabled={isDisabled}
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain

--- a/webview-ui/src/components/ProfileManager/ProfileEditorForm.tsx
+++ b/webview-ui/src/components/ProfileManager/ProfileEditorForm.tsx
@@ -80,7 +80,7 @@ export const ProfileEditorForm: React.FC<{
 
   useEffect(() => {
     // Only reset localProfile if it's a different profile to prevent overwriting pending changes
-    if (profile.id !== localProfile.id) {
+    if (profile.id !== localProfile.id || profile.customRules !== localProfile.customRules) {
       setLocalProfile(profile);
     }
     setNameValidation("default");

--- a/webview-ui/src/components/ProfileManager/ProfileEditorForm.tsx
+++ b/webview-ui/src/components/ProfileManager/ProfileEditorForm.tsx
@@ -60,7 +60,8 @@ export const ProfileEditorForm: React.FC<{
   onDelete: (id: string) => void;
   onMakeActive: (id: string) => void;
   allProfiles: AnalysisProfile[];
-}> = ({ profile, isActive, onChange, onDelete, onMakeActive, allProfiles }) => {
+  isDisabled?: boolean;
+}> = ({ profile, isActive, onChange, onDelete, onMakeActive, allProfiles, isDisabled = false }) => {
   const [localProfile, setLocalProfile] = useState(profile);
   const [selectedSources, setSelectedSources] = useState<string[]>([]);
   const [selectedTargets, setSelectedTargets] = useState<string[]>([]);
@@ -182,8 +183,21 @@ export const ProfileEditorForm: React.FC<{
 
   return (
     <Form isWidthLimited>
+      {/* Operation in Progress Warning */}
+      {isDisabled && (
+        <Alert
+          variant="warning"
+          title="Profile editing is temporarily disabled"
+          isInline
+          style={{ marginBottom: "1rem" }}
+        >
+          Profile modifications are blocked while analysis or solution generation is in progress.
+          Please wait for the current operation to complete.
+        </Alert>
+      )}
+
       {/* Active Profile Header */}
-      {isActive && (
+      {isActive && !isDisabled && (
         <Alert
           variant="info"
           title={
@@ -247,7 +261,7 @@ export const ProfileEditorForm: React.FC<{
       <FormGroup label="Profile Name" fieldId="profile-name" isRequired>
         <TextInput
           id="profile-name"
-          isDisabled={profile.readOnly}
+          isDisabled={profile.readOnly || isDisabled}
           value={localProfile.name}
           onChange={(_e, value) => handleInputChange(value, "name")}
           onBlur={handleBlur}
@@ -273,6 +287,7 @@ export const ProfileEditorForm: React.FC<{
             updateLabelSelector(selectedSources, updated);
           }}
           initialOptions={targetOptions}
+          isDisabled={isDisabled}
         />
         {targetsErrorMsg ? (
           <FormHelperText>
@@ -302,6 +317,7 @@ export const ProfileEditorForm: React.FC<{
             updateLabelSelector(updated, selectedTargets);
           }}
           initialOptions={sourceOptions}
+          isDisabled={isDisabled}
         />
         <FormHelperText>
           <HelperText>
@@ -316,7 +332,7 @@ export const ProfileEditorForm: React.FC<{
         <Switch
           id="use-default-rules"
           isChecked={localProfile.useDefaultRules}
-          isDisabled={profile.readOnly}
+          isDisabled={profile.readOnly || isDisabled}
           onChange={(_e, checked) => {
             const updated = { ...localProfile, useDefaultRules: checked };
             setLocalProfile(updated);
@@ -348,7 +364,7 @@ export const ProfileEditorForm: React.FC<{
           <StackItem isFilled>
             <Button
               variant="secondary"
-              isDisabled={profile.readOnly}
+              isDisabled={profile.readOnly || isDisabled}
               onClick={() =>
                 dispatch({
                   type: CONFIGURE_CUSTOM_RULES,
@@ -378,13 +394,17 @@ export const ProfileEditorForm: React.FC<{
                     </Tooltip>
                   }
                   closeBtnAriaLabel="Remove rule"
-                  onClose={() => {
-                    const updated = localProfile.customRules.filter((_, i) => i !== index);
-                    const newProfile = { ...localProfile, customRules: updated };
-                    setLocalProfile(newProfile);
-                    validateRules(newProfile);
-                    debouncedChange(newProfile);
-                  }}
+                  onClose={
+                    isDisabled
+                      ? undefined
+                      : () => {
+                          const updated = localProfile.customRules.filter((_, i) => i !== index);
+                          const newProfile = { ...localProfile, customRules: updated };
+                          setLocalProfile(newProfile);
+                          validateRules(newProfile);
+                          debouncedChange(newProfile);
+                        }
+                  }
                 >
                   {truncateMiddle(path.split("/").pop() || path, 30)}
                 </Label>
@@ -404,7 +424,11 @@ export const ProfileEditorForm: React.FC<{
             </Tooltip>
           ) : (
             <Tooltip content="Set this profile as active to use it for new analyses">
-              <Button variant="secondary" onClick={() => onMakeActive(profile.id)}>
+              <Button
+                variant="secondary"
+                onClick={() => onMakeActive(profile.id)}
+                isDisabled={isDisabled}
+              >
                 Make Active
               </Button>
             </Tooltip>
@@ -414,7 +438,7 @@ export const ProfileEditorForm: React.FC<{
           <Button
             variant="danger"
             onClick={() => setIsDeleteDialogOpen(true)}
-            isDisabled={profile.readOnly}
+            isDisabled={profile.readOnly || isDisabled}
           >
             Delete Profile
           </Button>

--- a/webview-ui/src/components/ProfileManager/ProfileList.tsx
+++ b/webview-ui/src/components/ProfileManager/ProfileList.tsx
@@ -30,14 +30,25 @@ export const ProfileList: React.FC<{
   onMakeActive: (id: string) => void;
   onDelete: (id: string) => void;
   onDuplicate: (profile: AnalysisProfile) => void;
-}> = ({ profiles, selected, active, onSelect, onCreate, onDelete, onMakeActive, onDuplicate }) => {
+  isDisabled?: boolean;
+}> = ({
+  profiles,
+  selected,
+  active,
+  onSelect,
+  onCreate,
+  onDelete,
+  onMakeActive,
+  onDuplicate,
+  isDisabled = false,
+}) => {
   const [openDropdownProfileId, setOpenDropdownProfileId] = React.useState<string | null>(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
 
   return (
     <Flex direction={{ default: "column" }} spaceItems={{ default: "spaceItemsMd" }}>
       <FlexItem>
-        <Button variant="primary" onClick={onCreate} isBlock>
+        <Button variant="primary" onClick={onCreate} isBlock isDisabled={isDisabled}>
           + New Profile
         </Button>
       </FlexItem>
@@ -105,11 +116,13 @@ export const ProfileList: React.FC<{
                         <DropdownItem
                           key="make-active"
                           onClick={() => onMakeActive(profile.id)}
-                          isDisabled={active === profile.id}
+                          isDisabled={active === profile.id || isDisabled}
                           description={
                             active === profile.id
                               ? "This profile is already active. No action needed."
-                              : ""
+                              : isDisabled
+                                ? "Profile operations are blocked during analysis or solution generation."
+                                : ""
                           }
                         >
                           {active === profile.id ? "Active" : "Make Active"}
@@ -120,13 +133,14 @@ export const ProfileList: React.FC<{
                             onDuplicate(profile);
                             setIsOpen(false);
                           }}
+                          isDisabled={isDisabled}
                         >
                           Duplicate
                         </DropdownItem>
                         <DropdownItem
                           key="delete"
                           onClick={() => setIsDeleteDialogOpen(true)}
-                          isDisabled={profile.readOnly}
+                          isDisabled={profile.readOnly || isDisabled}
                         >
                           Delete
                         </DropdownItem>

--- a/webview-ui/src/components/ProfileManager/ProfileManagerPage.tsx
+++ b/webview-ui/src/components/ProfileManager/ProfileManagerPage.tsx
@@ -17,7 +17,7 @@ import { AnalysisProfile } from "../../../../shared/dist/types";
 
 export const ProfileManagerPage: React.FC = () => {
   const { state, dispatch } = useExtensionStateContext();
-  const { profiles, activeProfileId } = state;
+  const { profiles, activeProfileId, isAnalyzing } = state;
   const [selectedProfileId, setSelectedProfileId] = useState<string | null>(
     activeProfileId ?? profiles[0]?.id ?? null,
   );
@@ -106,6 +106,7 @@ export const ProfileManagerPage: React.FC = () => {
               onDelete={handleDeleteProfile}
               onMakeActive={handleMakeActive}
               onDuplicate={handleDuplicateProfile}
+              isDisabled={isAnalyzing}
             />
           </SplitItem>
           <SplitItem isFilled style={{ flex: "1 1 auto" }}>
@@ -117,6 +118,7 @@ export const ProfileManagerPage: React.FC = () => {
                 onChange={handleProfileChange}
                 onDelete={handleDeleteProfile}
                 onMakeActive={handleMakeActive}
+                isDisabled={isAnalyzing}
               />
             ) : (
               <Bullseye>


### PR DESCRIPTION
Fixes #794 
Fixes #838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When you update or switch the active profile, the analyzer will stop (if running) and prompt you to restart so custom rule changes take effect.
  * Profile management UI now supports a disabled state during analysis: editing, creation, duplication, deletion, and certain actions are disabled and show appropriate warnings.

* **Bug Fixes**
  * Profile editor now refreshes local data when a profile’s custom rules change, reducing stale or mismatched edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->