### PR TITLE
:seedling:  Add authentication and token refresh logic to MCPClient

### DIFF
--- a/tests/mcp-client/mcp-client.model.ts
+++ b/tests/mcp-client/mcp-client.model.ts
@@ -2,19 +2,87 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { z } from 'zod';
 import { BestHintResponse, SuccessRateResponse } from './mcp-client-responses.model';
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 export class MCPClient {
   private readonly url: string;
   private transport: StreamableHTTPClientTransport;
   private client?: Client;
+  private token?: string;
 
-  constructor(url: string) {
+  constructor(url: string, bearerToken?: string) {
     this.url = url;
-    this.transport = new StreamableHTTPClientTransport(new URL(this.url));
+    this.token = bearerToken;
+    const headers: Record<string, string> = {};
+    if (this.token) {
+      headers['Authorization'] = `Bearer ${this.token}`;
+    }
+
+    this.transport = new StreamableHTTPClientTransport(new URL(this.url), {
+      requestInit: {
+        headers,
+      },
+    });
   }
 
-  public static async connect(url: string) {
-    const mcpClient = new MCPClient(url);
+  private async refreshToken(): Promise<void> {
+    try {
+      const newToken = await MCPClient.exchangeForTokens();
+      this.token = newToken;
+
+      this.transport = new StreamableHTTPClientTransport(new URL(this.url), {
+        requestInit: {
+          headers: { Authorization: `Bearer ${newToken}` },
+        },
+      });
+      await this.client?.connect(this.transport);
+
+      console.log('✅ Token refreshed successfully');
+    } catch (err) {
+      console.error('Failed to refresh token:', err);
+    }
+  }
+
+  private static async exchangeForTokens(): Promise<string> {
+    const serverUrl = process.env.SOLUTION_SERVER_URL!;
+    const realm = process.env.SOLUTION_SERVER_REALM!;
+    const username = process.env.SOLUTION_SERVER_USERNAME!;
+    const password = process.env.SOLUTION_SERVER_PASSWORD!;
+
+    const url = new URL(serverUrl);
+    const keycloakUrl = `${url.protocol}//${url.host}/auth`;
+    const tokenUrl = `${keycloakUrl}/realms/${realm}/protocol/openid-connect/token`;
+
+    const params = new URLSearchParams();
+    params.append('grant_type', 'password');
+    params.append('client_id', `${realm}-ui`);
+    params.append('username', username);
+    params.append('password', password);
+
+    const response = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: params,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Auth failed ${response.status}: ${text.slice(0, 200)}`);
+    }
+
+    const { access_token } = await response.json();
+    return access_token;
+  }
+
+  public static async connect(url: string, bearerToken?: string) {
+    let token: string | undefined;
+    if (!url.includes('localhost')) {
+      token = await MCPClient.exchangeForTokens();
+    }
+    const mcpClient = new MCPClient(url, token);
     mcpClient.client = new Client(
       {
         name: 'testing-mcp-client',
@@ -30,9 +98,13 @@ export class MCPClient {
 
     try {
       await mcpClient.client.connect(mcpClient.transport);
+      console.log('Connected successfully to Solution Server');
+      setInterval(() => {
+        mcpClient.refreshToken().catch((e) => console.error('Token refresh failed:', e));
+      }, 50_000);
       return mcpClient;
     } catch (error) {
-      throw Error(`Failed to connect to the MCP server with error ${error}`);
+      throw new Error(`Failed to connect to the MCP server: ${(error as Error).message}`);
     }
   }
 


### PR DESCRIPTION
### Summary
This PR adds full authentication support for connecting the MCP client to the remote Solution Server hosted on OpenShift.

### Changes
- Implemented **Keycloak token exchange** (`exchangeForTokens`) to retrieve a real access token using username/password credentials from `.env`.
- Added dynamic **Authorization header** injection into `StreamableHTTPClientTransport` when a token is available.
- Added **automatic token refresh** using `setInterval()` to prevent session expiration during tests.
- Improved connection logic in `MCPClient.connect()` to handle secure, authenticated sessions.
- Removed reliance on static or fake bearer tokens in tests.

### Result
The MCP client can now authenticate, connect, and maintain an active session with the Solution Server in OpenShift using real Keycloak credentials.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bearer token authentication support for client connections.
  * Implemented automatic token refresh mechanism.
  * Added OAuth2 token exchange capability for authentication servers.
  * Enhanced error messaging for connection failures.

* **Chores**
  * Updated environment configuration for TLS handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->