### PR TITLE
:bug: Fix batch review state stuck after apply all 

### DIFF
--- a/vscode/core/src/webviewMessageHandler.ts
+++ b/vscode/core/src/webviewMessageHandler.ts
@@ -41,6 +41,7 @@ import {
 } from "./utilities/profiles/profileService";
 import { handleQuickResponse } from "./utilities/ModifiedFiles/handleQuickResponse";
 import { handleFileResponse } from "./utilities/ModifiedFiles/handleFileResponse";
+import { runPartialAnalysis } from "./analysis/runAnalysis";
 import winston from "winston";
 import { toggleAgentMode, updateConfigErrors } from "./utilities/configuration";
 import { saveHubConfig } from "./utilities/hubConfigStorage";
@@ -385,15 +386,12 @@ const actions: {
 
       const uri = vscode.Uri.file(path);
 
-      // Get the current file content
       const currentContent = await vscode.workspace.fs.readFile(uri);
       const currentText = currentContent.toString();
 
-      // Get the original content to compare against
       const modifiedFileState = state.modifiedFiles.get(path);
       const originalContent = modifiedFileState?.originalContent || "";
 
-      // Simple logic: if file changed from original = accepted, if unchanged = rejected
       const normalize = (text: string) => text.replace(/\r\n/g, "\n").replace(/\n$/, "");
       const hasChanges = normalize(currentText) !== normalize(originalContent);
 
@@ -407,7 +405,6 @@ const actions: {
 
       await handleFileResponse(messageToken, responseId, path, finalContent, state, true); // Skip analysis - it runs on save
 
-      // Remove from pendingBatchReview after processing
       state.mutateSolutionWorkflow((draft) => {
         if (draft.pendingBatchReview) {
           draft.pendingBatchReview = draft.pendingBatchReview.filter(
@@ -421,13 +418,11 @@ const actions: {
         messageToken,
       });
 
-      // Check if workflow cleanup should happen
       checkBatchReviewComplete(state, logger);
     } catch (error) {
       logger.error("Error handling CONTINUE_WITH_FILE_STATE:", error);
       await handleFileResponse(messageToken, "reject", path, content, state, true); // Skip analysis - it runs on save
 
-      // Remove from pendingBatchReview after error handling
       state.mutateSolutionWorkflow((draft) => {
         if (draft.pendingBatchReview) {
           draft.pendingBatchReview = draft.pendingBatchReview.filter(
@@ -436,30 +431,36 @@ const actions: {
         }
       });
 
-      // Check if workflow cleanup should happen
       checkBatchReviewComplete(state, logger);
     }
   },
 
   BATCH_APPLY_ALL: async ({ files }, state, logger) => {
     const failures: Array<{ path: string; error: string }> = [];
+    const appliedFileUris: vscode.Uri[] = [];
 
     try {
       logger.info(`BATCH_APPLY_ALL: Applying ${files.length} files`);
       console.log(`[BATCH_APPLY_ALL] Processing ${files.length} files`);
 
-      // Set processing flag at the start
       state.mutateSolutionWorkflow((draft) => {
         draft.isProcessingQueuedMessages = true;
       });
 
-      // Process files one by one with individual error handling
       for (const file of files) {
         try {
           logger.info(`BATCH_APPLY_ALL: Applying file ${file.path}`);
-          await handleFileResponse(file.messageToken, "apply", file.path, file.content, state);
+          await handleFileResponse(
+            file.messageToken,
+            "apply",
+            file.path,
+            file.content,
+            state,
+            true,
+          );
 
-          // Remove this file from pendingBatchReview only on success
+          appliedFileUris.push(vscode.Uri.file(file.path));
+
           state.mutateSolutionWorkflow((draft) => {
             if (draft.pendingBatchReview) {
               draft.pendingBatchReview = draft.pendingBatchReview.filter(
@@ -475,7 +476,6 @@ const actions: {
           logger.error(`BATCH_APPLY_ALL: Failed to apply file ${file.path}:`, fileError);
           failures.push({ path: file.path, error: errorMessage });
 
-          // Mark the file as having an error in pendingBatchReview
           state.mutateSolutionWorkflow((draft) => {
             if (draft.pendingBatchReview) {
               const fileIndex = draft.pendingBatchReview.findIndex(
@@ -489,13 +489,23 @@ const actions: {
         }
       }
 
-      // Report results
+      if (appliedFileUris.length > 0) {
+        try {
+          logger.info(
+            `BATCH_APPLY_ALL: Running combined analysis for ${appliedFileUris.length} files`,
+          );
+          await runPartialAnalysis(state, appliedFileUris);
+          logger.info(`BATCH_APPLY_ALL: Combined analysis completed`);
+        } catch (analysisError) {
+          logger.warn(`BATCH_APPLY_ALL: Failed to run combined analysis:`, analysisError);
+        }
+      }
+
       const successCount = files.length - failures.length;
       logger.info(
         `BATCH_APPLY_ALL: Completed. Success: ${successCount}, Failed: ${failures.length}`,
       );
 
-      // Notify user if there were failures
       if (failures.length > 0) {
         const failureDetails = failures.map((f) => `• ${f.path}: ${f.error}`).join("\n");
         logger.error(`BATCH_APPLY_ALL: Failures:\n${failureDetails}`);


### PR DESCRIPTION
- Fix isBatchOperationInProgress not resetting when batch operations complete with some failures (files with hasError remain in queue)
- Now also resets when isProcessingQueuedMessages transitions false
- Optimize BATCH_APPLY_ALL to run single combined analysis instead of N separate analyses for N files

Problem
When clicking "Apply All" in the batch review UI, if any files failed to apply, the UI would get stuck in a permanently disabled state with no way to recover.
Root cause: isBatchOperationInProgress was only reset when pendingBatchReview became empty. When files failed, they remained in the queue with hasError: true, so the queue was never empty and the state never reset.
Solution
1. Fix state reset logic (useVSCodeMessageHandler.ts)
Now resets isBatchOperationInProgress when either:
pendingBatchReview becomes empty (all files processed successfully), OR
isProcessingQueuedMessages transitions from true to false (batch operation finished, possibly with failures)
This ensures the UI is re-enabled after batch operations complete, allowing users to retry failed files or take other actions.
2. Optimize batch analysis (webviewMessageHandler.ts)
Before: N files → N separate runPartialAnalysis() calls
After: N files → 1 combined runPartialAnalysis(state, allAppliedUris) call
Skip individual analysis during file processing and run a single combined analysis at the end with all successfully applied file URIs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Batch processing now triggers a single combined analysis after applying multiple files, reducing redundant work.
  * Batch operations are more resilient—analysis failures are logged as warnings and do not fail the whole batch.
  * Better tracking of processing state and pending counts improves detection of batch completion and resets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->