### PR TITLE
:test_tube:  Refactor(mcp-client): Decouple auth architecture and enforce concurrency safety

### DIFF
--- a/tests/mcp-client/mcp-client.model.ts
+++ b/tests/mcp-client/mcp-client.model.ts
@@ -5,8 +5,69 @@ import { BestHintResponse, SuccessRateResponse } from './mcp-client-responses.mo
 import { AuthenticationManager } from '../solution-server-auth/authentication-manager';
 import { validateSolutionServerConfig } from '../solution-server-auth/utills';
 
+/**
+ * Creates a custom fetch function that handles redirects by preserving the original host
+ * and path prefix. This is necessary when the server redirects to internal K8s service
+ * names that cannot be resolved from outside the cluster.
+ *
+ * The server internally uses paths like /api but externally they're exposed at
+ * /hub/services/kai/api. This function maps internal paths back to external paths.
+ */
+function createRedirectAwareFetch(originalUrl: URL): typeof fetch {
+  const originalPath = originalUrl.pathname;
+  const apiIndex = originalPath.indexOf('/api');
+  const pathPrefix = apiIndex > 0 ? originalPath.substring(0, apiIndex) : '';
+  const maxRedirects = 10;
+
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    let currentUrl = input instanceof Request ? input.url : input.toString();
+
+    for (let redirectCount = 0; redirectCount < maxRedirects; redirectCount++) {
+      const parsedUrl = new URL(currentUrl);
+
+      // If the request is going to a different host than our original, rewrite it
+      if (parsedUrl.host !== originalUrl.host) {
+        let targetPath = parsedUrl.pathname;
+        if (pathPrefix && targetPath.startsWith('/api')) {
+          targetPath = pathPrefix + targetPath;
+        }
+        const rewrittenUrl = new URL(targetPath + parsedUrl.search, originalUrl);
+        console.log(`Rewriting URL from ${parsedUrl.href} to ${rewrittenUrl.href}`);
+        currentUrl = rewrittenUrl.toString();
+      }
+
+      const response = await fetch(currentUrl, {
+        ...init,
+        redirect: 'manual',
+      });
+
+      // If not a redirect, return the response
+      if (response.status < 300 || response.status >= 400) {
+        return response;
+      }
+
+      // Handle redirect
+      const location = response.headers.get('location');
+      if (!location) {
+        return response;
+      }
+
+      const redirectUrl = new URL(location, originalUrl);
+      let targetPath = redirectUrl.pathname;
+      if (pathPrefix && targetPath.startsWith('/api')) {
+        targetPath = pathPrefix + targetPath;
+      }
+      currentUrl = new URL(targetPath + redirectUrl.search, originalUrl).toString();
+      console.log(`Following redirect: ${location} -> ${currentUrl}`);
+    }
+
+    throw new Error('Maximum redirect limit reached');
+  };
+}
+
 export class MCPClient {
   private readonly url: string;
+  private readonly parsedUrl: URL;
   private transport?: StreamableHTTPClientTransport;
   private client?: Client;
   private authManager: AuthenticationManager;
@@ -14,6 +75,7 @@ export class MCPClient {
 
   constructor(url: string, authManager: AuthenticationManager) {
     this.url = url;
+    this.parsedUrl = new URL(url);
     this.authManager = authManager;
   }
 
@@ -35,6 +97,9 @@ export class MCPClient {
 
   private async connectTransport(): Promise<void> {
     const token = await this.authManager.getBearerToken();
+    if (!token) {
+      throw new Error('Failed to obtain authentication token');
+    }
     this.currentToken = token;
     const headers: Record<string, string> = {
       Authorization: `Bearer ${token}`,
@@ -42,11 +107,12 @@ export class MCPClient {
 
     this.transport = new StreamableHTTPClientTransport(new URL(this.url), {
       requestInit: { headers },
+      fetch: createRedirectAwareFetch(this.parsedUrl),
     });
 
     this.client = new Client(
       { name: 'authenticated-mcp-client', version: '1.0.0' },
-      { capabilities: { tools: {}, resources: {} } }
+      { capabilities: { roots: { listChanged: false }, sampling: {} } }
     );
 
     await this.client.connect(this.transport);
@@ -62,6 +128,7 @@ export class MCPClient {
     };
     this.transport = new StreamableHTTPClientTransport(new URL(this.url), {
       requestInit: { headers },
+      fetch: createRedirectAwareFetch(this.parsedUrl),
     });
     await this.client.connect(this.transport);
   }
@@ -89,12 +156,10 @@ export class MCPClient {
     );
   }
 
-  public async getSuccessRate(
-    violationIds: {
-      violation_name: string;
-      ruleset_name: string;
-    }[]
-  ): Promise<SuccessRateResponse> {
+  public async getSuccessRate(violationId: {
+    violation_name: string;
+    ruleset_name: string;
+  }): Promise<SuccessRateResponse> {
     const successRateSchema = z.object({
       counted_solutions: z.number(),
       accepted_solutions: z.number(),
@@ -107,7 +172,7 @@ export class MCPClient {
 
     const response = await this.request<SuccessRateResponse[]>(
       'get_success_rate',
-      { violation_ids: violationIds },
+      { violation_ids: [violationId] },
       responseSchema
     );
 
@@ -126,7 +191,7 @@ export class MCPClient {
   }
   private isUnauthorized(result: any): boolean {
     const msg = JSON.stringify(result?.content || '');
-    return msg.includes('401') || msg.includes('403') || msg.includes('unauthorized');
+    return msg.includes('401') || msg.includes('403') || msg.toLowerCase().includes('unauthorized');
   }
 
   private async request<T>(
@@ -144,7 +209,7 @@ export class MCPClient {
       this.currentToken = token;
     }
 
-    const result = await this.client?.callTool({
+    const result = await this.client.callTool({
       name: endpoint,
       arguments: params,
     });

--- a/tests/solution-server-auth/authentication-manager.ts
+++ b/tests/solution-server-auth/authentication-manager.ts
@@ -111,7 +111,7 @@ export class AuthenticationManager {
     const params = new URLSearchParams();
     params.append('grant_type', 'refresh_token');
     params.append('client_id', `${this.realm}-ui`);
-    params.append('refresh_token', this.refreshToken!);
+    params.append('refresh_token', this.refreshToken);
     const tokenData = await this.fetchToken(tokenUrl, params);
     this.setTokenData(tokenData);
   }
@@ -169,7 +169,7 @@ export class AuthenticationManager {
     if (this.tokenPromise) {
       return this.tokenPromise;
     }
-    if (this.bearerToken && !this.hasValidToken()) {
+    if (this.hasValidToken()) {
       return;
     }
     if (!this.refreshToken || this.isLocal) {
@@ -189,6 +189,7 @@ export class AuthenticationManager {
 
   public dispose(): void {
     this.stopAutoRefresh();
+    this.tokenPromise = null
     this.bearerToken = null;
     this.refreshToken = null;
     this.tokenExpiresAt = null;


### PR DESCRIPTION
## Summary
This PR involves a major refactor of the authentication layer and its interaction with the MCPClient. The main goals were to decouple the client from the authentication logic, resolve potential race conditions during token refreshes, and implement a robust retry mechanism for unauthorized requests.

## Key Changes

### 1. Architectural Decoupling (Separation of Concerns)
- **Before:** MCPClient was responsible for initializing the auth flow, and updates were pushed via callbacks.
- **After:** AuthenticationManager is now a standalone unit. MCPClient acts as a pure consumer, pulling tokens on demand via `getBearerToken()`.
- Removed the `initialize` method and the circular dependency.

### 2. Concurrency Safety & Race Conditions
- Fixed a critical issue where multiple concurrent requests could trigger multiple token refreshes.
- Implemented a Shared Promise Pattern in AuthenticationManager. If a refresh is in progress, subsequent requests await the same promise instead of starting a new one.

### 3. Resilience & Auto-Retry
- Added logic to MCPClient to intercept 401/403 (Unauthorized) errors.
- The client now automatically attempts to force-refresh the token and retries the original request once, transparently to the user.

### 4. Token Management Strategy
- Switched from a proactive "Timer & Callback" approach to a Lazy Load strategy.
- The token is validated/refreshed only when needed (or when expiring soon), reducing unnecessary network traffic.

  ### 5. Server Redirect Handling (New)                                                                                                                                                                   
  - Added `createRedirectAwareFetch` wrapper to handle server redirects to internal K8s URLs 
  - The server redirects external clients to `tackle-hub.konveyor-tackle.svc` which is unreachable outside the cluster
  - The wrapper intercepts redirects and rewrites them to use the external URL with proper path prefix mapping
  - Includes max redirect limit (10) to prevent infinite loops

  **Known limitations:**
  - Path prefix detection assumes `/api` in the URL structure
  - Relative redirects to `/api/*` paths won't get the prefix (server currently uses absolute URLs)

**Related:**  #1232 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserves original host/path across redirects for API calls.
  * Per-instance token handling with reconnect using a new token.
  * Success-rate query now accepts a single violation identifier and returns one result.

* **Bug Fixes**
  * Improved recovery from authorization failures with token refresh, reconnect and automatic retry.
  * Requests detect and reconcile token changes mid-flow; disposal clears tokens and stops refresh.

* **Refactor**
  * Centralized token lifecycle and single-flight token acquisition; reduced public token-management surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->