### PR TITLE
:sparkles:  (backport) Enhance TLS handling with proxy support and improved error reporting for analyzer binary downloads 

### DIFF
--- a/vscode/src/utilities/tls.ts
+++ b/vscode/src/utilities/tls.ts
@@ -7,12 +7,6 @@ import { NodeHttpHandler, NodeHttp2Handler } from "@smithy/node-http-handler";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import type { Logger } from "winston";
 
-/**
- * Creates an undici dispatcher for fetch-based HTTP clients.
- * Used by: OpenAI, Azure OpenAI, Ollama, DeepSeek
- *
- * @param allowH2 - Enable HTTP/2 support in undici client and proxy
- */
 export async function getDispatcherWithCertBundle(
   bundlePath: string | undefined,
   insecure: boolean = false,
@@ -20,13 +14,10 @@ export async function getDispatcherWithCertBundle(
 ): Promise<UndiciTypesDispatcher> {
   let allCerts: string[] | undefined;
   if (bundlePath) {
-    // Load custom certificate and combine with Node.js defaults as an array
-    // undici expects an array of certificate strings, not a concatenated string
     const customCert = await fs.readFile(bundlePath, "utf8");
     allCerts = [...tls.rootCertificates, customCert];
   }
 
-  // Check for proxy configuration
   const proxyUrl =
     process.env.HTTPS_PROXY ||
     process.env.https_proxy ||
@@ -34,10 +25,9 @@ export async function getDispatcherWithCertBundle(
     process.env.http_proxy;
 
   if (proxyUrl) {
-    // Use ProxyAgent when proxy is configured
     return new ProxyAgent({
       uri: proxyUrl,
-      allowH2, // Pass through HTTP/2 preference!
+      allowH2,
       connect: {
         ca: allCerts,
         rejectUnauthorized: !insecure,
@@ -60,7 +50,6 @@ export async function getHttpsAgentWithCertBundle(
 ): Promise<HttpsAgent> {
   let allCerts: string[] | undefined;
   if (bundlePath) {
-    // Load custom certificate and combine with Node.js defaults as an array
     const customCert = await fs.readFile(bundlePath, "utf8");
     allCerts = [...tls.rootCertificates, customCert];
   }


### PR DESCRIPTION
- # Fix: Binary Download Failures Behind Corporate Firewalls/Proxies

## Problem

Users behind corporate firewalls with SSL-inspecting proxies were experiencing binary download failures during extension activation:

```
UNABLE_TO_VERIFY_LEAF_SIGNATURE
UND_ERR_ABORTED
407 Proxy Authentication Required
```

### Root Causes

1. **No Proxy Support in Binary Downloads**: The `ensureKaiAnalyzerBinary()` function in `paths.ts` was using plain `fetch()` without any proxy configuration, causing downloads to fail when users had `HTTPS_PROXY` environment variables set.

2. **Custom CA Certificates Not Respected**: When enterprises use SSL-inspecting proxies, they issue their own certificates. The download code wasn't loading custom CA certificates specified via `NODE_EXTRA_CA_CERTS`.

3. **Proxy Authentication Ignored**: Due to [undici issue #1674](https://github.com/nodejs/undici/issues/1674), credentials in proxy URLs like `http://username:password@proxy.company.com:8080` were being ignored, causing `407 Proxy Authentication Required` errors.

## Solution

### 1. Added Proxy Support to Binary Downloads (`paths.ts`)

- Import and use `getDispatcherWithCertBundle()` and `getFetchWithDispatcher()` from `utilities/tls.ts`
- Create a dispatcher that respects both `HTTPS_PROXY` environment variables and `NODE_EXTRA_CA_CERTS`
- Apply the dispatcher to both SHA256 checksum and binary downloads

**Before:**
```typescript
const response = await fetch(downloadUrl);
```

**After:**
```typescript
const certBundlePath = process.env.NODE_EXTRA_CA_CERTS;
const dispatcher = await getDispatcherWithCertBundle(certBundlePath, false, false);
const fetchWithDispatcher = getFetchWithDispatcher(dispatcher);
const response = await fetchWithDispatcher(downloadUrl);
```

### 2. Added Proxy Authentication Support (`utilities/tls.ts`)

Implemented the workaround from [undici issue #1674](https://github.com/nodejs/undici/issues/1674) to handle credentials in proxy URLs:

- Parse proxy URL to extract username and password
- Base64 encode credentials
- Pass to `ProxyAgent` via the `auth` option

```typescript
const parsedUrl = new URL(proxyUrl);
let auth: string | undefined;

if (parsedUrl.username || parsedUrl.password) {
  const credentials = `${parsedUrl.username}:${parsedUrl.password}`;
  auth = Buffer.from(credentials).toString('base64');
}

return new ProxyAgent({
  uri: proxyUrl,
  auth, // Proxy authentication now works!
  connect: {
    ca: allCerts,
    rejectUnauthorized: !insecure,
  },
});
```


## Supported Proxy Configurations

This fix now supports:

✅ **Explicit Proxy** (most common):
```bash
export HTTPS_PROXY=http://proxy.company.com:8080
export NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem
```

✅ **Proxy with Authentication**:
```bash
export HTTPS_PROXY=http://username:password@proxy.company.com:8080
export NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem
```

✅ **Transparent Proxy** (WireGuard/network-level):
```bash
export NODE_EXTRA_CA_CERTS=/path/to/proxy-ca.pem
# No HTTPS_PROXY needed - traffic routes through proxy at network level
```

## Impact

This fix resolves download failures for users in:
- Corporate environments with HTTP/HTTPS proxies
- Networks with SSL-inspecting firewalls
- Environments requiring custom CA certificates
- Proxies requiring authentication

## Related Issues

- Fixes binary download failures with `UNABLE_TO_VERIFY_LEAF_SIGNATURE`
- Fixes `UND_ERR_ABORTED` errors behind proxies

## Files Changed

- `editor-extensions/vscode/src/paths.ts`: Added proxy support to binary downloads
- `editor-extensions/vscode/src/utilities/tls.ts`: Added proxy authentication support

## Breaking Changes

None. This is a backward-compatible fix that adds support for proxy configurations without affecting existing functionality.
