### PR TITLE
:bug: add documentSymbol search, do not respond to workspace/symbol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23321,7 +23321,6 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@editor-extensions/shared": "*",
         "vscode-jsonrpc": "^8.2.1",
         "winston": "^3.17.0",
         "winston-transport-vscode": "^0.1.0"

--- a/vscode/javascript/src/extension.ts
+++ b/vscode/javascript/src/extension.ts
@@ -123,6 +123,9 @@ export async function activate(context: vscode.ExtensionContext) {
           location: workspaceLocation,
           analysisMode: "source-only",
           pipeName: lspProxySocketPath, // JSON-RPC socket for vscode proxy communication
+          providerSpecificConfig: {
+            lspServerName: "nodejs",
+          },
         },
       ],
       contextLines: 10,


### PR DESCRIPTION
Requires https://github.com/konveyor/kai/pull/899


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved document symbol resolution and navigation with enhanced error handling.
  * Refined definition lookup to better support multiple result types, providing more reliable "Go to Definition" functionality.

* **Chores**
  * Updated provider initialization configuration for internal compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->