### PR TITLE
:ghost: Package-lock.json bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
       },
       "engines": {
         "node": ">=22.9.0",
-        "npm": "^9.5.0 || >=10.5.2",
+        "npm": ">=10.5.2",
         "vscode": "^1.93.0"
       },
       "optionalDependencies": {


### PR DESCRIPTION
This is out of sync after merging [👻 Standardizing npm to version 10.5.2+ to prevent package-lock.json format inconsistencies](https://github.com/konveyor/editor-extensions/pull/1012)