### PR TITLE
:bug: Remove tooltip for config button

### DIFF
--- a/webview-ui/src/components/AnalysisPage/ConfigButton/ConfigButton.tsx
+++ b/webview-ui/src/components/AnalysisPage/ConfigButton/ConfigButton.tsx
@@ -1,6 +1,6 @@
 import "./configButton.css";
 import React from "react";
-import { Button, Icon, Tooltip } from "@patternfly/react-core";
+import { Button, Icon } from "@patternfly/react-core";
 import CogIcon from "@patternfly/react-icons/dist/esm/icons/cog-icon";
 import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
 
@@ -16,20 +16,20 @@ export function ConfigButton({
   warningMessage = "Configuration needs attention",
 }: ConfigButtonProps) {
   return (
-    <Tooltip content={hasWarning ? warningMessage : "Configuration"} position="bottom">
-      <Button
-        variant="plain"
-        onClick={onClick}
-        aria-label="Configuration"
-        className="config-button"
-      >
-        <span className="config-button__icon-wrapper">
-          <Icon isInline>
-            <CogIcon />
-          </Icon>
-          {hasWarning && <ExclamationTriangleIcon className="config-button__warning-icon" />}
-        </span>
-      </Button>
-    </Tooltip>
+    <Button
+      variant="plain"
+      onClick={onClick}
+      aria-label={
+        hasWarning ? (warningMessage ?? "Configuration needs attention") : "Configuration"
+      }
+      className="config-button"
+    >
+      <span className="config-button__icon-wrapper">
+        <Icon isInline>
+          <CogIcon />
+        </Icon>
+        {hasWarning && <ExclamationTriangleIcon className="config-button__warning-icon" />}
+      </span>
+    </Button>
   );
 }


### PR DESCRIPTION
Currently, hovering over the agent toggle causes the config button tooltip to render. This blocks the agent mode toggle from being clickable. 

Before:


https://github.com/user-attachments/assets/f706da31-4ca1-4a68-a322-92cfed88b070



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced accessibility for the configuration button with improved aria-label messaging that dynamically reflects the current state, including warning status notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->