### PR TITLE
:test_tube: Add support for opening vscode in web environment

### DIFF
--- a/tests/.env.example
+++ b/tests/.env.example
@@ -24,3 +24,12 @@
 # Default REPO used for testing
 # TEST_REPO_URL=https://github.com/konveyor-ecosystem/coolstore
 # TEST_REPO_NAME=coolstore
+
+#########################
+### WEB CONFIGURATION ###
+#########################
+
+# WEB_ENV=1
+# WEB_BASE_URL="https://devspaces.apps.com"
+# WEB_LOGIN="user"
+# WEB_PASSWORD="password"

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -91,3 +91,4 @@ test-output
 test-data-dir/
 ehr_viewer/
 inventory_management/
+web-state.json

--- a/tests/docs/contrib/e2e-environment.md
+++ b/tests/docs/contrib/e2e-environment.md
@@ -73,11 +73,13 @@ Additionally, you can directly pass the env variables.
 | KAI_QE_S3_BUCKET_NAME  | (Optional) AWS S3 bucket name (only needed if running evaluation)                                                                                                                                                                                          |
 | PARASOL_API_KEY        | (Optional) API key for MaaS provider (Only used if working with https://maas.apps.prod.rhoai.rh-aiservices-bu.com/)                                                                                                                                        |
 | UPDATE_LLM_CACHE       | (Optional) When set to true, the offline tests will run in online mode and generate new cached data for the configured provider. Will require provider credentials to run.                                                                                 |
-| ANALYZER_BINARY_PATH   | (Optional) Absolute path used by [custom-binary-analysis.test.ts](../../e2e/tests/base/custom-binary-analysis.test.ts) to define a custom path for the analyzer binary |
-
-| TEST_REPO_URL   | (Optional) Default is <https://github.com/konveyor-ecosystem/coolstore> |
-| TEST_REPO_NAME  | (Optional) Default is `coolstore` |
-                                                                                   |
+| ANALYZER_BINARY_PATH   | (Optional) Absolute path used by [custom-binary-analysis.test.ts](../../e2e/tests/base/custom-binary-analysis.test.ts) to define a custom path for the analyzer binary                                                                                     |
+| TEST_REPO_URL          | (Optional) Default is <https://github.com/konveyor-ecosystem/coolstore>                                                                                                                                                                                    |
+| TEST_REPO_NAME         | (Optional) Default is `coolstore`                                                                                                                                                                                                                          |
+| WEB_ENV                | (Optional, boolean) If set to 1, the tests will run in VSCode in a web environment                                                                                                                                                                         |
+| WEB_BASE_URL           | (Required if WEB_ENV is 1) The URL of the VSCode web instance                                                                                                                                                                                              |
+| WEB_LOGIN              | (Required if WEB_ENV is 1) The login credentials for the web instance                                                                                                                                                                                      |
+| WEB_PASSWORD           | (Required if WEB_ENV is 1) The password for the web instance                                                                                                                                                                                               |
 
 ## Running Tests
 

--- a/tests/e2e/pages/vscode-desktop.page.ts
+++ b/tests/e2e/pages/vscode-desktop.page.ts
@@ -1,0 +1,268 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import { _electron as electron } from 'playwright';
+import { ElectronApplication, expect, Page } from '@playwright/test';
+import { createZip, extractZip } from '../utilities/archive';
+import { cleanupRepo, getOSInfo, writeOrUpdateSettingsJson } from '../utilities/utils';
+import { KAIViews } from '../enums/views.enum';
+import { TEST_DATA_DIR } from '../utilities/consts';
+import { installExtension } from '../utilities/vscode-commands.utils';
+import { stubDialog } from 'electron-playwright-helpers';
+import { extensionId } from '../utilities/utils';
+import { VSCode } from './vscode.page';
+
+export class VSCodeDesktop extends VSCode {
+  protected readonly app: ElectronApplication;
+  protected window: Page;
+
+  constructor(app: ElectronApplication, window: Page, repoDir?: string) {
+    super();
+    this.app = app;
+    this.window = window;
+    this.repoDir = repoDir;
+  }
+
+  public static async open(
+    repoUrl?: string,
+    repoDir?: string,
+    branch = 'main',
+    waitForInitialization = true
+  ) {
+    /**
+     * user-data-dir is passed to force opening a new instance avoiding the process to couple with an existing vscode instance
+     * so Playwright doesn't detect that the process has finished
+     */
+    const args = [
+      '--disable-workspace-trust',
+      '--skip-welcome',
+      `--user-data-dir=${TEST_DATA_DIR}`,
+    ];
+
+    try {
+      if (repoUrl) {
+        if (repoDir) {
+          await cleanupRepo(repoDir);
+        }
+        console.log(`Cloning repository from ${repoUrl} -b ${branch}`);
+        execSync(`git clone ${repoUrl} -b ${branch}`, { stdio: 'pipe' });
+      }
+    } catch (error: any) {
+      console.error(error);
+      throw new Error('Failed to clone the repository');
+    }
+
+    if (repoDir) {
+      args.push(path.resolve(repoDir));
+    }
+
+    // set the log level prior to starting vscode
+    writeOrUpdateSettingsJson(path.join(repoDir ?? '', '.vscode', 'settings.json'), {
+      'konveyor.logLevel': 'silly',
+    });
+
+    let executablePath = process.env.VSCODE_EXECUTABLE_PATH;
+    if (!executablePath) {
+      if (getOSInfo() === 'linux') {
+        executablePath = '/usr/share/code/code';
+      } else {
+        throw new Error('VSCODE_EXECUTABLE_PATH env variable not provided');
+      }
+    }
+
+    if (!process.env.VSIX_FILE_PATH && !process.env.VSIX_DOWNLOAD_URL) {
+      args.push(
+        `--extensionDevelopmentPath=${path.resolve(__dirname, '../../../vscode')}`,
+        `--enable-proposed-api=${extensionId}`
+      );
+      console.log('Running in DEV mode...');
+    }
+
+    console.log(`Code command: ${executablePath} ${args.join(' ')}`);
+
+    const vscodeApp = await electron.launch({
+      executablePath: executablePath,
+      args,
+      env: {
+        ...process.env,
+        __TEST_EXTENSION_END_TO_END__: 'true',
+      },
+    });
+    await vscodeApp.firstWindow();
+
+    const window = await vscodeApp.firstWindow({ timeout: 60000 });
+    console.log('VSCode opened');
+    const vscode = new VSCodeDesktop(vscodeApp, window, repoDir);
+
+    if (waitForInitialization) {
+      // Wait for extension initialization in downstream environment
+      await vscode.waitForExtensionInitialization();
+    }
+
+    return vscode;
+  }
+
+  /**
+   * launches VSCode with KAI plugin installed and repoUrl app opened.
+   * @param repoUrl
+   * @param repoDir path to repo
+   * @param branch optional branch to clone from
+   */
+  public static async init(repoUrl?: string, repoDir?: string, branch?: string): Promise<VSCode> {
+    try {
+      if (process.env.VSIX_FILE_PATH || process.env.VSIX_DOWNLOAD_URL) {
+        await installExtension();
+      }
+
+      return repoUrl ? VSCodeDesktop.open(repoUrl, repoDir, branch, false) : VSCodeDesktop.open();
+    } catch (error) {
+      console.error('Error launching VSCode:', error);
+      throw error;
+    }
+  }
+
+  public async closeVSCode(): Promise<void> {
+    try {
+      if (this.app) {
+        await this.app.close();
+        console.log('VSCode closed successfully.');
+      }
+    } catch (error) {
+      console.error('Error closing VSCode:', error);
+    }
+  }
+
+  /**
+   * Waits for the Konveyor extension to complete initialization by watching for
+   * the __EXTENSION_INITIALIZED__ info message signal.
+   */
+  public async waitForExtensionInitialization(): Promise<void> {
+    try {
+      console.log('Waiting for Konveyor extension initialization...');
+
+      const javaReadySelector = this.getWindow().getByRole('button', { name: 'Java: Ready' });
+
+      await javaReadySelector.waitFor({ timeout: 120000 });
+      // Sometimes the java ready status is displayed for a few seconds before starting to load again
+      // This checks that the state is kept for a few seconds before continuing
+      await this.waitDefault();
+      await javaReadySelector.waitFor({ timeout: 1200000 });
+
+      // Trigger extension activation by opening the analysis view
+      // This was working before - the extension activates and opens the view
+      await this.executeQuickCommand(`${VSCode.COMMAND_CATEGORY}: Open Analysis View`);
+
+      // Now wait for the initialization signal message to appear
+      // This message is shown by the extension when __TEST_EXTENSION_END_TO_END__ env var is set
+      const initializationMessage = this.window
+        .getByRole('alert')
+        .getByText('__EXTENSION_INITIALIZED__');
+      await expect(initializationMessage).toBeVisible({ timeout: 300000 }); // 5 minute timeout for asset downloads
+
+      // Dismiss the message
+      await this.window.keyboard.press('Escape');
+      await this.window.waitForTimeout(2000); // Give VSCode a chance to process the message
+      console.log('Konveyor extension initialized successfully');
+    } catch (error) {
+      console.error('Failed to wait for extension initialization:', error);
+      throw error;
+    }
+  }
+
+  protected async selectCustomRules(customRulesPath: string) {
+    const manageProfileView = await this.getView(KAIViews.manageProfiles);
+    console.log(`Selecting custom rules from: ${customRulesPath}`);
+
+    const customRulesButton = manageProfileView.getByRole('button', {
+      name: 'Select Custom Rules…',
+    });
+
+    if (await customRulesButton.isVisible()) {
+      await stubDialog(this.app, 'showOpenDialog', {
+        filePaths: [customRulesPath],
+        canceled: false,
+      });
+
+      await customRulesButton.click();
+
+      const folderName = path.basename(customRulesPath);
+      console.log(
+        `Waiting for custom rules label with folder name: "${folderName}" from path: "${customRulesPath}"`
+      );
+
+      const customRulesLabel = manageProfileView
+        .locator('[class*="label"], [class*="Label"]')
+        .filter({ hasText: folderName });
+      await expect(customRulesLabel.first()).toBeVisible({ timeout: 30000 });
+      console.log(`Custom rules label for "${folderName}" is now visible`);
+    }
+  }
+
+  /**
+   * Unzips all test data into workspace .vscode/ directory, deletes the zip files if cleanup is true
+   * @param cleanup
+   */
+  public async ensureLLMCache(cleanup: boolean = false): Promise<void> {
+    try {
+      const wspacePath = this.llmCachePaths().workspacePath;
+      const storedPath = this.llmCachePaths().storedPath;
+      if (cleanup) {
+        if (fs.existsSync(wspacePath)) {
+          fs.rmSync(wspacePath, { recursive: true, force: true });
+        }
+        return;
+      }
+      if (!fs.existsSync(wspacePath)) {
+        fs.mkdirSync(wspacePath, { recursive: true });
+      }
+      if (!fs.existsSync(storedPath)) {
+        return;
+      }
+      // move stored zip to workspace
+      extractZip(storedPath, wspacePath);
+    } catch (error) {
+      console.error('Error unzipping test data:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Copies all newly generated LLM cache data into a zip file in the repo, merges with the existing data
+   * This will be used when we want to generate a new cache data
+   */
+  public async updateLLMCache() {
+    const newCacheZip = path.join(path.dirname(this.llmCachePaths().storedPath), 'new.zip');
+    createZip(this.llmCachePaths().workspacePath, newCacheZip);
+    fs.renameSync(newCacheZip, this.llmCachePaths().storedPath);
+    fs.renameSync(`${newCacheZip}.metadata`, `${this.llmCachePaths().storedPath}.metadata`);
+  }
+
+  private llmCachePaths(): {
+    storedPath: string; // this is where the data is checked-in in the repo
+    workspacePath: string; // this is where a workspace is expecting to find cached data
+  } {
+    return {
+      storedPath: path.join(__dirname, '..', '..', 'data', 'llm_cache.zip'),
+      workspacePath: path.join(this.repoDir ?? '', '.vscode', 'cache'),
+    };
+  }
+
+  public async writeOrUpdateVSCodeSettings(settings: Record<string, any>): Promise<void> {
+    writeOrUpdateSettingsJson(path.join(this.repoDir ?? '', '.vscode', 'settings.json'), settings);
+  }
+
+  public async pasteContent(content: string) {
+    await this.app.evaluate(({ clipboard }, content) => {
+      clipboard.writeText(content);
+    }, content);
+    const modifier = getOSInfo() === 'macOS' ? 'Meta' : 'Control';
+    await this.window.keyboard.press(`${modifier}+v`, { delay: 500 });
+  }
+
+  public getWindow(): Page {
+    if (!this.window) {
+      throw new Error('VSCode window is not initialized.');
+    }
+    return this.window;
+  }
+}

--- a/tests/e2e/pages/vscode-web.page.ts
+++ b/tests/e2e/pages/vscode-web.page.ts
@@ -1,0 +1,168 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { BrowserContextOptions } from 'playwright';
+import { expect, Page } from '@playwright/test';
+import { createZip, extractZip } from '../utilities/archive';
+import { VSCode } from './vscode.page';
+import { chromium } from 'playwright';
+import { existsSync } from 'node:fs';
+
+export class VSCodeWeb extends VSCode {
+  protected window: Page;
+
+  constructor(window: Page, repoDir?: string) {
+    super();
+    this.window = window;
+    this.repoDir = repoDir;
+  }
+
+  public static async open(repoUrl?: string, repoDir?: string, branch = 'main') {
+    const browser = await chromium.launch();
+    const context = await browser.newContext({
+      ignoreHTTPSErrors: true,
+      storageState: './web-state.json',
+    });
+    const page = await context.newPage();
+    await page.goto(`${process.env.WEB_BASE_URL}/dashboard/`);
+    await page.waitForSelector('tbody tr');
+    const repoRow = page.locator('tbody tr', { hasText: repoDir });
+    const [newPage] = await Promise.all([
+      context.waitForEvent('page'),
+      repoRow.getByRole('button', { name: 'Open' }).first().click(),
+    ]);
+    await newPage.waitForLoadState();
+    await page.close();
+    await newPage
+      .getByRole('button', { name: 'Yes, I trust the authors' })
+      .click({ timeout: 120000 });
+    // TODO (abrugaro): Remove this and replace for an assertion
+    await newPage.waitForTimeout(120000);
+    await newPage
+      .getByLabel('Restricted Mode is intended')
+      .getByRole('button', { name: 'Manage' })
+      .first()
+      .click({ timeout: 60000 });
+    await newPage.getByRole('button', { name: 'Trust', exact: true }).first().click();
+    const javaReadySelector = newPage.getByRole('button', { name: 'Java: Ready' });
+    await javaReadySelector.waitFor({ timeout: 120000 });
+    return new VSCodeWeb(newPage, repoDir);
+  }
+
+  /**
+   * launches VSCode with KAI plugin installed and repoUrl app opened.
+   * @param repoUrl
+   * @param repoDir path to repo
+   * @param branch optional branch to clone from
+   */
+  public static async init(repoUrl?: string, repoDir?: string, branch?: string): Promise<VSCode> {
+    if (!process.env.WEB_BASE_URL || !process.env.WEB_LOGIN || !process.env.WEB_PASSWORD) {
+      throw new Error(
+        'The following environment variables are required for running tests in web mode: WEB_BASE_URL, WEB_LOGIN, WEB PASSWORD'
+      );
+    }
+    const browser = await chromium.launch();
+    const contextOptions: BrowserContextOptions = { ignoreHTTPSErrors: true };
+    if (existsSync('./web-state.json')) {
+      contextOptions.storageState = './web-state.json';
+    }
+    const context = await browser.newContext(contextOptions);
+    const page = await context.newPage();
+    await page.goto(`${process.env.WEB_BASE_URL}/dashboard/`);
+    const loginButton = page.getByRole('button', { name: 'Log in' }).first();
+    if (!(await loginButton.isVisible())) {
+      await page.close();
+      return VSCodeWeb.open(repoUrl, repoDir, branch);
+    }
+    await expect(loginButton).toBeVisible();
+    await loginButton.click();
+    const kubeadminBtn = page.getByRole('link', { name: 'kube:admin' }).first();
+    await expect(kubeadminBtn).toBeVisible();
+    await kubeadminBtn.click();
+    await page.locator('#inputUsername').fill(process.env.WEB_LOGIN);
+    await page.locator('#inputPassword').fill(process.env.WEB_PASSWORD);
+    await page.getByRole('button', { name: 'Log in' }).click();
+
+    const allowSelectButton = page.getByRole('button', { name: 'Allow' });
+    if (await allowSelectButton.isVisible()) {
+      await allowSelectButton.click();
+    }
+    await context.storageState({ path: './web-state.json' });
+    await page.waitForTimeout(5000);
+    await page.close();
+    return VSCodeWeb.open(repoUrl, repoDir, branch);
+  }
+
+  public async closeVSCode(): Promise<void> {
+    // TODO implement
+    return new Promise<void>((resolve) => {});
+  }
+
+  protected async selectCustomRules(customRulesPath: string) {
+    // TODO implementc
+    return new Promise<void>((resolve) => {});
+  }
+
+  /**
+   * Unzips all test data into workspace .vscode/ directory, deletes the zip files if cleanup is true
+   * @param cleanup
+   */
+  public async ensureLLMCache(cleanup: boolean = false): Promise<void> {
+    try {
+      const wspacePath = this.llmCachePaths().workspacePath;
+      const storedPath = this.llmCachePaths().storedPath;
+      if (cleanup) {
+        if (fs.existsSync(wspacePath)) {
+          fs.rmSync(wspacePath, { recursive: true, force: true });
+        }
+        return;
+      }
+      if (!fs.existsSync(wspacePath)) {
+        fs.mkdirSync(wspacePath, { recursive: true });
+      }
+      if (!fs.existsSync(storedPath)) {
+        return;
+      }
+      // move stored zip to workspace
+      extractZip(storedPath, wspacePath);
+    } catch (error) {
+      console.error('Error unzipping test data:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Copies all newly generated LLM cache data into a zip file in the repo, merges with the existing data
+   * This will be used when we want to generate a new cache data
+   */
+  public async updateLLMCache() {
+    const newCacheZip = path.join(path.dirname(this.llmCachePaths().storedPath), 'new.zip');
+    createZip(this.llmCachePaths().workspacePath, newCacheZip);
+    fs.renameSync(newCacheZip, this.llmCachePaths().storedPath);
+    fs.renameSync(`${newCacheZip}.metadata`, `${this.llmCachePaths().storedPath}.metadata`);
+  }
+
+  private llmCachePaths(): {
+    storedPath: string; // this is where the data is checked-in in the repo
+    workspacePath: string; // this is where a workspace is expecting to find cached data
+  } {
+    return {
+      storedPath: path.join(__dirname, '..', '..', 'data', 'llm_cache.zip'),
+      workspacePath: path.join(this.repoDir ?? '', '.vscode', 'cache'),
+    };
+  }
+
+  public async writeOrUpdateVSCodeSettings(settings: Record<string, any>): Promise<void> {
+    // TODO implement
+  }
+
+  public async pasteContent(content: string) {
+    // TODO (abrugaro) implement
+  }
+
+  public getWindow(): Page {
+    if (!this.window) {
+      throw new Error('VSCode window is not initialized.');
+    }
+    return this.window;
+  }
+}

--- a/tests/e2e/pages/vscode.page.ts
+++ b/tests/e2e/pages/vscode.page.ts
@@ -1,187 +1,32 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import { execSync } from 'child_process';
-import { _electron as electron, FrameLocator } from 'playwright';
-import { ElectronApplication, expect, Page } from '@playwright/test';
-import { MIN, SEC } from '../utilities/consts';
-import { createZip, extractZip } from '../utilities/archive';
-import {
-  cleanupRepo,
-  generateRandomString,
-  getOSInfo,
-  writeOrUpdateSettingsJson,
-} from '../utilities/utils';
+import { FrameLocator } from 'playwright';
+import { expect, Page } from '@playwright/test';
+import { generateRandomString, getOSInfo } from '../utilities/utils';
 import { DEFAULT_PROVIDER } from '../fixtures/provider-configs.fixture';
 import { KAIViews } from '../enums/views.enum';
-import { TEST_DATA_DIR } from '../utilities/consts';
-import { BasePage } from './base.page';
-import { installExtension } from '../utilities/vscode-commands.utils';
 import { FixTypes } from '../enums/fix-types.enum';
-import { stubDialog } from 'electron-playwright-helpers';
-import { extensionId } from '../utilities/utils';
-
-const COMMAND_CATEGORY = process.env.TEST_CATEGORY || 'Konveyor';
 
 type SortOrder = 'ascending' | 'descending';
 type ListKind = 'issues' | 'files';
 
-export class VSCode extends BasePage {
-  constructor(
-    app: ElectronApplication,
-    window: Page,
-    private readonly repoDir?: string
-  ) {
-    super(app, window);
-  }
-
-  public static async open(
-    repoUrl?: string,
-    repoDir?: string,
-    branch = 'main',
-    waitForInitialization = true
-  ) {
-    /**
-     * user-data-dir is passed to force opening a new instance avoiding the process to couple with an existing vscode instance
-     * so Playwright doesn't detect that the process has finished
-     */
-    const args = [
-      '--disable-workspace-trust',
-      '--skip-welcome',
-      `--user-data-dir=${TEST_DATA_DIR}`,
-    ];
-
-    try {
-      if (repoUrl) {
-        if (repoDir) {
-          await cleanupRepo(repoDir);
-        }
-        console.log(`Cloning repository from ${repoUrl} -b ${branch}`);
-        execSync(`git clone ${repoUrl} -b ${branch}`, { stdio: 'pipe' });
-      }
-    } catch (error: any) {
-      console.error(error);
-      throw new Error('Failed to clone the repository');
-    }
-
-    if (repoDir) {
-      args.push(path.resolve(repoDir));
-    }
-
-    // set the log level prior to starting vscode
-    writeOrUpdateSettingsJson(path.join(repoDir ?? '', '.vscode', 'settings.json'), {
-      'konveyor.logLevel': 'silly',
-    });
-
-    let executablePath = process.env.VSCODE_EXECUTABLE_PATH;
-    if (!executablePath) {
-      if (getOSInfo() === 'linux') {
-        executablePath = '/usr/share/code/code';
-      } else {
-        throw new Error('VSCODE_EXECUTABLE_PATH env variable not provided');
-      }
-    }
-
-    if (!process.env.VSIX_FILE_PATH && !process.env.VSIX_DOWNLOAD_URL) {
-      args.push(
-        `--extensionDevelopmentPath=${path.resolve(__dirname, '../../../vscode')}`,
-        `--enable-proposed-api=${extensionId}`
-      );
-      console.log('Running in DEV mode...');
-    }
-
-    console.log(`Code command: ${executablePath} ${args.join(' ')}`);
-
-    const vscodeApp = await electron.launch({
-      executablePath: executablePath,
-      args,
-      env: {
-        ...process.env,
-        __TEST_EXTENSION_END_TO_END__: 'true',
-      },
-    });
-    await vscodeApp.firstWindow();
-
-    const window = await vscodeApp.firstWindow({ timeout: 60000 });
-    console.log('VSCode opened');
-    const vscode = new VSCode(vscodeApp, window, repoDir);
-
-    if (waitForInitialization) {
-      // Wait for extension initialization in downstream environment
-      await vscode.waitForExtensionInitialization();
-    }
-
-    return vscode;
-  }
+export abstract class VSCode {
+  protected repoDir?: string;
+  protected abstract window: Page;
+  public static readonly COMMAND_CATEGORY = process.env.TEST_CATEGORY || 'Konveyor';
 
   /**
-   * launches VSCode with KAI plugin installed and repoUrl app opened.
-   * @param repoUrl
-   * @param repoDir path to repo
-   * @param branch optional branch to clone from
+   * Unzips all test data into workspace .vscode/ directory, deletes the zip files if cleanup is true
    */
-  public static async init(repoUrl?: string, repoDir?: string, branch?: string): Promise<VSCode> {
-    try {
-      if (process.env.VSIX_FILE_PATH || process.env.VSIX_DOWNLOAD_URL) {
-        await installExtension();
-      }
-
-      return repoUrl ? VSCode.open(repoUrl, repoDir, branch, false) : VSCode.open();
-    } catch (error) {
-      console.error('Error launching VSCode:', error);
-      throw error;
-    }
-  }
-
+  public abstract ensureLLMCache(cleanup: boolean): Promise<void>;
+  public abstract updateLLMCache(): Promise<void>;
   /**
-   * Closes the VSCode instance.
+   * Writes or updates the VSCode settings.json file to current workspace @ .vscode/settings.json
+   * @param settings - Key - value: A pair of settings to write or update, if a setting already exists, the new values will be merged
    */
-  public async closeVSCode(): Promise<void> {
-    try {
-      if (this.app) {
-        await this.app.close();
-        console.log('VSCode closed successfully.');
-      }
-    } catch (error) {
-      console.error('Error closing VSCode:', error);
-    }
-  }
-
-  /**
-   * Waits for the Konveyor extension to complete initialization by watching for
-   * the __EXTENSION_INITIALIZED__ info message signal.
-   */
-  public async waitForExtensionInitialization(): Promise<void> {
-    try {
-      console.log('Waiting for Konveyor extension initialization...');
-
-      const javaReadySelector = this.getWindow().getByRole('button', { name: 'Java: Ready' });
-
-      await javaReadySelector.waitFor({ timeout: 120000 });
-      // Sometimes the java ready status is displayed for a few seconds before starting to load again
-      // This checks that the state is kept for a few seconds before continuing
-      await this.waitDefault();
-      await javaReadySelector.waitFor({ timeout: 1200000 });
-
-      // Trigger extension activation by opening the analysis view
-      // This was working before - the extension activates and opens the view
-      await this.executeQuickCommand(`${COMMAND_CATEGORY}: Open Analysis View`);
-
-      // Now wait for the initialization signal message to appear
-      // This message is shown by the extension when __TEST_EXTENSION_END_TO_END__ env var is set
-      const initializationMessage = this.window
-        .getByRole('alert')
-        .getByText('__EXTENSION_INITIALIZED__');
-      await expect(initializationMessage).toBeVisible({ timeout: 300000 }); // 5 minute timeout for asset downloads
-
-      // Dismiss the message
-      await this.window.keyboard.press('Escape');
-      await this.window.waitForTimeout(2000); // Give VSCode a chance to process the message
-      console.log('Konveyor extension initialized successfully');
-    } catch (error) {
-      console.error('Failed to wait for extension initialization:', error);
-      throw error;
-    }
-  }
+  public abstract writeOrUpdateVSCodeSettings(settings: Record<string, any>): Promise<void>;
+  protected abstract selectCustomRules(customRulesPath: string): Promise<void>;
+  public abstract closeVSCode(): Promise<void>;
+  public abstract pasteContent(content: string): void;
+  public abstract getWindow(): Page;
 
   public async executeQuickCommand(command: string) {
     await this.waitDefault();
@@ -220,7 +65,7 @@ export class VSCode extends BasePage {
   public async openAnalysisView(): Promise<void> {
     // Try using command palette first - this works reliably when extension is hidden due to too many extensions
     try {
-      await this.executeQuickCommand(`${COMMAND_CATEGORY}: Open Analysis View`);
+      await this.executeQuickCommand(`${VSCode.COMMAND_CATEGORY}: Open Analysis View`);
       return;
     } catch (error) {
       console.log('Command palette approach failed:', error);
@@ -228,8 +73,8 @@ export class VSCode extends BasePage {
 
     // Fallback to activity bar approach
     try {
-      await this.openLeftBarElement(COMMAND_CATEGORY);
-      await this.window.getByText(`${COMMAND_CATEGORY} Issues`).dblclick();
+      await this.openLeftBarElement(VSCode.COMMAND_CATEGORY);
+      await this.window.getByText(`${VSCode.COMMAND_CATEGORY} Issues`).dblclick();
       await this.window.locator(`a[aria-label*="Analysis View"]`).click();
     } catch (error) {
       console.log('Activity bar approach failed:', error);
@@ -317,31 +162,25 @@ export class VSCode extends BasePage {
    */
   public async setListKindAndSort(kind: ListKind, order: SortOrder): Promise<void> {
     const analysisView = await this.getView(KAIViews.analysisView);
+    const kindButton = analysisView.getByRole('button', {
+      name: kind === 'issues' ? 'Issues' : 'Files',
+    });
+    const toggleFilterButton = analysisView.locator('button[aria-label="Show Filters"]');
 
-    // Handle the Group by dropdown
-    const groupByButton = analysisView.getByRole('button', { name: /Group by/i });
-    await expect(groupByButton).toBeVisible({ timeout: 5_000 });
-    await groupByButton.click();
-    await expect(groupByButton).toHaveAttribute('aria-expanded', 'true');
+    if (!(await kindButton.isVisible()) && (await toggleFilterButton.isVisible())) {
+      await toggleFilterButton.click();
+    }
 
-    // Select the appropriate option from the dropdown
-    const optionName = kind === 'issues' ? 'Issues' : 'Files';
-    const option = analysisView.getByRole('option', { name: optionName });
-    await expect(option).toBeVisible({ timeout: 3_000 });
-    await option.click();
-
-    // Wait for dropdown to close
-    await expect(groupByButton).toHaveAttribute('aria-expanded', 'false');
-
-    // Handle the sort toggle buttons
+    await expect(kindButton).toBeVisible({ timeout: 5_000 });
+    await expect(kindButton).toBeEnabled({ timeout: 3_000 });
+    await kindButton.click();
+    await expect(kindButton).toHaveAttribute('aria-pressed', 'true');
     const sortButton = analysisView.getByRole('button', {
       name: order === 'ascending' ? 'Sort ascending' : 'Sort descending',
     });
     await expect(sortButton).toBeVisible({ timeout: 3_000 });
     await sortButton.click();
-    // Note: ToggleGroupItem uses isSelected prop, not aria-pressed
-    // We can verify the button was clicked by checking if it's visible and enabled
-    await expect(sortButton).toBeEnabled();
+    await expect(sortButton).toHaveAttribute('aria-pressed', 'true');
   }
 
   /**
@@ -425,7 +264,7 @@ export class VSCode extends BasePage {
 
   public async configureGenerativeAI(config: string = DEFAULT_PROVIDER.config) {
     await this.executeQuickCommand(
-      `${COMMAND_CATEGORY}: Open the GenAI model provider configuration file`
+      `${VSCode.COMMAND_CATEGORY}: Open the GenAI model provider configuration file`
     );
 
     const modifier = getOSInfo() === 'macOS' ? 'Meta' : 'Control';
@@ -435,7 +274,7 @@ export class VSCode extends BasePage {
   }
 
   public async findDebugArchiveCommand(): Promise<string> {
-    return `${COMMAND_CATEGORY}: Generate Debug Archive`;
+    return `${VSCode.COMMAND_CATEGORY}: Generate Debug Archive`;
   }
 
   public async createProfile(
@@ -444,7 +283,7 @@ export class VSCode extends BasePage {
     profileName?: string,
     customRulesPath?: string
   ) {
-    await this.executeQuickCommand(`${COMMAND_CATEGORY}: Manage Analysis Profile`);
+    await this.executeQuickCommand(`${VSCode.COMMAND_CATEGORY}: Manage Analysis Profile`);
 
     const manageProfileView = await this.getView(KAIViews.manageProfiles);
 
@@ -478,33 +317,8 @@ export class VSCode extends BasePage {
     }
     await this.window.keyboard.press('Escape');
 
-    // Select Custom Rules if provided
     if (customRulesPath) {
-      console.log(`Creating profile with custom rules from: ${customRulesPath}`);
-
-      const customRulesButton = manageProfileView.getByRole('button', {
-        name: 'Select Custom Rules…',
-      });
-
-      if (await customRulesButton.isVisible()) {
-        await stubDialog(this.app, 'showOpenDialog', {
-          filePaths: [customRulesPath],
-          canceled: false,
-        });
-
-        await customRulesButton.click();
-
-        const folderName = path.basename(customRulesPath);
-        console.log(
-          `Waiting for custom rules label with folder name: "${folderName}" from path: "${customRulesPath}"`
-        );
-
-        const customRulesLabel = manageProfileView
-          .locator('[class*="label"], [class*="Label"]')
-          .filter({ hasText: folderName });
-        await expect(customRulesLabel.first()).toBeVisible({ timeout: 30000 });
-        console.log(`Custom rules label for "${folderName}" is now visible`);
-      }
+      await this.selectCustomRules(customRulesPath);
     }
     return nameToUse;
   }
@@ -512,7 +326,7 @@ export class VSCode extends BasePage {
   public async deleteProfile(profileName: string) {
     try {
       console.log(`Attempting to delete profile: ${profileName}`);
-      await this.executeQuickCommand(`${COMMAND_CATEGORY}: Manage Analysis Profile`);
+      await this.executeQuickCommand(`${VSCode.COMMAND_CATEGORY}: Manage Analysis Profile`);
       const manageProfileView = await this.getView(KAIViews.manageProfiles);
 
       const profileList = manageProfileView.getByRole('list', {
@@ -579,60 +393,9 @@ export class VSCode extends BasePage {
     await analysisView.locator('button#get-solution-button').nth(fixType).click();
   }
 
-  /**
-   * Unzips all test data into workspace .vscode/ directory, deletes the zip files if cleanup is true
-   */
-  public async ensureLLMCache(cleanup: boolean = false): Promise<void> {
-    try {
-      const wspacePath = this.llmCachePaths().workspacePath;
-      const storedPath = this.llmCachePaths().storedPath;
-      if (cleanup) {
-        if (fs.existsSync(wspacePath)) {
-          fs.rmSync(wspacePath, { recursive: true, force: true });
-        }
-        return;
-      }
-      if (!fs.existsSync(wspacePath)) {
-        fs.mkdirSync(wspacePath, { recursive: true });
-      }
-      if (!fs.existsSync(storedPath)) {
-        return;
-      }
-      // move stored zip to workspace
-      extractZip(storedPath, wspacePath);
-    } catch (error) {
-      console.error('Error unzipping test data:', error);
-      throw error;
-    }
-  }
-
-  /**
-   * Copies all newly generated LLM cache data into a zip file in the repo, merges with the existing data
-   * This will be used when we want to generate a new cache data
-   */
-  public async updateLLMCache() {
-    const newCacheZip = path.join(path.dirname(this.llmCachePaths().storedPath), 'new.zip');
-    createZip(this.llmCachePaths().workspacePath, newCacheZip);
-    fs.renameSync(newCacheZip, this.llmCachePaths().storedPath);
-    fs.renameSync(`${newCacheZip}.metadata`, `${this.llmCachePaths().storedPath}.metadata`);
-  }
-
-  private llmCachePaths(): {
-    storedPath: string; // this is where the data is checked-in in the repo
-    workspacePath: string; // this is where a workspace is expecting to find cached data
-  } {
-    return {
-      storedPath: path.join(__dirname, '..', '..', 'data', 'llm_cache.zip'),
-      workspacePath: path.join(this.repoDir ?? '', '.vscode', 'cache'),
-    };
-  }
-
-  /**
-   * Writes or updates the VSCode settings.json file to current workspace @ .vscode/settings.json
-   * @param settings - Key - value pair of settings to write or update, if a setting already exists, the new values will be merged
-   */
-  public async writeOrUpdateVSCodeSettings(settings: Record<string, any>): Promise<void> {
-    writeOrUpdateSettingsJson(path.join(this.repoDir ?? '', '.vscode', 'settings.json'), settings);
+  public async searchViolationAndAcceptAllSolutions(violation: string) {
+    await this.searchAndRequestFix(violation, FixTypes.Issue);
+    await this.acceptAllSolutions();
   }
 
   public async waitForSolutionConfirmation(): Promise<void> {
@@ -660,7 +423,7 @@ export class VSCode extends BasePage {
     const MAX_FIXES = 500;
 
     for (let i = 0; i < MAX_FIXES; i++) {
-      await expect(fixLocator.first()).toBeVisible({ timeout: 300000 });
+      await expect(fixLocator.first()).toBeVisible({ timeout: 30000 });
       // Ensures the button is clicked even if there are notifications overlaying it due to screen size
       await fixLocator.first().dispatchEvent('click');
       await this.waitDefault();
@@ -673,8 +436,7 @@ export class VSCode extends BasePage {
     throw new Error('MAX_FIXES limit reached while requesting solutions');
   }
 
-  public async searchViolationAndAcceptAllSolutions(violation: string) {
-    await this.searchAndRequestFix(violation, FixTypes.Issue);
-    await this.acceptAllSolutions();
+  public async waitDefault() {
+    await this.window.waitForTimeout(process.env.CI ? 5000 : 3000);
   }
 }

--- a/tests/e2e/tests/agent_flow_coolstore.test.ts
+++ b/tests/e2e/tests/agent_flow_coolstore.test.ts
@@ -6,6 +6,7 @@ import { getRepoName } from '../utilities/utils';
 import { OPENAI_GPT4O_PROVIDER } from '../fixtures/provider-configs.fixture';
 import { KAIViews } from '../enums/views.enum';
 import { kaiCacheDir, kaiDemoMode } from '../enums/configuration-options.enum';
+import * as VSCodeFactory from '../utilities/vscode.factory';
 
 // NOTE: This is the list of providers that have cached data for the coolstore app
 // Update this list when you create cache for a new provider, you probably don't need
@@ -22,7 +23,7 @@ providers.forEach((config) => {
       test.setTimeout(1600000);
       const repoName = getRepoName(testInfo);
       const repoInfo = testRepoData[repoName];
-      vscodeApp = await VSCode.open(repoInfo.repoUrl, repoInfo.repoName);
+      vscodeApp = await VSCodeFactory.init(repoInfo.repoUrl, repoInfo.repoName);
       try {
         await vscodeApp.deleteProfile(profileName);
       } catch {
@@ -31,7 +32,7 @@ providers.forEach((config) => {
       await vscodeApp.createProfile(repoInfo.sources, repoInfo.targets, profileName);
       await vscodeApp.configureGenerativeAI(config.config);
       await vscodeApp.startServer();
-      await vscodeApp.ensureLLMCache();
+      await vscodeApp.ensureLLMCache(false);
     });
 
     test.beforeEach(async () => {

--- a/tests/e2e/tests/analyze_coolstore.test.ts
+++ b/tests/e2e/tests/analyze_coolstore.test.ts
@@ -8,6 +8,7 @@ import { runEvaluation } from '../../kai-evaluator/core';
 import { prepareEvaluationData, saveOriginalAnalysisFile } from '../utilities/evaluation.utils';
 import { KAIViews } from '../enums/views.enum';
 import { isAWSConfigured } from '../../kai-evaluator/utils/s3.utils';
+import * as VSCodeFactory from '../utilities/vscode.factory';
 
 const providers = process.env.CI ? getAvailableProviders() : [DEFAULT_PROVIDER];
 
@@ -23,7 +24,7 @@ providers.forEach((config) => {
       const repoName = getRepoName(testInfo);
       const repoInfo = testRepoData[repoName];
       profileName = `${repoInfo.repoName}-${randomString}`;
-      vscodeApp = await VSCode.open(repoInfo.repoUrl, repoInfo.repoName);
+      vscodeApp = await VSCodeFactory.init(repoInfo.repoUrl, repoInfo.repoName);
       await vscodeApp.createProfile(repoInfo.sources, repoInfo.targets, profileName);
       await vscodeApp.configureGenerativeAI(config.config);
       await vscodeApp.startServer();

--- a/tests/e2e/tests/base/configure-and-run-analysis.test.ts
+++ b/tests/e2e/tests/base/configure-and-run-analysis.test.ts
@@ -5,6 +5,7 @@ import { OPENAI_GPT4O_PROVIDER } from '../../fixtures/provider-configs.fixture';
 import * as fs from 'fs/promises';
 import { generateRandomString } from '../../utilities/utils';
 import { extractZip } from '../../utilities/archive';
+import * as VSCodeFactory from '../../utilities/vscode.factory';
 
 test.describe(`Configure extension and run analysis`, () => {
   let vscodeApp: VSCode;
@@ -21,7 +22,7 @@ test.describe(`Configure extension and run analysis`, () => {
   test.beforeAll(async ({ testRepoData }) => {
     test.setTimeout(900000);
     repoInfo = testRepoData['coolstore'];
-    vscodeApp = await VSCode.open(repoInfo.repoUrl, repoInfo.repoName);
+    vscodeApp = await VSCodeFactory.open(repoInfo.repoUrl, repoInfo.repoName);
   });
 
   test('Create Profile and Set Sources and targets', async () => {

--- a/tests/e2e/tests/base/custom-binary-analysis.test.ts
+++ b/tests/e2e/tests/base/custom-binary-analysis.test.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import { Configuration } from '../../pages/configuration.page';
 import { KAIViews } from '../../enums/views.enum';
 import { analyzerPath } from '../../enums/configuration-options.enum';
+import * as VSCodeFactory from '../../utilities/vscode.factory';
 
 /**
  * This test executes an analysis on the coolstore app using a custom analyzer binary.
@@ -54,7 +55,7 @@ test.describe.serial(`@tier2 Override the analyzer binary and run analysis`, () 
 
     console.log(`Custom analyzer path found in ${binaryPath}`);
     const repoInfo = testRepoData['coolstore'];
-    vscodeApp = await VSCode.open(repoInfo.repoUrl, repoInfo.repoName);
+    vscodeApp = await VSCodeFactory.init(repoInfo.repoUrl, repoInfo.repoName);
     await vscodeApp.createProfile(repoInfo.sources, repoInfo.targets, profileName);
   });
 

--- a/tests/e2e/tests/base/fix-one-issue.test.ts
+++ b/tests/e2e/tests/base/fix-one-issue.test.ts
@@ -4,6 +4,7 @@ import { getAvailableProviders } from '../../fixtures/provider-configs.fixture';
 import { generateRandomString } from '../../utilities/utils';
 import { KAIViews } from '../../enums/views.enum';
 import { FixTypes } from '../../enums/fix-types.enum';
+import * as VSCodeFactory from '../../utilities/vscode.factory';
 
 getAvailableProviders().forEach((provider) => {
   test.describe(`@tier0 Run analysis and fix one issue - ${provider.model}`, () => {
@@ -13,7 +14,7 @@ getAvailableProviders().forEach((provider) => {
     test.beforeAll(async ({ testRepoData }) => {
       test.setTimeout(600000);
       const repoInfo = testRepoData['coolstore'];
-      vscodeApp = await VSCode.open(repoInfo.repoUrl, repoInfo.repoName);
+      vscodeApp = await VSCodeFactory.init(repoInfo.repoUrl, repoInfo.repoName);
       await vscodeApp.waitDefault();
       await vscodeApp.createProfile(repoInfo.sources, repoInfo.targets, profileName);
       await vscodeApp.configureGenerativeAI(provider.config);

--- a/tests/e2e/tests/base/llm-revert-check.test.ts
+++ b/tests/e2e/tests/base/llm-revert-check.test.ts
@@ -6,6 +6,7 @@ import { generateRandomString } from '../../utilities/utils';
 
 import path from 'path';
 import { getFileImports } from '../../utilities/file.utils';
+import * as VSCodeFactory from '../../utilities/vscode.factory';
 /**
  * Automates https://github.com/konveyor/kai/issues/798
  * Tests that fixes applied by the LLM do not unintentionally revert .
@@ -31,10 +32,16 @@ getAvailableProviders().forEach((provider) => {
     test.beforeAll(async ({ testRepoData }) => {
       test.setTimeout(15 * MIN);
       repoInfo = testRepoData['jboss-eap-quickstarts'];
-      vscodeApp = await VSCode.open(repoInfo.repoUrl, repoInfo.repoName, repoInfo.branch, false);
+      vscodeApp = await VSCodeFactory.open(
+        repoInfo.repoUrl,
+        repoInfo.repoName,
+        repoInfo.branch,
+        false
+      );
       await vscodeApp.closeVSCode();
       // Only analyzing kitchensink to save time vs. full jboss repo
-      vscodeApp = await VSCode.open(undefined, kitchenRepoPath, undefined);
+      // TODO (abrugaro) handle opening a subfolder in web environment
+      vscodeApp = await VSCodeFactory.open(undefined, kitchenRepoPath, undefined);
       await vscodeApp.createProfile(repoInfo.sources, repoInfo.targets, profileName);
       await vscodeApp.configureGenerativeAI(provider.config);
       await vscodeApp.startServer();

--- a/tests/e2e/tests/solution-server/analysis-validation.test.ts
+++ b/tests/e2e/tests/solution-server/analysis-validation.test.ts
@@ -10,6 +10,7 @@ import {
   BestHintResponse,
   SuccessRateResponse,
 } from '../../../mcp-client/mcp-client-responses.model';
+import * as VSCodeFactory from '../../utilities/vscode.factory';
 
 test.describe(`Solution server analysis validations`, () => {
   let vsCode: VSCode;
@@ -21,7 +22,7 @@ test.describe(`Solution server analysis validations`, () => {
     const repoInfo = testRepoData['coolstore'];
     test.setTimeout(600000);
     mcpClient = await MCPClient.connect('http://localhost:8000');
-    vsCode = await VSCode.open(repoInfo.repoUrl, repoInfo.repoName);
+    vsCode = await VSCodeFactory.init(repoInfo.repoUrl, repoInfo.repoName);
     const config = await Configuration.open(vsCode);
     await config.setEnabledConfiguration(solutionServerEnabled, true);
     await vsCode.executeQuickCommand('Konveyor: Restart Solution Server');

--- a/tests/e2e/tests/solution-server/partially-migrated-apps-scenario.test.ts
+++ b/tests/e2e/tests/solution-server/partially-migrated-apps-scenario.test.ts
@@ -27,6 +27,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { TestLogger } from '../../utilities/logger';
 import { solutionServerEnabled } from '../../enums/configuration-options.enum';
+import * as VSCodeFactory from '../../utilities/vscode.factory';
 
 class SolutionServerWorkflowHelper {
   public logger: TestLogger;
@@ -78,7 +79,7 @@ class SolutionServerWorkflowHelper {
     let vsCode: VSCode | undefined;
 
     try {
-      vsCode = await VSCode.open(repoInfo.repoUrl, repoInfo.repoName, repoInfo.branch);
+      vsCode = await VSCodeFactory.init(repoInfo.repoUrl, repoInfo.repoName);
       this.logger.debug(`VSCode opened for ${appName}`);
 
       if (!vsCode) throw new Error('VSCode not initialized');

--- a/tests/e2e/utilities/vscode.factory.ts
+++ b/tests/e2e/utilities/vscode.factory.ts
@@ -1,0 +1,24 @@
+import { VSCodeWeb } from '../pages/vscode-web.page';
+import { VSCodeDesktop } from '../pages/vscode-desktop.page';
+import { VSCode } from '../pages/vscode.page';
+
+export async function open(
+  repoUrl?: string,
+  repoDir?: string,
+  branch = 'main',
+  waitForInitialization = true
+) {
+  if (process.env.WEB_ENV) {
+    return VSCodeWeb.open(repoUrl, repoDir, branch);
+  }
+
+  return VSCodeDesktop.open(repoUrl, repoDir, branch, waitForInitialization);
+}
+
+export async function init(repoUrl?: string, repoDir?: string, branch?: string): Promise<VSCode> {
+  if (process.env.WEB_ENV) {
+    return VSCodeWeb.init(repoUrl, repoDir, branch);
+  }
+  console.log('b');
+  return VSCodeDesktop.init(repoUrl, repoDir, branch);
+}

--- a/tests/global.setup.ts
+++ b/tests/global.setup.ts
@@ -1,13 +1,15 @@
-import { VSCode } from './e2e/pages/vscode.page';
 import { generateRandomString, getOSInfo } from './e2e/utilities/utils';
 import { isExtensionInstalled } from './e2e/utilities/vscode-commands.utils';
 import { KAIViews } from './e2e/enums/views.enum';
+import * as VSCodeFactory from './e2e/utilities/vscode.factory';
 
 async function globalSetup() {
   const repoUrl = process.env.TEST_REPO_URL ?? 'https://github.com/konveyor-ecosystem/coolstore';
   const repoName = process.env.TEST_REPO_NAME ?? 'coolstore';
   console.log('Running global setup...');
-  let vscodeApp = await VSCode.init(repoUrl, repoName);
+  const vscodeApp = await VSCodeFactory.init(repoUrl, repoName);
+
+  // TODO (abrugaro) move to vscode classes
   if (!isExtensionInstalled('redhat.java')) {
     throw new Error(
       'Required extension `redhat.java` was not found. It should have been installed automatically as a dependency'
@@ -27,7 +29,7 @@ async function globalSetup() {
   console.log('Completed global setup.');
 
   if (getOSInfo() === 'windows' && process.env.CI) {
-    const vscodeApp = await VSCode.open(repoUrl, repoName);
+    const vscodeApp = await VSCodeFactory.open(repoUrl, repoName);
     await vscodeApp.createProfile([], ['openjdk17'], generateRandomString());
     await vscodeApp.configureGenerativeAI();
     await vscodeApp.openAnalysisView();

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -44,5 +44,9 @@ export default defineConfig({
       name: 'agent-flow-tests',
       testMatch: /.*agent_flow.+\.test\.ts/,
     },
+    {
+      name: 'devspaces',
+      testMatch: ['**/devspaces/**/*.test.ts'],
+    },
   ],
 });


### PR DESCRIPTION
Part of #903 

Please do not merge yet

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
