### PR TITLE
:bug: fixing the javascript extension to pass config correctly to provider

### DIFF
--- a/vscode/javascript/src/extension.ts
+++ b/vscode/javascript/src/extension.ts
@@ -104,7 +104,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const providerDisposable = coreApi.registerProvider({
     name: "javascript",
     providerConfig: {
-      name: "javascript",
+      name: "nodejs",
       address: providerAddress, // GRPC socket address
       useSocket: true,
       initConfig: [

--- a/vscode/javascript/src/vscodeProxyServer.ts
+++ b/vscode/javascript/src/vscodeProxyServer.ts
@@ -28,7 +28,7 @@ export class vscodeProxyServer implements vscode.Disposable {
   async start(): Promise<void> {
     return new Promise((resolve, reject) => {
       this.server = createServer((socket: Socket) => {
-        this.logger.info("Java external provider connected to LSP proxy");
+        this.logger.info("Javascript external provider connected to LSP proxy");
         this.handleConnection(socket);
       });
 
@@ -128,7 +128,7 @@ export class vscodeProxyServer implements vscode.Disposable {
 
     // Handle connection close
     connection.onClose(() => {
-      this.logger.info("Java external provider disconnected from LSP proxy");
+      this.logger.info("Javascript external provider disconnected from LSP proxy");
       this.connections.delete(connection);
     });
 


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->

Fixes the provider config to pass the correct (for the generic provider) config value to start the javascript language server.
Also found two invalid logs that needed updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected internal provider configuration and logging messages in the JavaScript extension to ensure accurate identification and troubleshooting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->