### PR TITLE
:test_tube: Add Hub Configuration page object and form automation

### DIFF
--- a/tests/e2e/enums/views.enum.ts
+++ b/tests/e2e/enums/views.enum.ts
@@ -4,4 +4,5 @@ export const KAIViews = {
   manageProfiles: `${extensionShortName} Manage Profiles`,
   resolutionDetails: `${extensionShortName} Resolution Details`,
   analysisView: getAnalysisViewTitle(),
+  hubConfiguration: `${extensionShortName} Hub Configuration`,
 } as const;

--- a/tests/e2e/pages/hub-configuration.page.ts
+++ b/tests/e2e/pages/hub-configuration.page.ts
@@ -1,0 +1,96 @@
+import { VSCode } from './vscode.page';
+import { HubConfiguration } from '../types/hub-configuration';
+import { KAIViews } from '../enums/views.enum';
+import { expect } from '@playwright/test';
+
+/**
+ * Page object for automating the Hub Configuration form in VS Code.
+ * Handles connection settings, authentication, and feature toggles.
+ */
+export class HubConfigurationPage {
+  public constructor(private readonly vsCode: VSCode) {}
+
+  public static async open(vsCode: VSCode) {
+    const hubConfig = new HubConfigurationPage(vsCode);
+    await hubConfig.openHubConfiguration();
+    return hubConfig;
+  }
+
+  public async openHubConfiguration() {
+    await this.vsCode.openConfiguration();
+    const view = await this.vsCode.getView(KAIViews.analysisView);
+    await view.getByRole('button', { name: 'Configure Hub Settings' }).click();
+  }
+
+  /**
+   * Fills the hub configuration form based on provided config.
+   * Toggles are only clicked when current state differs from desired state.
+   */
+  public async fillForm(config: HubConfiguration) {
+    const view = await this.vsCode.getView(KAIViews.hubConfiguration);
+    const hubGroup = view
+      .locator('.pf-v6-c-form__group')
+      .filter({ has: view.getByText('Enable Hub', { exact: true }) })
+      .first();
+
+    const hubInput = hubGroup.locator('input#hub-enabled');
+    const label = hubGroup.locator('label.pf-v6-c-switch[for="hub-enabled"]');
+
+    await hubInput.setChecked(config.enabled);
+    await expect(hubInput).toBeChecked({ checked: config.enabled });
+
+    if (!config.enabled) {
+      console.log('HubConfigurationPage: hub connection disabled, skipping config...');
+      return;
+    }
+
+    await view.locator('#hub-url').fill(config.url);
+
+    if (config.auth) {
+      const authGroup = view
+        .locator('.pf-v6-c-form__group')
+        .filter({ has: view.getByText('Enable authentication', { exact: true }) })
+        .first();
+
+      const authInput = authGroup.locator('input#auth-enabled');
+      await authInput.setChecked(config.auth.enabled);
+
+      await expect(authInput).toBeChecked({ checked: config.auth.enabled });
+
+      if (config.auth.enabled) {
+        await view.locator('#auth-username').fill(config.auth.username);
+        await view.locator('#auth-password').fill(config.auth.password);
+      }
+    }
+
+    //SSL Settings
+    const insecureGroup = view
+      .locator('.pf-v6-c-form__group')
+      .filter({ has: view.getByText('Insecure connection', { exact: true }) })
+      .first();
+
+    const insecureInput = insecureGroup.locator('input#auth-insecure');
+    await insecureInput.setChecked(config.skipSSL);
+    await expect(insecureInput).toBeChecked({ checked: config.skipSSL });
+
+    await expect(insecureInput).toBeChecked({ checked: config.skipSSL });
+
+    await view.locator('#feature-solution-server').setChecked(config.solutionServerEnabled);
+    const group = view
+      .locator('.pf-v6-c-form__group')
+      .filter({ has: view.getByText('Profile Sync', { exact: true }) })
+      .first();
+
+    const profileSyncInput = group.locator('input#feature-profile-sync');
+    await profileSyncInput.setChecked(config.profileSyncEnabled);
+    await expect(profileSyncInput).toBeChecked({ checked: config.profileSyncEnabled });
+
+    const saveBtn = view.getByRole('button', { name: 'Save' });
+    if (await saveBtn.isEnabled()) {
+      await saveBtn.click();
+      console.log('Hub configuration form saved');
+    } else {
+      console.log('Hub configuration unchanged; Save is disabled, skipping click');
+    }
+  }
+}

--- a/tests/e2e/types/hub-configuration.ts
+++ b/tests/e2e/types/hub-configuration.ts
@@ -1,0 +1,14 @@
+export type HubConfiguration = {
+  enabled: boolean;
+  url: string;
+  skipSSL: boolean;
+  auth?: HubConfigurationAuth;
+  solutionServerEnabled: boolean;
+  profileSyncEnabled: boolean;
+};
+
+export type HubConfigurationAuth = {
+  enabled: boolean;
+  username: string;
+  password: string;
+};

--- a/tests/e2e/utilities/utils.ts
+++ b/tests/e2e/utilities/utils.ts
@@ -8,6 +8,7 @@ import process from 'process';
 import { expect } from '@playwright/test';
 import type { VSCode } from '../pages/vscode.page';
 import { LogEntry } from '../types/log-entry';
+import { HubConfiguration } from '../types/hub-configuration';
 
 export const extensionName = process.env.EXTENSION_NAME || 'konveyor';
 export const extensionPublisher = process.env.EXTENSION_PUBLISHER || 'konveyor';
@@ -203,4 +204,44 @@ export function parseLogEntries(rawContent: string): LogEntry[] {
   }
 
   return entries;
+}
+
+export function getHubConfig(
+  toEnableSolutionServer: boolean,
+  toEnableAuth: boolean,
+  toSyncProfiles: boolean
+): HubConfiguration {
+  const url = process.env.SOLUTION_SERVER_URL;
+  if (!url) {
+    throw new Error('Missing required URL');
+  }
+
+  const baseConfig: HubConfiguration = {
+    enabled: true,
+    url,
+    skipSSL: true,
+    solutionServerEnabled: toEnableSolutionServer,
+    profileSyncEnabled: toSyncProfiles,
+  };
+
+
+  if (!toEnableAuth) {
+    return baseConfig;
+  }
+
+  const username = process.env.SOLUTION_SERVER_USERNAME;
+  const password = process.env.SOLUTION_SERVER_PASSWORD;
+
+  if (!username || !password) {
+    throw new Error('Missing solution server credentials');
+  }
+
+  return {
+    ...baseConfig,
+    auth: {
+      enabled: true,
+      username,
+      password,
+    },
+  };
 }


### PR DESCRIPTION
## Summary
Add page object and utilities for automating Hub Configuration settings in e2e tests.

## Changes
- Add `HubConfiguration` and `HubConfigurationAuth` types
- Add `getHubConfig()` utility with automatic local/remote server detection
- Add `HubConfigurationPage` for hub settings form automation
- Add `hubConfiguration` view to `KAIViews` enum

## Notes
- Local servers (http://) skip authentication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test support for Hub Configuration
    * New Hub Configuration view label
    * Page automation for Hub Configuration UI (navigation, form interactions, save)
    * Type definitions for Hub Configuration and optional authentication
    * Utility to generate hub configurations with local vs remote handling and optional auth

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->