### PR TITLE
:bug: Add provider check to fix race condition on server start

### DIFF
--- a/vscode/core/src/client/analyzerClient.ts
+++ b/vscode/core/src/client/analyzerClient.ts
@@ -337,6 +337,10 @@ export class AnalyzerClient {
     return !!this.analyzerRpcServer && !this.analyzerRpcServer.killed;
   }
 
+  public getRegisteredProviders() {
+    return this.providerRegistry.getProviders();
+  }
+
   public async notifyFileChanges(fileChanges: FileChange[]): Promise<void> {
     if (this.serverState !== "running" || !this.analyzerRpcConnection) {
       this.logger.warn("kai rpc server is not running, skipping notifyFileChanged.");

--- a/vscode/core/src/commands.ts
+++ b/vscode/core/src/commands.ts
@@ -57,6 +57,23 @@ export function executeExtensionCommand(commandSuffix: string, ...args: any[]): 
 }
 
 /**
+ * Check if any language providers are registered before starting analyzer
+ * @returns true if providers are registered, false if not (and shows warning)
+ */
+function checkProvidersRegistered(state: ExtensionState, logger: Logger): boolean {
+  const providers = state.analyzerClient.getRegisteredProviders();
+  if (providers.length === 0) {
+    const message =
+      "No language providers are registered yet. Please wait for language extensions " +
+      "(e.g., Konveyor Java) to finish loading before starting the analyzer.";
+    logger.warn(message);
+    vscode.window.showWarningMessage(message);
+    return false;
+  }
+  return true;
+}
+
+/**
  * Helper function to execute deferred workflow disposal after solution completes
  */
 function executeDeferredWorkflowDisposal(state: ExtensionState, logger: Logger): void {
@@ -84,6 +101,11 @@ const commandsMap: (
     },
     [`${EXTENSION_NAME}.startServer`]: async () => {
       const analyzerClient = state.analyzerClient;
+
+      if (!checkProvidersRegistered(state, logger)) {
+        return;
+      }
+
       if (!(await analyzerClient.canAnalyzeInteractive())) {
         return;
       }
@@ -106,6 +128,10 @@ const commandsMap: (
       try {
         if (analyzerClient.isServerRunning()) {
           await analyzerClient.stop();
+        }
+
+        if (!checkProvidersRegistered(state, logger)) {
+          return;
         }
 
         if (!(await analyzerClient.canAnalyzeInteractive())) {


### PR DESCRIPTION
Resolves https://github.com/konveyor/editor-extensions/issues/989
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to query the status of registered language providers

* **Bug Fixes**
  * Server startup and restart commands now validate that language providers are registered before proceeding, preventing errors and displaying user-friendly warnings when providers are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->