### PR TITLE
:test_tube:  Automate mcp client auth

### DIFF
--- a/tests/.env.example
+++ b/tests/.env.example
@@ -18,7 +18,7 @@
 
 # OPENAI_API_KEY="sk-proj-something"
 
-# Name of the bucket to store evaluator results
+# Name of the bucket to store the evaluator results in
 # KAI_QE_S3_BUCKET_NAME="exampleBucket"
 
 # Default REPO used for testing
@@ -34,8 +34,14 @@
 # WEB_LOGIN="user"
 # WEB_PASSWORD="password"
 
-# Solution Server configuration
-# SOLUTION_SERVER_URL='https://tackle-konveyor-tackle.apps.mig08.rhos-psi.cnv-qe.rhood.us/hub/services/kai/api/'
-# SOLUTION_SERVER_REALM='tackle'
-# SOLUTION_SERVER_USERNAME='admin'
-# SOLUTION_SERVER_PASSWORD='Dog8code'
+#####################################
+### SOLUTION SERVER CONFIGURATION ###
+#####################################
+
+# SOLUTION_SERVER_URL="https://your-solution-server.com"
+# SOLUTION_SERVER_USERNAME="username"
+# SOLUTION_SERVER_PASSWORD="password"
+# SOLUTION_SERVER_REALM="your-realm"
+# SOLUTION_SERVER_INSECURE=true
+# SOLUTION_SERVER_LOCAL=false
+# LOCAL_MCP_TOKEN="your-local-mcp-token"


### PR DESCRIPTION
### **Summary**
Adds full authentication support for connecting the MCP Client to the remote Solution Server running on OpenShift.

---

### **Changes**
- Implemented Keycloak-based authentication and automatic token refresh.  
- Added dynamic Authorization header injection into `StreamableHTTPClientTransport`.  
- Enhanced `MCPClient.connect()` to support secure remote and local modes.  
- Removed reliance on static bearer tokens in tests.  
- Updated `.env.example` with Solution Server configuration variables.

---

### **Result**
The MCP Client can now securely authenticate, connect, and maintain an active session with the Solution Server using real Keycloak credentials.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Introduced token-based authentication with bearer token and refresh token flow
  - Added local mode connection support
  - Implemented automatic token expiry handling and refresh mechanism
  - Added TLS verification bypass option for local development

* **Documentation**
  - Updated configuration example with generic placeholder values

* **Refactor**
  - Made URL parameter optional in the connect method

<!-- end of auto-generated comment: release notes by coderabbit.ai -->