### PR TITLE
:bug: Remove tooltip for config button (#1025)

### DIFF
--- a/webview-ui/src/components/AnalysisPage/ConfigButton/ConfigButton.tsx
+++ b/webview-ui/src/components/AnalysisPage/ConfigButton/ConfigButton.tsx
@@ -1,6 +1,6 @@
 import "./configButton.css";
 import React from "react";
-import { Button, Icon, Tooltip } from "@patternfly/react-core";
+import { Button, Icon } from "@patternfly/react-core";
 import CogIcon from "@patternfly/react-icons/dist/esm/icons/cog-icon";
 import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
 
@@ -16,20 +16,20 @@ export function ConfigButton({
   warningMessage = "Configuration needs attention",
 }: ConfigButtonProps) {
   return (
-    <Tooltip content={hasWarning ? warningMessage : "Configuration"} position="bottom">
-      <Button
-        variant="plain"
-        onClick={onClick}
-        aria-label="Configuration"
-        className="config-button"
-      >
-        <span className="config-button__icon-wrapper">
-          <Icon isInline>
-            <CogIcon />
-          </Icon>
-          {hasWarning && <ExclamationTriangleIcon className="config-button__warning-icon" />}
-        </span>
-      </Button>
-    </Tooltip>
+    <Button
+      variant="plain"
+      onClick={onClick}
+      aria-label={
+        hasWarning ? (warningMessage ?? "Configuration needs attention") : "Configuration"
+      }
+      className="config-button"
+    >
+      <span className="config-button__icon-wrapper">
+        <Icon isInline>
+          <CogIcon />
+        </Icon>
+        {hasWarning && <ExclamationTriangleIcon className="config-button__warning-icon" />}
+      </span>
+    </Button>
   );
 }


### PR DESCRIPTION
Currently, hovering over the agent toggle causes the config button tooltip to render. This blocks the agent mode toggle from being clickable.

Before:



https://github.com/user-attachments/assets/f706da31-4ca1-4a68-a322-92cfed88b070



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
* Enhanced accessibility for the configuration button with improved aria-label messaging that dynamically reflects the current state, including warning status notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
