### PR TITLE
:sparkles:  Enhance TLS handling with proxy support and improved error reporting for analyzer binary downloads

### DIFF
--- a/vscode/core/src/utilities/tls.ts
+++ b/vscode/core/src/utilities/tls.ts
@@ -13,17 +13,15 @@ export async function getDispatcherWithCertBundle(
   allowH2: boolean = false,
   logger?: Logger,
 ): Promise<UndiciTypesDispatcher> {
-  let allCerts: string | undefined;
+  let allCerts: string[] | undefined;
   if (bundlePath) {
     try {
-      const defaultCerts = tls.rootCertificates.join("\n");
-      const certs = await fs.readFile(bundlePath, "utf8");
-      allCerts = [defaultCerts, certs].join("\n");
+      const customCert = await fs.readFile(bundlePath, "utf8");
+      allCerts = [...tls.rootCertificates, customCert];
     } catch (error) {
       if (logger) {
         logger.error(`Failed to read CA bundle from ${bundlePath}: ${String(error)}`);
       }
-      allCerts = tls.rootCertificates.join("\n");
     }
   }
 


### PR DESCRIPTION
Add NODE_EXTRA_CA_CERT support for fetch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added download progress reporting with percentage and TTFB-based updates
  * Added support for proxy and custom CA certificates and optional modern HTTP/2 transfers
  * Shows firewall-buffering warnings during slow starts

* **Bug Fixes**
  * Enhanced download reliability with automatic retry logic and cleanup of partial downloads
  * Improved error messages with detailed troubleshooting guidance
  * Ensures verification, extraction, and executable permissions are handled correctly

* **Chores**
  * Adjusted CA bundle handling to treat certificates as a list and tightened error logging on bundle read failures

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->