### PR TITLE
:ghost: Add stale PR/Issue check to github actions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,43 @@
+name: Close Stale Issues
+
+on:
+  schedule:
+    # Run daily at 1:30 AM UTC
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    name: Close Stale Issues
+    steps:
+      - name: Close Stale Issues
+        uses: actions/stale@v10.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed if no further activity occurs within 7 days.
+            Thank you for your contributions.
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had recent activity.
+            It will be closed if no further activity occurs within 7 days.
+            Thank you for your contributions.
+          close-issue-message: |
+            This issue was automatically closed due to inactivity.
+            If you believe this issue is still relevant, please reopen it.
+          close-pr-message: |
+            This pull request was automatically closed due to inactivity.
+            If this PR is still relevant, please reopen it.
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+          days-before-stale: 60
+          days-before-close: 7
+          remove-stale-when-updated: true
+          operations-per-run: 30
+          exempt-issue-labels: "pinned,security,enhancement"
+          exempt-pr-labels: "pinned,security,work-in-progress"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated repository maintenance workflow to proactively manage repository health by identifying and handling inactive issues and pull requests, automatically marking stale content with labels and closing after configured inactivity periods, complete with customizable notification messages and exemption options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->