### PR TITLE
:bug: (Backport) Address ECONNRESET when http2 blocked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1916,6 +1916,13 @@
       "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==",
       "license": "MIT"
     },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
@@ -9028,6 +9035,24 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {
@@ -23214,6 +23239,94 @@
         "vscode": "^1.93.0"
       }
     },
+<<<<<<< HEAD
+=======
+    "vscode/core": {
+      "name": "konveyor",
+      "version": "0.4.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "@types/mustache": "^4.2.5",
+        "adm-zip": "^0.5.16",
+        "diff": "^7.0.0",
+        "jsesc": "^3.1.0",
+        "mustache": "^4.2.0",
+        "undici": "^7.14.0",
+        "winston": "^3.17.0",
+        "winston-transport-vscode": "^0.1.0"
+      },
+      "devDependencies": {
+        "@types/adm-zip": "^0.5.7",
+        "@types/diff": "^6.0.0",
+        "@types/express": "^5.0.3",
+        "@types/jsesc": "^3.0.3",
+        "@types/uuid": "^10.0.0",
+        "@types/vscode": "^1.93.0",
+        "@vscode/test-cli": "^0.0.10",
+        "@vscode/test-electron": "^2.4.1",
+        "copy-webpack-plugin": "^12.0.2",
+        "cross-env": "^10.1.0",
+        "css-loader": "^7.1.2",
+        "express": "^5.1.0",
+        "style-loader": "^4.0.0",
+        "ts-loader": "^9.5.1",
+        "webpack": "^5.94.0",
+        "webpack-cli": "^5.1.4"
+      },
+      "engines": {
+        "node": ">=22.9.0",
+        "npm": "^9.5.0 || >=10.5.2",
+        "vscode": "^1.93.0"
+      }
+    },
+    "vscode/java": {
+      "name": "konveyor-java",
+      "version": "0.4.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "vscode-jsonrpc": "^8.2.1",
+        "winston": "^3.17.0",
+        "winston-transport-vscode": "^0.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.9.0",
+        "@types/vscode": "^1.93.0",
+        "ts-loader": "^9.5.1",
+        "webpack": "^5.94.0",
+        "webpack-cli": "^5.1.4"
+      },
+      "engines": {
+        "node": ">=22.9.0",
+        "npm": "^9.5.0 || >=10.5.2",
+        "vscode": "^1.93.0"
+      }
+    },
+    "vscode/javascript": {
+      "name": "konveyor-javascript",
+      "version": "0.4.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "vscode-jsonrpc": "^8.2.1",
+        "vscode-languageclient": "^9.0.1",
+        "vscode-languageserver-types": "^3.17.5",
+        "winston": "^3.17.0",
+        "winston-transport-vscode": "^0.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.9.0",
+        "@types/vscode": "^1.93.0",
+        "ts-loader": "^9.5.1",
+        "webpack": "^5.94.0",
+        "webpack-cli": "^5.1.4"
+      },
+      "engines": {
+        "node": ">=22.9.0",
+        "npm": "^9.5.0 || >=10.5.2",
+        "vscode": "^1.93.0"
+      }
+    },
+>>>>>>> a4592ee5 (:bug: Address ECONNRESET when http2 blocked)
     "vscode/node_modules/@types/uuid": {
       "version": "10.0.0",
       "dev": true,

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -364,6 +364,21 @@
           "scope": "window",
           "order": 26
         },
+        "konveyor.genai.httpProtocol": {
+          "type": "string",
+          "enum": [
+            "http1",
+            "http2"
+          ],
+          "default": "http1",
+          "enumDescriptions": [
+            "HTTP/1.1 - Compatible with all networks, including restrictive corporate firewalls (default)",
+            "HTTP/2 - Better performance and efficiency, but may be blocked by some firewalls"
+          ],
+          "description": "HTTP protocol version for AI model provider connections",
+          "scope": "window",
+          "order": 27
+        },
         "konveyor.solutionServer": {
           "type": "object",
           "description": "Configuration for the MCP solution server. Set 'enabled: true' to enable, 'url' for server endpoint, and configure 'auth' object with 'enabled: true', 'realm' (default: tackle), and 'insecure: true' to skip SSL verification if needed.",
@@ -433,7 +448,7 @@
     "dev": "webpack --watch --mode development",
     "pretest": "npm run build",
     "test": "npm run test:unit-tests && npm run test:integration",
-    "test:unit-tests": "mocha",
+    "test:unit-tests": "cross-env NODE_ENV=test mocha",
     "test:integration": "vscode-test"
   },
   "lint-staged": {
@@ -450,6 +465,7 @@
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.4.1",
     "copy-webpack-plugin": "^12.0.2",
+    "cross-env": "^10.1.0",
     "css-loader": "^7.1.2",
     "express": "^5.1.0",
     "style-loader": "^4.0.0",

--- a/vscode/src/modelProvider/modelCreator.ts
+++ b/vscode/src/modelProvider/modelCreator.ts
@@ -3,11 +3,17 @@ import { ChatOllama } from "@langchain/ollama";
 import { ChatDeepSeek } from "@langchain/deepseek";
 import { AzureChatOpenAI, ChatOpenAI } from "@langchain/openai";
 import { ChatBedrockConverse, type ChatBedrockConverseInput } from "@langchain/aws";
+import { BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime";
 import { ChatGoogleGenerativeAI, type GoogleGenerativeAIChatInput } from "@langchain/google-genai";
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 
-import { getDispatcherWithCertBundle, getFetchWithDispatcher } from "../utilities/tls";
+import {
+  getDispatcherWithCertBundle,
+  getFetchWithDispatcher,
+  getNodeHttpHandler,
+} from "../utilities/tls";
 import { ModelCreator, PROVIDER_ENV_CA_BUNDLE, PROVIDER_ENV_INSECURE, type FetchFn } from "./types";
+import { getConfigHttpProtocol } from "../utilities/httpProtocol";
 
 export const ModelCreators: Record<string, (logger: Logger) => ModelCreator> = {
   AzureChatOpenAI: (logger) => new AzureChatOpenAICreator(logger),
@@ -22,12 +28,14 @@ class AzureChatOpenAICreator implements ModelCreator {
   constructor(private readonly logger: Logger) {}
 
   async create(args: Record<string, any>, env: Record<string, string>): Promise<BaseChatModel> {
+    const httpProtocol = getConfigHttpProtocol();
+    const allowH2 = httpProtocol === "http2";
     return new AzureChatOpenAI({
       openAIApiKey: env.AZURE_OPENAI_API_KEY,
       ...args,
       configuration: {
         ...args.configuration,
-        fetch: await getFetchFn(env, this.logger),
+        fetch: await getFetchFn(env, this.logger, allowH2),
       },
     });
   }
@@ -59,6 +67,8 @@ class ChatBedrockCreator implements ModelCreator {
   constructor(private readonly logger: Logger) {}
 
   async create(args: Record<string, any>, env: Record<string, string>): Promise<BaseChatModel> {
+    const httpProtocol = getConfigHttpProtocol();
+
     const config: ChatBedrockConverseInput = {
       ...args,
       region: env.AWS_DEFAULT_REGION,
@@ -70,6 +80,18 @@ class ChatBedrockCreator implements ModelCreator {
         secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
       };
     }
+
+    // Always create a custom client with the appropriate protocol
+    // Only use default client (HTTP/2) if explicitly set to "http2"
+    const httpVersion = httpProtocol === "http2" ? "2.0" : "1.1";
+    const requestHandler = await getNodeHttpHandler(env, this.logger, httpVersion);
+    const runtimeClient = new BedrockRuntimeClient({
+      region: env.AWS_DEFAULT_REGION,
+      credentials: config.credentials,
+      requestHandler,
+    });
+    config.client = runtimeClient;
+
     return new ChatBedrockConverse(config);
   }
 
@@ -89,12 +111,14 @@ class ChatDeepSeekCreator implements ModelCreator {
   constructor(private readonly logger: Logger) {}
 
   async create(args: Record<string, any>, env: Record<string, string>): Promise<BaseChatModel> {
+    const httpProtocol = getConfigHttpProtocol();
+    const allowH2 = httpProtocol === "http2";
     return new ChatDeepSeek({
       apiKey: env.DEEPSEEK_API_KEY,
       ...args,
       configuration: {
         ...args.configuration,
-        fetch: await getFetchFn(env, this.logger),
+        fetch: await getFetchFn(env, this.logger, allowH2),
       },
     });
   }
@@ -142,9 +166,11 @@ class ChatOllamaCreator implements ModelCreator {
   constructor(private readonly logger: Logger) {}
 
   async create(args: Record<string, any>, env: Record<string, string>): Promise<BaseChatModel> {
+    const httpProtocol = getConfigHttpProtocol();
+    const allowH2 = httpProtocol === "http2";
     return new ChatOllama({
       ...args,
-      fetch: await getFetchFn(env, this.logger),
+      fetch: await getFetchFn(env, this.logger, allowH2),
     });
   }
 
@@ -164,12 +190,14 @@ class ChatOpenAICreator implements ModelCreator {
   constructor(private readonly logger: Logger) {}
 
   async create(args: Record<string, any>, env: Record<string, string>): Promise<BaseChatModel> {
+    const httpProtocol = getConfigHttpProtocol();
+    const allowH2 = httpProtocol === "http2";
     return new ChatOpenAI({
       openAIApiKey: env.OPENAI_API_KEY,
       ...args,
       configuration: {
         ...args.configuration,
-        fetch: await getFetchFn(env, this.logger),
+        fetch: await getFetchFn(env, this.logger, allowH2),
       },
     });
   }
@@ -220,19 +248,31 @@ function getCaBundleAndInsecure(env: Record<string, string>): {
 async function getFetchFn(
   env: Record<string, string>,
   logger: Logger,
+  allowH2: boolean = false,
 ): Promise<FetchFn | undefined> {
   const { caBundle, insecure } = getCaBundleAndInsecure(env);
-  if (caBundle) {
+
+  // We need a custom dispatcher in these cases:
+  // 1. Custom CA bundle is provided
+  // 2. Insecure mode is enabled (skip TLS verification)
+  // 3. HTTP/1.1 is requested (allowH2 = false)
+  //
+  // Only skip custom dispatcher when:
+  // - Using HTTP/2 (allowH2 = true) AND
+  // - No custom CA bundle AND
+  // - Not in insecure mode
+  const needsCustomDispatcher = caBundle || insecure || !allowH2;
+
+  if (needsCustomDispatcher) {
     try {
-      const dispatcher = await getDispatcherWithCertBundle(caBundle, insecure);
+      const dispatcher = await getDispatcherWithCertBundle(caBundle, insecure, allowH2);
       return getFetchWithDispatcher(dispatcher);
     } catch (error) {
       logger.error(error);
-      throw new Error(`Failed to setup CA bundle ${String(error)}`);
+      throw new Error(`Failed to setup dispatcher: ${String(error)}`);
     }
-  } else if (insecure) {
-    const dispatcher = await getDispatcherWithCertBundle(undefined, insecure);
-    return getFetchWithDispatcher(dispatcher);
   }
+
+  // Return undefined to use LangChain's default fetch (supports HTTP/2)
   return undefined;
 }

--- a/vscode/src/utilities/httpProtocol.ts
+++ b/vscode/src/utilities/httpProtocol.ts
@@ -1,0 +1,13 @@
+// HTTP protocol configuration getter
+// Separate file to avoid vscode import in test environments
+
+export function getConfigHttpProtocol(): "http1" | "http2" {
+  if (process.env.NODE_ENV === "test") {
+    return "http1";
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const vscode = require("vscode");
+  const config = vscode.workspace.getConfiguration("konveyor");
+  return config.get("genai.httpProtocol", "http1");
+}

--- a/vscode/src/utilities/tls.ts
+++ b/vscode/src/utilities/tls.ts
@@ -3,10 +3,13 @@ import fs from "fs/promises";
 import { Agent as HttpsAgent } from "node:https";
 import { Agent as UndiciAgent } from "undici";
 import type { Dispatcher as UndiciTypesDispatcher } from "undici-types";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import type { Logger } from "winston";
 
 export async function getDispatcherWithCertBundle(
   bundlePath: string | undefined,
   insecure: boolean = false,
+  allowH2: boolean = false,
 ): Promise<UndiciTypesDispatcher> {
   let allCerts: string | undefined;
   if (bundlePath) {
@@ -19,6 +22,7 @@ export async function getDispatcherWithCertBundle(
       ca: allCerts,
       rejectUnauthorized: !insecure,
     },
+    allowH2,
   }) as unknown as UndiciTypesDispatcher;
 }
 
@@ -50,4 +54,48 @@ export function getFetchWithDispatcher(
       } as any,
     );
   };
+}
+
+export async function getNodeHttpHandler(
+  env: Record<string, string>,
+  logger: Logger,
+  httpVersion: "1.1" | "2.0" = "1.1",
+): Promise<NodeHttpHandler> {
+  const caBundle = env["CA_BUNDLE"] || env["AWS_CA_BUNDLE"];
+  const insecureRaw =
+    env["ALLOW_INSECURE"] || env["NODE_TLS_REJECT_UNAUTHORIZED"] === "0" ? "true" : undefined;
+  let insecure = false;
+  if (insecureRaw && insecureRaw.match(/^(true|1)$/i)) {
+    insecure = true;
+  }
+
+  let allCerts: string | undefined;
+  if (caBundle) {
+    try {
+      const defaultCerts = tls.rootCertificates.join("\n");
+      const certs = await fs.readFile(caBundle, "utf8");
+      allCerts = [defaultCerts, certs].join("\n");
+    } catch (error) {
+      logger.error(error);
+      throw new Error(`Failed to read CA bundle: ${String(error)}`);
+    }
+  }
+
+  const agentOptions: any = {
+    ca: allCerts,
+    rejectUnauthorized: !insecure,
+    // Configure HTTP version using ALPN
+    ...(httpVersion === "1.1"
+      ? {
+          ALPNProtocols: ["http/1.1"],
+        }
+      : {
+          ALPNProtocols: ["h2", "http/1.1"], // Allow HTTP/2 with fallback
+        }),
+  };
+
+  return new NodeHttpHandler({
+    httpsAgent: new HttpsAgent(agentOptions),
+    requestTimeout: 30000,
+  });
 }


### PR DESCRIPTION
## Summary
Adds HTTP protocol version configuration to fix connection failures in enterprise environments that block HTTP/2.

Fixes #1030

## Problem
- Corporate firewalls block HTTP/2 traffic → AWS Bedrock connections fail with `ECONNRESET`
- No automatic fallback possible when connections are killed at TLS handshake

## Solution
New setting `konveyor.genai.httpProtocol`:
- `"http1"` (default) - Forces HTTP/1.1, works everywhere
- `"http2"` - Allows HTTP/2, better performance if supported

## Changes
- ➕ Add configuration setting in `package.json`
- ➕ Add `httpProtocol.ts` utility
- 🔧 Update all model providers to respect HTTP protocol setting
- 🔧 Configure ALPN protocols to enforce HTTP version

## Testing
Tested with `mitmproxy --set http2=false` (simulates firewall):
- Corporate firewalls terminate connections during TLS handshake when they see ‘h2’ in ALPN, resulting in ECONNRESET with no recovery possible.
- The automatic fallback  observed with mitmproxy occurs at the HTTP layer after successful TLS negotiation

## Impact
Enterprise users behind restrictive firewalls can now use AI features by forcing HTTP/1.1.