### PR TITLE
:test_tube: Update extension urls fetching script

### DIFF
--- a/tests/scripts/set-latest-vsix-env.mjs
+++ b/tests/scripts/set-latest-vsix-env.mjs
@@ -5,8 +5,12 @@ const repoName = 'editor-extensions';
 const releaseTag = 'development-builds';
 
 /**
- * Gets the latest dev build from https://github.com/konveyor/editor-extensions/releases/tag/development-builds
- * and appends the link and vsix file name to the .env file
+ * Gets the latest dev builds from https://github.com/konveyor/editor-extensions/releases/tag/development-builds
+ * and appends the links and vsix file names to the .env file for each extension type:
+ * - CORE_VSIX_DOWNLOAD_URL (konveyor-X.X.X-dev.*.vsix)
+ * - JAVA_VSIX_DOWNLOAD_URL (konveyor-java-X.X.X-dev.*.vsix)
+ * - JAVASCRIPT_VSIX_DOWNLOAD_URL (konveyor-javascript-X.X.X-dev.*.vsix)
+ * - GO_VSIX_DOWNLOAD_URL (konveyor-go-X.X.X-dev.*.vsix)
  * @return {Promise<void>}
  */
 async function main() {
@@ -18,16 +22,38 @@ async function main() {
   }
 
   const data = await res.json();
-  console.log(data);
 
-  const asset = data.assets.findLast((a) => a.name.endsWith('.vsix'));
-  if (!asset) {
-    throw new Error('No .vsix asset found in release');
+  const vsixAssets = data.assets.filter((a) => a.name.endsWith('.vsix'));
+
+  // Define the patterns for each extension type
+  // Core: konveyor-X.X.X-dev.*.vsix (no language suffix after "konveyor-")
+  // Language-specific: konveyor-{language}-X.X.X-dev.*.vsix
+  const extensions = [
+    { name: 'CORE', pattern: /^konveyor-\d+\.\d+\.\d+-dev\..*\.vsix$/ },
+    { name: 'JAVA', pattern: /^konveyor-java-\d+\.\d+\.\d+-dev\..*\.vsix$/ },
+    { name: 'JAVASCRIPT', pattern: /^konveyor-javascript-\d+\.\d+\.\d+-dev\..*\.vsix$/ },
+    { name: 'GO', pattern: /^konveyor-go-\d+\.\d+\.\d+-dev\..*\.vsix$/ },
+  ];
+
+  let envContent = '\n';
+
+  for (const ext of extensions) {
+    // Filter assets matching the pattern, sort by created_at descending, take the first (latest)
+    const matchingAssets = vsixAssets
+      .filter((a) => ext.pattern.test(a.name))
+      .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+    const asset = matchingAssets[0];
+    if (!asset) {
+      console.warn(`No .vsix asset found for ${ext.name}`);
+      continue;
+    }
+    envContent += `${ext.name}_VSIX_DOWNLOAD_URL=${asset.browser_download_url}\n`;
+    console.log(`Found ${ext.name}: ${asset.name} (created: ${asset.created_at})`);
   }
 
-  const envContent = `\nCORE_VSIX_DOWNLOAD_URL=${asset.browser_download_url}\n`;
   appendFileSync('.env', envContent);
-  console.log('Generated .env with latest core VSIX url');
+  console.log('Generated .env with latest VSIX urls');
 }
 
 main().catch((err) => {


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test setup to support multiple extension types (CORE, JAVA, JAVASCRIPT, GO) with automatic selection of the latest version per type and improved diagnostic logging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->