### PR TITLE
:fix: improve diff line ending filtering to handle CRLF changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20102,7 +20102,12 @@
     },
     "shared": {
       "name": "@editor-extensions/shared",
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.3.2"
+      }
     },
     "vscode": {},
     "vscode/core": {

--- a/shared/jest.config.js
+++ b/shared/jest.config.js
@@ -1,0 +1,18 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} **/
+export default {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        useESM: true,
+      },
+    ],
+  },
+  extensionsToTreatAsEsm: [".ts"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  testMatch: ["**/__tests__/**/*.test.ts"],
+};

--- a/shared/package.json
+++ b/shared/package.json
@@ -18,6 +18,7 @@
     "clean": "rimraf dist",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
+    "test": "jest",
     "prebuild": "npm run clean",
     "build": "vite build",
     "dev": "vite build --watch"
@@ -25,5 +26,10 @@
   "lint-staged": {
     "*.{js,cjs,mjs,ts,cts,mts}": "eslint --fix",
     "*.json": "prettier --write"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.3.2"
   }
 }

--- a/shared/src/__tests__/diffUtils.test.ts
+++ b/shared/src/__tests__/diffUtils.test.ts
@@ -1,0 +1,573 @@
+import {
+  normalizeLineEndings,
+  isOnlyLineEndingDiff,
+  normalizeUnifiedDiff,
+  hasNoMeaningfulDiffContent,
+  filterLineEndingOnlyChanges,
+  combineIdenticalTrimmedLines,
+  cleanDiff,
+} from "../utils/diffUtils";
+import { expect } from "expect";
+
+describe("diffUtils", () => {
+  describe("normalizeLineEndings", () => {
+    it("should convert CRLF to LF", () => {
+      const input = "line1\r\nline2\r\nline3";
+      expect(normalizeLineEndings(input)).toBe("line1\nline2\nline3");
+    });
+
+    it("should convert CR to LF", () => {
+      const input = "line1\rline2\rline3";
+      expect(normalizeLineEndings(input)).toBe("line1\nline2\nline3");
+    });
+
+    it("should preserve existing LF", () => {
+      const input = "line1\nline2\nline3";
+      expect(normalizeLineEndings(input)).toBe("line1\nline2\nline3");
+    });
+
+    it("should handle mixed line endings", () => {
+      const input = "line1\r\nline2\rline3\nline4";
+      expect(normalizeLineEndings(input)).toBe("line1\nline2\nline3\nline4");
+    });
+
+    it("should handle empty string", () => {
+      expect(normalizeLineEndings("")).toBe("");
+    });
+
+    it("should handle string without line endings", () => {
+      expect(normalizeLineEndings("single line")).toBe("single line");
+    });
+  });
+
+  describe("isOnlyLineEndingDiff", () => {
+    it("should return true for diff with only line ending changes", () => {
+      // Note: In a real diff, CRLF is represented as \r at line end before newline
+      // This is a simplified test showing identical content
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,2 +1,2 @@
+-line1
++line1
+-line2
++line2`;
+      expect(isOnlyLineEndingDiff(diff)).toBe(true);
+    });
+
+    it("should return false for diff with actual content changes", () => {
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,2 +1,2 @@
+-line1
++modified_line1
+-line2
++line2`;
+      expect(isOnlyLineEndingDiff(diff)).toBe(false);
+    });
+
+    it('should return true when only special marker "No newline at end of file" exists', () => {
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1 +1 @@
+ line1
+\\ No newline at end of file`;
+      expect(isOnlyLineEndingDiff(diff)).toBe(true);
+    });
+
+    it("should return false for empty diff", () => {
+      expect(isOnlyLineEndingDiff("")).toBe(false);
+    });
+
+    it("should handle block-style diffs where all removed lines appear before added lines", () => {
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,3 @@
+-line1
+-line2
+-line3
++line1
++line2
++line3`;
+      expect(isOnlyLineEndingDiff(diff)).toBe(true);
+    });
+
+    it("should return false for block-style diff with actual changes", () => {
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,3 @@
+-line1
+-line2
+-line3
++line1_modified
++line2
++line3`;
+      expect(isOnlyLineEndingDiff(diff)).toBe(false);
+    });
+
+    it("should handle trailing whitespace differences as line ending changes", () => {
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,2 +1,2 @@
+-line1  
++line1
+-line2	
++line2`;
+      // Lines differ only in trailing whitespace - should be treated as line ending change
+      expect(isOnlyLineEndingDiff(diff)).toBe(true);
+    });
+  });
+
+  describe("filterLineEndingOnlyChanges", () => {
+    it("should filter out line-ending-only changes", () => {
+      const lines = [
+        "--- a/file.txt",
+        "+++ b/file.txt",
+        "@@ -1,2 +1,2 @@",
+        "-line1",
+        "+line1",
+        " context",
+      ];
+      const filtered = filterLineEndingOnlyChanges(lines);
+      // Should remove the -line1/+line1 pair since they're identical
+      expect(filtered).not.toContain("-line1");
+      expect(filtered).not.toContain("+line1");
+      expect(filtered).toContain(" context");
+    });
+
+    it("should keep actual content changes", () => {
+      const lines = [
+        "--- a/file.txt",
+        "+++ b/file.txt",
+        "@@ -1,2 +1,2 @@",
+        "-old_content",
+        "+new_content",
+        " context",
+      ];
+      const filtered = filterLineEndingOnlyChanges(lines);
+      expect(filtered).toContain("-old_content");
+      expect(filtered).toContain("+new_content");
+    });
+
+    it('should filter out "No newline at end of file" markers', () => {
+      const lines = [
+        "--- a/file.txt",
+        "+++ b/file.txt",
+        "@@ -1 +1 @@",
+        " line1",
+        "\\ No newline at end of file",
+      ];
+      const filtered = filterLineEndingOnlyChanges(lines);
+      expect(filtered).not.toContain("\\ No newline at end of file");
+    });
+
+    it("should handle block-style diffs with all removed before all added", () => {
+      const lines = [
+        "--- a/file.txt",
+        "+++ b/file.txt",
+        "@@ -1,3 +1,3 @@",
+        "-line1",
+        "-line2",
+        "-line3",
+        "+line1",
+        "+line2",
+        "+line3",
+      ];
+      const filtered = filterLineEndingOnlyChanges(lines);
+      // All pairs should be filtered out as they're identical
+      expect(filtered).not.toContain("-line1");
+      expect(filtered).not.toContain("+line1");
+    });
+
+    it("should keep block-style diffs with actual content changes", () => {
+      const lines = [
+        "--- a/file.txt",
+        "+++ b/file.txt",
+        "@@ -1,3 +1,3 @@",
+        "-line1",
+        "-line2",
+        "-line3",
+        "+line1_modified",
+        "+line2",
+        "+line3",
+      ];
+      const filtered = filterLineEndingOnlyChanges(lines);
+      // Should keep all lines since there's a real change
+      expect(filtered).toContain("-line1");
+      expect(filtered).toContain("+line1_modified");
+    });
+
+    it("should handle mixed content and line-ending changes in same hunk", () => {
+      const lines = [
+        "--- a/file.txt",
+        "+++ b/file.txt",
+        "@@ -1,4 +1,4 @@",
+        "-line1",
+        "+line1",
+        "-old_content",
+        "+new_content",
+      ];
+      const filtered = filterLineEndingOnlyChanges(lines);
+      // Since not all pairs are identical, all changes should be kept
+      expect(filtered).toContain("-line1");
+      expect(filtered).toContain("+line1");
+      expect(filtered).toContain("-old_content");
+      expect(filtered).toContain("+new_content");
+    });
+
+    it("should preserve header lines", () => {
+      const lines = [
+        "diff --git a/file.txt b/file.txt",
+        "index abc123..def456 100644",
+        "--- a/file.txt",
+        "+++ b/file.txt",
+        "@@ -1 +1 @@",
+        "-content",
+        "+content",
+      ];
+      const filtered = filterLineEndingOnlyChanges(lines);
+      expect(filtered[0]).toBe("diff --git a/file.txt b/file.txt");
+      expect(filtered[1]).toBe("index abc123..def456 100644");
+      expect(filtered[2]).toBe("--- a/file.txt");
+      expect(filtered[3]).toBe("+++ b/file.txt");
+    });
+
+    it("should handle multiple hunks", () => {
+      const lines = [
+        "--- a/file.txt",
+        "+++ b/file.txt",
+        "@@ -1,2 +1,2 @@",
+        "-line1",
+        "+line1",
+        " context",
+        "@@ -10,2 +10,2 @@",
+        "-line10",
+        "+line10_changed",
+        " more context",
+      ];
+      const filtered = filterLineEndingOnlyChanges(lines);
+      // First hunk should be filtered, second should be kept
+      expect(filtered).toContain("-line10");
+      expect(filtered).toContain("+line10_changed");
+    });
+  });
+
+  describe("combineIdenticalTrimmedLines", () => {
+    it("should combine consecutive -/+ pairs that are identical after trimming", () => {
+      const lines = ["-  line with spaces  ", "+line with spaces", " context"];
+      const combined = combineIdenticalTrimmedLines(lines);
+      expect(combined).toHaveLength(2);
+      expect(combined[0]).toBe("   line with spaces  ");
+      expect(combined[1]).toBe(" context");
+    });
+
+    it("should keep pairs that differ after trimming", () => {
+      const lines = ["-old content", "+new content"];
+      const combined = combineIdenticalTrimmedLines(lines);
+      expect(combined).toHaveLength(2);
+      expect(combined[0]).toBe("-old content");
+      expect(combined[1]).toBe("+new content");
+    });
+
+    it("should handle non-consecutive changes", () => {
+      const lines = ["-old", " context", "+new"];
+      const combined = combineIdenticalTrimmedLines(lines);
+      expect(combined).toEqual(lines);
+    });
+
+    it("should handle multiple pairs", () => {
+      const lines = ["-  line1  ", "+line1", "-  line2  ", "+line2"];
+      const combined = combineIdenticalTrimmedLines(lines);
+      expect(combined).toHaveLength(2);
+    });
+  });
+
+  describe("hasNoMeaningfulDiffContent", () => {
+    it("should return true for empty diff", () => {
+      expect(hasNoMeaningfulDiffContent("")).toBe(true);
+    });
+
+    it("should return true for whitespace-only diff", () => {
+      expect(hasNoMeaningfulDiffContent("   \n  \n")).toBe(true);
+    });
+
+    it("should return true for diff with only headers", () => {
+      const diff = `--- a/file.txt
++++ b/file.txt`;
+      expect(hasNoMeaningfulDiffContent(diff)).toBe(true);
+    });
+
+    it("should return true for diff with only context lines", () => {
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,2 +1,2 @@
+ line1
+ line2`;
+      expect(hasNoMeaningfulDiffContent(diff)).toBe(true);
+    });
+
+    it("should return false for diff with actual changes", () => {
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,2 +1,2 @@
+-old
++new
+ line2`;
+      expect(hasNoMeaningfulDiffContent(diff)).toBe(false);
+    });
+  });
+
+  describe("normalizeUnifiedDiff", () => {
+    it("should return empty string when contents are identical after normalization", () => {
+      const diff = "some diff";
+      const original = "line1\r\nline2";
+      const modified = "line1\nline2";
+      expect(normalizeUnifiedDiff(diff, original, modified)).toBe("");
+    });
+
+    it("should return original diff when contents actually differ", () => {
+      const diff = "the diff content";
+      const original = "line1\nline2";
+      const modified = "line1\nmodified_line2";
+      expect(normalizeUnifiedDiff(diff, original, modified)).toBe(diff);
+    });
+  });
+
+  describe("cleanDiff", () => {
+    it("should return empty string for null/undefined input", () => {
+      expect(cleanDiff("")).toBe("");
+      expect(cleanDiff("   ")).toBe("");
+    });
+
+    it("should return empty string for line-ending-only diff", () => {
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1 +1 @@
+-line1
++line1`;
+      expect(cleanDiff(diff)).toBe("");
+    });
+
+    it("should return cleaned diff for mixed changes", () => {
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,3 @@
+-unchanged
++unchanged
+-old_content
++new_content
+ context`;
+      const cleaned = cleanDiff(diff);
+      // Should contain the actual change but not the line-ending-only change
+      expect(cleaned).toContain("+new_content");
+      expect(cleaned).toContain("-old_content");
+    });
+
+    it("should handle real-world CRLF diff scenario", () => {
+      // Simulating a diff where file was converted from CRLF to LF
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,4 +1,4 @@
+-public class Example {
+-    public void method() {
+-    }
+-}
++public class Example {
++    public void method() {
++    }
++}`;
+      const cleaned = cleanDiff(diff);
+      // If all lines are identical after normalization, should return empty
+      expect(cleaned).toBe("");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle diff with only additions (new file)", () => {
+      const lines = [
+        "--- /dev/null",
+        "+++ b/newfile.txt",
+        "@@ -0,0 +1,3 @@",
+        "+line1",
+        "+line2",
+        "+line3",
+      ];
+      const filtered = filterLineEndingOnlyChanges(lines);
+      expect(filtered).toContain("+line1");
+      expect(filtered).toContain("+line2");
+      expect(filtered).toContain("+line3");
+    });
+
+    it("should handle diff with only deletions (deleted file)", () => {
+      const lines = [
+        "--- a/oldfile.txt",
+        "+++ /dev/null",
+        "@@ -1,3 +0,0 @@",
+        "-line1",
+        "-line2",
+        "-line3",
+      ];
+      const filtered = filterLineEndingOnlyChanges(lines);
+      expect(filtered).toContain("-line1");
+      expect(filtered).toContain("-line2");
+      expect(filtered).toContain("-line3");
+    });
+
+    it("should handle unbalanced changes (more additions than deletions)", () => {
+      const lines = [
+        "--- a/file.txt",
+        "+++ b/file.txt",
+        "@@ -1,2 +1,3 @@",
+        "-line1",
+        "+line1",
+        "+new_line",
+        " context",
+      ];
+      const filtered = filterLineEndingOnlyChanges(lines);
+      // Unbalanced - should keep all changes
+      expect(filtered).toContain("-line1");
+      expect(filtered).toContain("+line1");
+      expect(filtered).toContain("+new_line");
+    });
+
+    it("should handle unbalanced changes (more deletions than additions)", () => {
+      const lines = [
+        "--- a/file.txt",
+        "+++ b/file.txt",
+        "@@ -1,3 +1,2 @@",
+        "-line1",
+        "-deleted_line",
+        "+line1",
+        " context",
+      ];
+      const filtered = filterLineEndingOnlyChanges(lines);
+      // Unbalanced - should keep all changes
+      expect(filtered).toContain("-line1");
+      expect(filtered).toContain("-deleted_line");
+      expect(filtered).toContain("+line1");
+    });
+  });
+
+  describe("isOnlyLineEndingDiff - additional block-style tests", () => {
+    it("should return false when additions don't match removals (different order)", () => {
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,3 @@
+-line1
+-line2
+-line3
++line3
++line2
++line1`;
+      // Lines are in different order, so this is NOT just a line ending change
+      expect(isOnlyLineEndingDiff(diff)).toBe(false);
+    });
+
+    it("should handle block diff with trailing whitespace changes", () => {
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,2 +1,2 @@
+-line1   
+-line2	
++line1
++line2`;
+      // Only trailing whitespace differs
+      expect(isOnlyLineEndingDiff(diff)).toBe(true);
+    });
+
+    it("should return false when one line differs in block", () => {
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,3 @@
+-line1
+-line2
+-line3
++line1
++line2_changed
++line3`;
+      expect(isOnlyLineEndingDiff(diff)).toBe(false);
+    });
+
+    it("should return false for unbalanced block diff", () => {
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,2 @@
+-line1
+-line2
+-line3
++line1
++line2`;
+      expect(isOnlyLineEndingDiff(diff)).toBe(false);
+    });
+
+    it("should handle empty lines in block diff", () => {
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,3 @@
+-
+-line2
+-
++
++line2
++`;
+      expect(isOnlyLineEndingDiff(diff)).toBe(true);
+    });
+  });
+
+  describe("real-world scenarios", () => {
+    it("should handle Java file with CRLF to LF conversion", () => {
+      // Simulating a Java file that was saved with different line endings
+      const diff = `--- a/Example.java
++++ b/Example.java
+@@ -1,5 +1,5 @@
+-package com.example;
+-
+-public class Example {
+-    
+-}
++package com.example;
++
++public class Example {
++    
++}`;
+      expect(isOnlyLineEndingDiff(diff)).toBe(true);
+    });
+
+    it("should not filter out actual code changes", () => {
+      const diff = `--- a/Example.java
++++ b/Example.java
+@@ -1,5 +1,6 @@
+-package com.example;
+-
+-public class Example {
+-    
+-}
++package com.example;
++
++public class Example {
++    public void newMethod() {}
++}`;
+      expect(isOnlyLineEndingDiff(diff)).toBe(false);
+    });
+
+    it("should handle multiple hunks with mixed changes", () => {
+      const diff = `--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,3 @@
+-line1
+-line2
+-line3
++line1
++line2
++line3
+@@ -10,3 +10,3 @@
+-line10
+-line11
+-line12
++line10_changed
++line11
++line12`;
+      // Second hunk has real change, so overall it's not just line ending
+      expect(isOnlyLineEndingDiff(diff)).toBe(false);
+    });
+  });
+});

--- a/shared/src/utils/diffUtils.ts
+++ b/shared/src/utils/diffUtils.ts
@@ -14,9 +14,11 @@ export function normalizeLineEndings(content: string): string {
  */
 export function isOnlyLineEndingDiff(unifiedDiff: string): boolean {
   const lines = unifiedDiff.split("\n");
-  const changeLines: string[] = [];
+  const removedLines: string[] = [];
+  const addedLines: string[] = [];
+  const specialMarkers: string[] = [];
 
-  // Collect all +/- lines
+  // Collect all +/- lines and special markers
   for (const line of lines) {
     // Skip diff headers and context markers
     if (
@@ -30,36 +32,38 @@ export function isOnlyLineEndingDiff(unifiedDiff: string): boolean {
       continue;
     }
 
-    // Collect actual change lines
-    if (line.startsWith("+") || line.startsWith("-")) {
-      changeLines.push(line);
+    // Collect special markers (e.g., "\ No newline at end of file")
+    if (line.startsWith("\\")) {
+      specialMarkers.push(line);
+      continue;
+    }
+
+    // Collect removed and added lines separately
+    if (line.startsWith("-")) {
+      removedLines.push(line.substring(1));
+    } else if (line.startsWith("+")) {
+      addedLines.push(line.substring(1));
     }
   }
 
-  // If no changes, not a line ending diff
-  if (changeLines.length === 0) {
+  // If no changes, check if only special markers exist
+  if (removedLines.length === 0 && addedLines.length === 0) {
+    // Check if only special markers exist (which might indicate line ending differences)
+    return specialMarkers.some((marker) => marker.includes("No newline at end of file"));
+  }
+
+  // Must have equal number of removed and added lines for it to be line-ending-only
+  if (removedLines.length !== addedLines.length) {
     return false;
   }
 
-  // Check if changes come in pairs where the only difference is line endings
-  for (let i = 0; i < changeLines.length; i += 2) {
-    if (i + 1 >= changeLines.length) {
-      return false; // Unpaired change
-    }
+  // Compare each pair of removed/added lines
+  for (let i = 0; i < removedLines.length; i++) {
+    const normalizedRemoved = normalizeLineEndings(removedLines[i]).trimEnd();
+    const normalizedAdded = normalizeLineEndings(addedLines[i]).trimEnd();
 
-    const removedLine = changeLines[i];
-    const addedLine = changeLines[i + 1];
-
-    // Must be a - followed by a +
-    if (!removedLine.startsWith("-") || !addedLine.startsWith("+")) {
-      return false;
-    }
-
-    const removedContent = removedLine.substring(1);
-    const addedContent = addedLine.substring(1);
-
-    // Check if they're the same after normalizing line endings
-    if (normalizeLineEndings(removedContent) !== normalizeLineEndings(addedContent)) {
+    // If content differs after normalization, it's not just a line ending change
+    if (normalizedRemoved !== normalizedAdded) {
       return false;
     }
   }
@@ -99,7 +103,7 @@ export function hasNoMeaningfulDiffContent(unifiedDiff: string): boolean {
   const lines = unifiedDiff.split("\n");
   const filteredLines = filterLineEndingOnlyChanges(lines);
 
-  let formattedDiff = "";
+  let hasActualChanges = false;
   let inHunk = false;
 
   for (const line of filteredLines) {
@@ -113,16 +117,19 @@ export function hasNoMeaningfulDiffContent(unifiedDiff: string): boolean {
 
     if (line.startsWith("@@")) {
       inHunk = true;
-      formattedDiff += line + "\n";
       continue;
     }
 
     if (inHunk) {
-      formattedDiff += line + "\n";
+      // Check for actual changes (not just context lines)
+      if (line.startsWith("+") || line.startsWith("-")) {
+        hasActualChanges = true;
+        break;
+      }
     }
   }
 
-  return !formattedDiff.trim();
+  return !hasActualChanges;
 }
 
 /**
@@ -131,6 +138,46 @@ export function hasNoMeaningfulDiffContent(unifiedDiff: string): boolean {
 export function filterLineEndingOnlyChanges(diffLines: string[]): string[] {
   const filtered: string[] = [];
   let i = 0;
+
+  // First, collect all removed and added lines in the current hunk
+  const removedLines: { index: number; content: string }[] = [];
+  const addedLines: { index: number; content: string }[] = [];
+  let inHunk = false;
+
+  // Helper function to process collected lines
+  const processHunkLines = () => {
+    if (removedLines.length === 0 || addedLines.length === 0) {
+      // No pairs to compare, keep all lines
+      removedLines.forEach((item) => filtered.push(diffLines[item.index]));
+      addedLines.forEach((item) => filtered.push(diffLines[item.index]));
+    } else if (removedLines.length === addedLines.length) {
+      // Check if all pairs only differ in line endings
+      let allLineEndingChanges = true;
+      for (let k = 0; k < removedLines.length; k++) {
+        const normalizedRemoved = normalizeLineEndings(removedLines[k].content).trimEnd();
+        const normalizedAdded = normalizeLineEndings(addedLines[k].content).trimEnd();
+        if (normalizedRemoved !== normalizedAdded) {
+          allLineEndingChanges = false;
+          break;
+        }
+      }
+
+      if (!allLineEndingChanges) {
+        // Not all changes are line-ending only, keep all lines
+        removedLines.forEach((item) => filtered.push(diffLines[item.index]));
+        addedLines.forEach((item) => filtered.push(diffLines[item.index]));
+      }
+      // If all are line-ending changes, we skip them (don't add to filtered)
+    } else {
+      // Different number of removed/added lines, keep all
+      removedLines.forEach((item) => filtered.push(diffLines[item.index]));
+      addedLines.forEach((item) => filtered.push(diffLines[item.index]));
+    }
+
+    // Clear collections
+    removedLines.length = 0;
+    addedLines.length = 0;
+  };
 
   while (i < diffLines.length) {
     const line = diffLines[i];
@@ -141,40 +188,124 @@ export function filterLineEndingOnlyChanges(diffLines: string[]): string[] {
       line.startsWith("index ") ||
       line.startsWith("--- ") ||
       line.startsWith("+++ ") ||
-      line.startsWith("@@") ||
-      line.startsWith(" ")
+      line.startsWith("@@")
     ) {
+      // Process any collected lines before the new section
+      if (inHunk) {
+        processHunkLines();
+        inHunk = false;
+      }
+      filtered.push(line);
+      if (line.startsWith("@@")) {
+        inHunk = true;
+      }
+      i++;
+      continue;
+    }
+
+    // Handle context lines
+    if (line.startsWith(" ")) {
+      // Process any collected lines before the context
+      processHunkLines();
       filtered.push(line);
       i++;
       continue;
     }
 
-    // Check for paired +/- lines that only differ in line endings
-    if (line.startsWith("-") && i + 1 < diffLines.length) {
-      const nextLine = diffLines[i + 1];
-
-      if (nextLine.startsWith("+")) {
-        const removedContent = normalizeLineEndings(line.substring(1));
-        const addedContent = normalizeLineEndings(nextLine.substring(1));
-
-        // If they're the same after normalization, skip both lines
-        if (removedContent === addedContent) {
-          i += 2; // Skip both lines
-          continue;
-        } else {
-          // They're different - keep both lines
-          filtered.push(line);
-          filtered.push(nextLine);
-          i += 2;
-          continue;
-        }
+    // Handle special diff markers (e.g., "\ No newline at end of file")
+    if (line.startsWith("\\")) {
+      // Check if this is a line-ending-related marker
+      if (line.includes("No newline at end of file")) {
+        // Skip this marker as it's related to line endings
+        i++;
+        continue;
       }
+      // Process collected lines and keep other backslash markers
+      processHunkLines();
+      filtered.push(line);
+      i++;
+      continue;
     }
 
-    // Keep the line if it's not just a line ending change
-    filtered.push(line);
+    // Collect removed and added lines
+    if (line.startsWith("-")) {
+      removedLines.push({ index: i, content: line.substring(1) });
+    } else if (line.startsWith("+")) {
+      addedLines.push({ index: i, content: line.substring(1) });
+    } else {
+      // Unknown line type, process collected and keep this line
+      processHunkLines();
+      filtered.push(line);
+    }
+
     i++;
   }
 
+  // Process any remaining collected lines
+  processHunkLines();
+
   return filtered;
+}
+
+/**
+ * Post-process diff lines to combine consecutive old/new pairs that are identical after trimming
+ * This helps reduce noise from whitespace-only changes
+ */
+export function combineIdenticalTrimmedLines(diffLines: string[]): string[] {
+  const result: string[] = [];
+  let i = 0;
+
+  while (i < diffLines.length) {
+    const line = diffLines[i];
+    const nextLine = diffLines[i + 1];
+
+    // Check if we have a consecutive old/new pair
+    if (
+      line &&
+      nextLine &&
+      line.startsWith("-") &&
+      nextLine.startsWith("+") &&
+      line.substring(1).trim() === nextLine.substring(1).trim()
+    ) {
+      // Replace the pair with a context line (using the original formatting from the old line)
+      result.push(" " + line.substring(1));
+      i += 2; // Skip both lines
+    } else {
+      // Keep the line as is
+      result.push(line);
+      i++;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Apply all line ending and whitespace filtering to a unified diff
+ */
+export function cleanDiff(unifiedDiff: string): string {
+  if (!unifiedDiff || unifiedDiff.trim() === "") {
+    return "";
+  }
+
+  // First, check if it's only line ending changes
+  if (isOnlyLineEndingDiff(unifiedDiff)) {
+    return "";
+  }
+
+  // Split into lines and apply filters
+  const lines = unifiedDiff.split("\n");
+
+  // Filter out line-ending-only changes
+  let filteredLines = filterLineEndingOnlyChanges(lines);
+
+  // Combine identical trimmed lines
+  filteredLines = combineIdenticalTrimmedLines(filteredLines);
+
+  // Check if we have any meaningful content left
+  if (hasNoMeaningfulDiffContent(filteredLines.join("\n"))) {
+    return "";
+  }
+
+  return filteredLines.join("\n");
 }

--- a/vscode/src/utilities/ModifiedFiles/handleModifiedFile.ts
+++ b/vscode/src/utilities/ModifiedFiles/handleModifiedFile.ts
@@ -1,0 +1,237 @@
+import {
+  KaiWorkflowMessage,
+  KaiWorkflowMessageType,
+  KaiModifiedFile,
+} from "@editor-extensions/agentic";
+import { createTwoFilesPatch, createPatch } from "diff";
+import { ExtensionState } from "src/extensionState";
+import { Uri } from "vscode";
+import { ModifiedFileState, ChatMessageType } from "@editor-extensions/shared";
+// Import path module for platform-agnostic path handling
+import { processModifiedFile } from "./processModifiedFile";
+import { MessageQueueManager, handleUserInteractionComplete } from "./queueManager";
+
+/**
+ * Performs comprehensive cleanup of resources and state variables when an error occurs
+ * during file processing. This ensures the system returns to a consistent state.
+ */
+export const cleanupOnError = (
+  filePath: string,
+  msgId: string,
+  state: ExtensionState,
+  modifiedFiles: Map<string, ModifiedFileState>,
+  pendingInteractions: Map<string, (response: any) => void>,
+  processedTokens: Set<string>,
+  modifiedFilesPromises: Array<Promise<void>>,
+  eventEmitter?: { emit: (event: string, ...args: any[]) => void },
+  error?: any,
+) => {
+  // Reset the waiting flag
+  state.mutateData((draft) => {
+    draft.isWaitingForUserInteraction = false;
+  });
+
+  // Clean up pending interactions to prevent memory leaks
+  if (pendingInteractions.has(msgId)) {
+    pendingInteractions.delete(msgId);
+  }
+
+  // Remove any partially processed file state from modifiedFiles map
+  const uri = Uri.file(filePath);
+  if (modifiedFiles.has(uri.fsPath)) {
+    modifiedFiles.delete(uri.fsPath);
+  }
+
+  // Remove the processed token if it was added
+  if (processedTokens.has(msgId)) {
+    processedTokens.delete(msgId);
+  }
+
+  // Clear any promises that might be stuck in the array
+  // Since we can't easily identify which promises are related to this specific file,
+  // we'll clear all promises that haven't been resolved yet
+  // This is a conservative approach to prevent stuck promises
+  modifiedFilesPromises.length = 0;
+
+  // Emit cleanup event if eventEmitter is available
+  if (eventEmitter) {
+    eventEmitter.emit("modifiedFileError", { filePath, error });
+  }
+};
+
+/**
+ * Creates a diff for UI display based on the file state and path.
+ * @param fileState The state of the modified file.
+ * @param filePath The path of the file for diff creation.
+ * @returns The diff string for UI display.
+ */
+const createFileDiff = (fileState: ModifiedFileState, filePath: string): string => {
+  // Note: Use path module for any directory path extraction to ensure platform independence.
+  // For example, use path.dirname(filePath) instead of string manipulation with lastIndexOf.
+  const isNew = fileState.originalContent === undefined;
+  const isDeleted = !isNew && fileState.modifiedContent.trim() === "";
+  let diff: string;
+
+  if (isNew) {
+    diff = createTwoFilesPatch("", filePath, "", fileState.modifiedContent, undefined, undefined, {
+      ignoreNewlineAtEof: true,
+    });
+  } else if (isDeleted) {
+    diff = createTwoFilesPatch(
+      filePath,
+      "",
+      fileState.originalContent as string,
+      "",
+      undefined,
+      undefined,
+      {
+        ignoreNewlineAtEof: true,
+      },
+    );
+  } else {
+    try {
+      diff = createPatch(
+        filePath,
+        fileState.originalContent as string,
+        fileState.modifiedContent,
+        undefined,
+        undefined,
+        {
+          ignoreNewlineAtEof: true,
+        },
+      );
+    } catch (diffErr) {
+      diff = `// Error creating diff for ${filePath}`;
+    }
+  }
+  return diff;
+};
+
+/**
+ * Handles user response to file modification, updating file state accordingly.
+ * @param response The user's response to the modification.
+ * @param uri The URI of the file.
+ * @param filePath The path of the file.
+ * @param fileState The state of the modified file.
+ * @param state The extension state.
+ * @param isNew Whether the file is new.
+ * @param isDeleted Whether the file is deleted.
+ */
+
+/**
+ * Handles a modified file message from the agent
+ * 1. Processes the file modification
+ * 2. Creates a diff for UI display
+ * 3. Adds a chat message with accept/reject buttons
+ * 4. Waits for user response before continuing
+ */
+export const handleModifiedFileMessage = async (
+  msg: KaiWorkflowMessage,
+  modifiedFiles: Map<string, ModifiedFileState>,
+  modifiedFilesPromises: Array<Promise<void>>,
+  processedTokens: Set<string>,
+  pendingInteractions: Map<string, (response: any) => void>,
+  state: ExtensionState,
+  queueManager: MessageQueueManager,
+  eventEmitter?: { emit: (event: string, ...args: any[]) => void },
+) => {
+  // Ensure we're dealing with a ModifiedFile message
+  if (msg.type !== KaiWorkflowMessageType.ModifiedFile) {
+    return;
+  }
+
+  // Get file info for UI display
+  const { path: filePath } = msg.data as KaiModifiedFile;
+
+  // Process the modified file and store it in the modifiedFiles map
+  modifiedFilesPromises.push(
+    processModifiedFile(modifiedFiles, msg.data as KaiModifiedFile, eventEmitter),
+  );
+
+  const uri = Uri.file(filePath);
+
+  try {
+    // Wait for the file to be processed
+    await Promise.all(modifiedFilesPromises);
+
+    // Get file state from modifiedFiles map
+    const fileState = modifiedFiles.get(uri.fsPath);
+    if (fileState) {
+      // Use unified logic for both agent and non-agent modes to enable decorator flow
+      const isNew = fileState.originalContent === undefined;
+      const isDeleted = !isNew && fileState.modifiedContent.trim() === "";
+      const diff = createFileDiff(fileState, filePath);
+
+      // Add a chat message with quick responses for user interaction
+      state.mutateData((draft) => {
+        draft.chatMessages.push({
+          kind: ChatMessageType.ModifiedFile,
+          messageToken: msg.id,
+          timestamp: new Date().toISOString(),
+          value: {
+            path: filePath,
+            content: fileState.modifiedContent,
+            originalContent: fileState.originalContent, // Use from ModifiedFileState
+            isNew: isNew,
+            isDeleted: isDeleted,
+            diff: diff,
+            messageToken: msg.id, // Add message token to value for reference
+            userInteraction: msg.data.userInteraction,
+          },
+          quickResponses: [
+            { id: "apply", content: "Apply" },
+            { id: "reject", content: "Reject" },
+          ],
+        });
+      });
+
+      state.mutateData((draft) => {
+        draft.isWaitingForUserInteraction = true;
+      });
+
+      // Set up the pending interaction using the same mechanism as UserInteraction messages
+      // This ensures that handleFileResponse can properly trigger queue processing
+      await new Promise<void>((resolve) => {
+        pendingInteractions.set(msg.id, async (response: any) => {
+          try {
+            // Use the centralized interaction completion handler
+            await handleUserInteractionComplete(state, queueManager);
+
+            // Remove the entry from pendingInteractions to prevent memory leaks
+            pendingInteractions.delete(msg.id);
+            resolve();
+          } catch (error) {
+            console.error(`Error in ModifiedFile resolver for messageId: ${msg.id}:`, error);
+            // Remove the entry from pendingInteractions to prevent memory leaks
+            pendingInteractions.delete(msg.id);
+            resolve();
+          }
+        });
+      });
+    }
+  } catch (err) {
+    console.error(`Error in handleModifiedFileMessage for ${filePath}:`, err);
+
+    // Comprehensive cleanup of all resources and state variables
+    // This ensures the system returns to a consistent state after an error
+    try {
+      cleanupOnError(
+        filePath,
+        msg.id,
+        state,
+        modifiedFiles,
+        pendingInteractions,
+        processedTokens,
+        modifiedFilesPromises,
+        eventEmitter,
+        err,
+      );
+    } catch (cleanupError) {
+      console.error(`Error during cleanup for ${filePath}:`, cleanupError);
+      // Even if cleanup fails, ensure the waiting flag is reset
+      state.mutateData((draft) => {
+        draft.isWaitingForUserInteraction = false;
+      });
+    }
+  }
+};


### PR DESCRIPTION
- Enhanced filterLineEndingOnlyChanges to handle block-style diffs where all removed lines appear before added lines
- Updated isOnlyLineEndingDiff to handle special diff markers like '\ No newline at end of file'
- Added combineIdenticalTrimmedLines function to reduce noise from whitespace-only changes
- Added cleanDiff utility that combines all filtering strategies
- Added ignoreNewlineAtEof option to diff creation to prevent trailing newline diffs
- Improved hasNoMeaningfulDiffContent for better performance

These changes prevent noisy diffs when files only differ in line endings or trailing whitespace, particularly important for cross-platform development where CRLF/LF differences are common.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ignore newline-at-EOF and other non-content markers to reduce diff noise.
  * Filter out line-ending-only and whitespace-only changes; improved pairing of removals/additions to avoid false positives.

* **New Features**
  * Collapse identical trimmed -/+ pairs into single context lines.
  * Normalize and clean diffs so identical content (post-normalization) yields empty diffs.

* **Tests**
  * Comprehensive test suite added to validate diff normalization, filtering, and edge cases.

* **Chores**
  * Added Jest config and test script for running the new tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->