### PR TITLE
:seedling: Update extension naming in activation error

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -11,6 +11,7 @@ import {
   EXTENSION_DISPLAY_NAME,
   EXTENSION_ID,
   EXTENSION_NAME,
+  EXTENSION_SHORT_NAME,
 } from "./utilities/constants";
 import {
   KaiInteractiveWorkflow,
@@ -978,8 +979,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   } catch (error) {
     await extension?.dispose();
     extension = undefined;
-    logger.error("Failed to activate Konveyor extension", error);
-    vscode.window.showErrorMessage(`Failed to activate Konveyor extension: ${error}`);
+    logger.error(`Failed to activate ${EXTENSION_SHORT_NAME} extension`, error);
+    vscode.window.showErrorMessage(
+      `Failed to activate ${EXTENSION_SHORT_NAME} extension: ${error}`,
+    );
     throw error; // Re-throw to ensure VS Code marks the extension as failed to activate
   }
 }


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
