### PR TITLE
:ghost: Revert ":bug: Add provider check to fix race condition on server star…

### DIFF
--- a/vscode/core/src/client/analyzerClient.ts
+++ b/vscode/core/src/client/analyzerClient.ts
@@ -337,10 +337,6 @@ export class AnalyzerClient {
     return !!this.analyzerRpcServer && !this.analyzerRpcServer.killed;
   }
 
-  public getRegisteredProviders() {
-    return this.providerRegistry.getProviders();
-  }
-
   public async notifyFileChanges(fileChanges: FileChange[]): Promise<void> {
     if (this.serverState !== "running" || !this.analyzerRpcConnection) {
       this.logger.warn("kai rpc server is not running, skipping notifyFileChanged.");

--- a/vscode/core/src/commands.ts
+++ b/vscode/core/src/commands.ts
@@ -57,23 +57,6 @@ export function executeExtensionCommand(commandSuffix: string, ...args: any[]): 
 }
 
 /**
- * Check if any language providers are registered before starting analyzer
- * @returns true if providers are registered, false if not (and shows warning)
- */
-function checkProvidersRegistered(state: ExtensionState, logger: Logger): boolean {
-  const providers = state.analyzerClient.getRegisteredProviders();
-  if (providers.length === 0) {
-    const message =
-      "No language providers are registered yet. Please wait for language extensions " +
-      "(e.g., Konveyor Java) to finish loading before starting the analyzer.";
-    logger.warn(message);
-    vscode.window.showWarningMessage(message);
-    return false;
-  }
-  return true;
-}
-
-/**
  * Helper function to execute deferred workflow disposal after solution completes
  */
 function executeDeferredWorkflowDisposal(state: ExtensionState, logger: Logger): void {
@@ -101,11 +84,6 @@ const commandsMap: (
     },
     [`${EXTENSION_NAME}.startServer`]: async () => {
       const analyzerClient = state.analyzerClient;
-
-      if (!checkProvidersRegistered(state, logger)) {
-        return;
-      }
-
       if (!(await analyzerClient.canAnalyzeInteractive())) {
         return;
       }
@@ -128,10 +106,6 @@ const commandsMap: (
       try {
         if (analyzerClient.isServerRunning()) {
           await analyzerClient.stop();
-        }
-
-        if (!checkProvidersRegistered(state, logger)) {
-          return;
         }
 
         if (!(await analyzerClient.canAnalyzeInteractive())) {


### PR DESCRIPTION
…t (#988)"

This reverts commit 936b89aa9547497371e0b774bd71da620a32a7a9.

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified analyzer server start and restart command flows by removing the prerequisite check for registered language providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->