### PR TITLE
:bug: Gracefully handle provider errors when dependencies are missing

### DIFF
--- a/vscode/go/src/extension.ts
+++ b/vscode/go/src/extension.ts
@@ -109,14 +109,39 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   // Start LSP proxy server (JSON-RPC over UDS)
-  const lspProxyServer = new GoVscodeProxyServer(lspProxySocketPath, logger);
-  await lspProxyServer.start();
-  context.subscriptions.push(lspProxyServer);
+  let lspProxyServer: GoVscodeProxyServer;
+  let providerManager: GoExternalProviderManager;
 
-  // Start go-external-provider subprocess (GRPC over UDS)
-  const providerManager = new GoExternalProviderManager(providerSocketPath, context, logger);
-  await providerManager.start();
-  context.subscriptions.push(providerManager);
+  try {
+    lspProxyServer = new GoVscodeProxyServer(lspProxySocketPath, logger);
+    await lspProxyServer.start();
+    context.subscriptions.push(lspProxyServer);
+  } catch (err) {
+    const message =
+      "Failed to start Go LSP proxy server. Go analysis will be disabled. " +
+      `Error: ${err instanceof Error ? err.message : String(err)}`;
+    logger.error(message, err);
+    vscode.window.showWarningMessage(
+      "Go provider could not start: LSP proxy server failed. Go analysis will be disabled.",
+    );
+    return;
+  }
+
+  try {
+    // Start go-external-provider subprocess (GRPC over UDS)
+    providerManager = new GoExternalProviderManager(providerSocketPath, context, logger);
+    await providerManager.start();
+    context.subscriptions.push(providerManager);
+  } catch (err) {
+    const message =
+      "Failed to start go-external-provider. Go analysis will be disabled. " +
+      `Error: ${err instanceof Error ? err.message : String(err)}`;
+    logger.error(message, err);
+    vscode.window.showWarningMessage("Go provider could not start. Go analysis will be disabled.");
+    // Clean up LSP proxy server since we won't be using it
+    lspProxyServer.dispose();
+    return;
+  }
 
   // Get workspace location for analysis
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0];


### PR DESCRIPTION
Fixes #1071

When analyzing non-Java or mixed-language projects, provider initialization failures no longer crash the entire analyzer server. Instead:

1. **Graceful provider failure handling**: If a language provider fails to start (LSP proxy or external provider subprocess), the extension now:
   - Logs detailed error messages for debugging
   - Shows user-friendly warning (not error) messages
   - Disables only that specific language provider
   - Cleans up resources (disposes LSP proxy if provider fails)
   - Returns early without registering the failed provider

2. **Consistent error handling across all providers**: Applied the same graceful error handling pattern to Java, JavaScript, and Go extensions for consistency.

This allows the analyzer server to continue with other working providers even when one provider encounters issues (missing build tools, incompatible project structure, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling during initialization of Go, Java, and JavaScript language features.
  * Improved user notifications when language features fail to start.
  * Better resource management and cleanup on initialization failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->