### PR TITLE
:bug: Catch all causing store reset in devspaces

### DIFF
--- a/shared/src/types/messages.ts
+++ b/shared/src/types/messages.ts
@@ -203,16 +203,5 @@ export function isSettingsUpdate(msg: WebviewMessage): msg is SettingsUpdateMess
 }
 
 export function isFullStateUpdate(msg: WebviewMessage): msg is FullStateUpdateMessage {
-  return (
-    !isAnalysisStateUpdate(msg) &&
-    !isChatMessagesUpdate(msg) &&
-    !isChatMessageStreamingUpdate(msg) &&
-    !isChatStreamingChunk(msg) &&
-    !isSolutionWorkflowUpdate(msg) &&
-    !isServerStateUpdate(msg) &&
-    !isProfilesUpdate(msg) &&
-    !isConfigErrorsUpdate(msg) &&
-    !isDecoratorsUpdate(msg) &&
-    !isSettingsUpdate(msg)
-  );
+  return (msg as any).type === MessageTypes.FULL_STATE_UPDATE;
 }

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -19,7 +19,7 @@ const App: React.FC = () => {
       const windowData = window["konveyorInitialData"] as Partial<ExtensionData>;
       const store = useExtensionStore.getState();
 
-      // Initialize store with window data
+      // Initialize store with window data from extension
       store.batchUpdate({
         ruleSets: Array.isArray(windowData.ruleSets) ? windowData.ruleSets : [],
         enhancedIncidents: Array.isArray(windowData.enhancedIncidents)
@@ -37,6 +37,7 @@ const App: React.FC = () => {
         solutionServerEnabled: windowData.solutionServerEnabled ?? false,
         solutionServerConnected: windowData.solutionServerConnected ?? false,
         isAgentMode: windowData.isAgentMode ?? false,
+        isInTreeMode: windowData.isInTreeMode ?? false,
         workspaceRoot: windowData.workspaceRoot ?? "/",
         activeProfileId: windowData.activeProfileId ?? null,
         isWaitingForUserInteraction: windowData.isWaitingForUserInteraction ?? false,

--- a/webview-ui/src/store/store.ts
+++ b/webview-ui/src/store/store.ts
@@ -1,21 +1,5 @@
-/**
- * Zustand Store POC
- *
- * ✅ BENEFITS over Redux Toolkit:
- * - Much simpler API
- * - No boilerplate (no slices, actions, reducers)
- * - Still has selector-based subscriptions
- * - Smaller bundle size (~1KB)
- * - Can optionally use Immer middleware
- *
- * ✅ BENEFITS over current Context approach:
- * - Selective subscriptions (no unnecessary re-renders)
- * - Better performance
- * - Can still use Immer but in a smarter way
- */
-
 import { create } from "zustand";
-import { devtools, persist } from "zustand/middleware";
+import { devtools } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 import type {
   RuleSet,
@@ -30,16 +14,8 @@ import type {
   HubConfig,
 } from "@editor-extensions/shared";
 
-/**
- * Maximum number of chat messages to keep in memory.
- * NOTE: This constant is duplicated in useVSCodeMessageHandler.ts
- * TODO: Consider consolidating into a shared constants file
- *
- * Must match the value in useVSCodeMessageHandler.ts
- */
 const MAX_CHAT_MESSAGES = 50000;
 
-// ✅ BENEFIT: Single interface for entire state (simpler than Redux slices)
 interface ExtensionStore {
   // Analysis state
   ruleSets: RuleSet[];
@@ -83,8 +59,6 @@ interface ExtensionStore {
   pendingBatchReview: PendingBatchReviewFile[];
   isBatchOperationInProgress: boolean;
 
-  // ✅ BENEFIT: Actions are just methods on the store
-  // No need for separate action creators like Redux
   setRuleSets: (ruleSets: RuleSet[]) => void;
   setEnhancedIncidents: (incidents: EnhancedIncident[]) => void;
   setIsAnalyzing: (isAnalyzing: boolean) => void;
@@ -131,273 +105,245 @@ interface ExtensionStore {
   batchUpdate: (updates: Partial<ExtensionStore>) => void;
 }
 
-/**
- * ✅ BENEFIT: Create store with middleware stack
- * - immer: Safe mutations (optional, can remove for max performance)
- * - devtools: Redux DevTools integration
- * - persist: Persist to localStorage
- */
 export const useExtensionStore = create<ExtensionStore>()(
   devtools(
-    persist(
-      immer((set) => ({
-        // Initial state
-        ruleSets: [],
-        enhancedIncidents: [],
-        profiles: [],
-        activeProfileId: null,
-        isInTreeMode: false,
-        isAnalyzing: false,
-        analysisProgress: 0,
-        analysisProgressMessage: "",
-        isAnalysisScheduled: false,
-        serverState: "initial",
-        chatMessages: [],
-        isFetchingSolution: false,
-        isStartingServer: false,
-        isInitializingServer: false,
-        isWaitingForUserInteraction: false,
-        isProcessingQueuedMessages: false,
-        activeDecorators: {},
-        workspaceRoot: "/",
-        configErrors: [],
-        solutionState: "none",
-        solutionScope: undefined,
-        solutionServerEnabled: false,
-        solutionServerConnected: false,
-        isAgentMode: false,
-        isContinueInstalled: false,
-        hubConfig: undefined,
-        profileSyncEnabled: false,
-        profileSyncConnected: false,
-        isSyncingProfiles: false,
-        llmProxyAvailable: false,
+    immer((set) => ({
+      // Initial state
+      ruleSets: [],
+      enhancedIncidents: [],
+      profiles: [],
+      activeProfileId: null,
+      isInTreeMode: false,
+      isAnalyzing: false,
+      analysisProgress: 0,
+      analysisProgressMessage: "",
+      isAnalysisScheduled: false,
+      serverState: "initial",
+      chatMessages: [],
+      isFetchingSolution: false,
+      isStartingServer: false,
+      isInitializingServer: false,
+      isWaitingForUserInteraction: false,
+      isProcessingQueuedMessages: false,
+      activeDecorators: {},
+      workspaceRoot: "/",
+      configErrors: [],
+      solutionState: "none",
+      solutionScope: undefined,
+      solutionServerEnabled: false,
+      solutionServerConnected: false,
+      isAgentMode: false,
+      isContinueInstalled: false,
+      hubConfig: undefined,
+      profileSyncEnabled: false,
+      profileSyncConnected: false,
+      isSyncingProfiles: false,
+      llmProxyAvailable: false,
 
-        // Batch review state
-        pendingBatchReview: [],
-        isBatchOperationInProgress: false,
+      // Batch review state
+      pendingBatchReview: [],
+      isBatchOperationInProgress: false,
 
-        // ✅ BENEFIT: Actions are simple functions
-        // With Immer middleware, you can write mutable code
-        setRuleSets: (ruleSets) =>
-          set((state) => {
-            state.ruleSets = ruleSets;
-          }),
-
-        setEnhancedIncidents: (incidents) =>
-          set((state) => {
-            state.enhancedIncidents = incidents;
-          }),
-
-        setIsAnalyzing: (isAnalyzing) =>
-          set((state) => {
-            state.isAnalyzing = isAnalyzing;
-          }),
-
-        setAnalysisProgress: (progress) =>
-          set((state) => {
-            state.analysisProgress = progress;
-          }),
-
-        setAnalysisProgressMessage: (message) =>
-          set((state) => {
-            state.analysisProgressMessage = message;
-          }),
-
-        setIsAnalysisScheduled: (isScheduled) =>
-          set((state) => {
-            state.isAnalysisScheduled = isScheduled;
-          }),
-
-        setServerState: (serverState) =>
-          set((state) => {
-            state.serverState = serverState;
-          }),
-
-        setProfiles: (profiles) =>
-          set((state) => {
-            state.profiles = profiles;
-          }),
-
-        setActiveProfileId: (profileId) =>
-          set((state) => {
-            state.activeProfileId = profileId;
-          }),
-
-        // ✅ BENEFIT: Complex logic in actions
-        addChatMessage: (message) =>
-          set((state) => {
-            state.chatMessages.push(message);
-
-            // Auto-limit messages to prevent memory issues
-            if (state.chatMessages.length > MAX_CHAT_MESSAGES) {
-              const droppedCount = state.chatMessages.length - MAX_CHAT_MESSAGES;
-              state.chatMessages = state.chatMessages.slice(-MAX_CHAT_MESSAGES);
-              console.warn(
-                `Chat messages exceeded limit in addChatMessage. ` +
-                  `Dropping ${droppedCount} oldest messages, keeping the most recent ${MAX_CHAT_MESSAGES}.`,
-              );
-            }
-          }),
-
-        clearChatMessages: () =>
-          set((state) => {
-            state.chatMessages = [];
-          }),
-
-        setChatMessages: (messages) =>
-          set((state) => {
-            state.chatMessages = messages;
-          }),
-
-        setIsFetchingSolution: (isFetching) =>
-          set((state) => {
-            state.isFetchingSolution = isFetching;
-          }),
-
-        setIsStartingServer: (isStarting) =>
-          set((state) => {
-            state.isStartingServer = isStarting;
-          }),
-
-        setIsInitializingServer: (isInitializing) =>
-          set((state) => {
-            state.isInitializingServer = isInitializing;
-          }),
-
-        setIsWaitingForUserInteraction: (isWaiting) =>
-          set((state) => {
-            state.isWaitingForUserInteraction = isWaiting;
-          }),
-
-        setIsProcessingQueuedMessages: (isProcessing) =>
-          set((state) => {
-            state.isProcessingQueuedMessages = isProcessing;
-          }),
-
-        setBatchOperationInProgress: (isInProgress) =>
-          set((state) => {
-            state.isBatchOperationInProgress = isInProgress;
-          }),
-
-        setActiveDecorators: (decorators) =>
-          set((state) => {
-            state.activeDecorators = decorators;
-          }),
-
-        deleteActiveDecorator: (streamId) =>
-          set((state) => {
-            if (state.activeDecorators && state.activeDecorators[streamId]) {
-              delete state.activeDecorators[streamId];
-            }
-          }),
-
-        setConfigErrors: (errors) =>
-          set((state) => {
-            state.configErrors = errors;
-          }),
-
-        addConfigError: (error) =>
-          set((state) => {
-            state.configErrors.push(error);
-          }),
-
-        clearConfigErrors: () =>
-          set((state) => {
-            state.configErrors = [];
-          }),
-
-        setSolutionState: (solutionState) =>
-          set((state) => {
-            state.solutionState = solutionState;
-          }),
-
-        setSolutionScope: (scope) =>
-          set((state) => {
-            state.solutionScope = scope;
-          }),
-
-        setSolutionServerConnected: (connected) =>
-          set((state) => {
-            state.solutionServerConnected = connected;
-          }),
-
-        setSolutionServerEnabled: (enabled) =>
-          set((state) => {
-            state.solutionServerEnabled = enabled;
-          }),
-
-        setIsAgentMode: (isAgentMode) =>
-          set((state) => {
-            state.isAgentMode = isAgentMode;
-          }),
-
-        setIsContinueInstalled: (isInstalled) =>
-          set((state) => {
-            state.isContinueInstalled = isInstalled;
-          }),
-
-        setHubConfig: (config) =>
-          set((state) => {
-            state.hubConfig = config;
-          }),
-
-        setWorkspaceRoot: (root) =>
-          set((state) => {
-            state.workspaceRoot = root;
-          }),
-
-        setProfileSyncEnabled: (enabled) =>
-          set((state) => {
-            state.profileSyncEnabled = enabled;
-          }),
-
-        setProfileSyncConnected: (connected) =>
-          set((state) => {
-            state.profileSyncConnected = connected;
-          }),
-
-        setIsSyncingProfiles: (isSyncing) =>
-          set((state) => {
-            state.isSyncingProfiles = isSyncing;
-          }),
-
-        setLlmProxyAvailable: (available) =>
-          set((state) => {
-            state.llmProxyAvailable = available;
-          }),
-
-        clearAnalysisData: () =>
-          set((state) => {
-            state.ruleSets = [];
-            state.enhancedIncidents = [];
-          }),
-
-        batchUpdate: (updates) =>
-          set((state) => {
-            Object.assign(state, updates);
-          }),
-      })),
-      {
-        name: "konveyor-storage",
-        // ✅ Only persist specific fields
-        partialize: (state) => ({
-          activeProfileId: state.activeProfileId,
-          profiles: state.profiles,
-          isInTreeMode: state.isInTreeMode,
-          isAgentMode: state.isAgentMode,
-          solutionServerEnabled: state.solutionServerEnabled,
-          // NOT persisting large arrays like ruleSets or enhancedIncidents
+      setRuleSets: (ruleSets) =>
+        set((state) => {
+          state.ruleSets = ruleSets;
         }),
-      },
-    ),
+
+      setEnhancedIncidents: (incidents) =>
+        set((state) => {
+          state.enhancedIncidents = incidents;
+        }),
+
+      setIsAnalyzing: (isAnalyzing) =>
+        set((state) => {
+          state.isAnalyzing = isAnalyzing;
+        }),
+
+      setAnalysisProgress: (progress) =>
+        set((state) => {
+          state.analysisProgress = progress;
+        }),
+
+      setAnalysisProgressMessage: (message) =>
+        set((state) => {
+          state.analysisProgressMessage = message;
+        }),
+
+      setIsAnalysisScheduled: (isScheduled) =>
+        set((state) => {
+          state.isAnalysisScheduled = isScheduled;
+        }),
+
+      setServerState: (serverState) =>
+        set((state) => {
+          state.serverState = serverState;
+        }),
+
+      setProfiles: (profiles) =>
+        set((state) => {
+          state.profiles = profiles;
+        }),
+
+      setActiveProfileId: (profileId) =>
+        set((state) => {
+          state.activeProfileId = profileId;
+        }),
+
+      addChatMessage: (message) =>
+        set((state) => {
+          state.chatMessages.push(message);
+
+          if (state.chatMessages.length > MAX_CHAT_MESSAGES) {
+            const droppedCount = state.chatMessages.length - MAX_CHAT_MESSAGES;
+            state.chatMessages = state.chatMessages.slice(-MAX_CHAT_MESSAGES);
+            console.warn(
+              `Chat messages exceeded limit in addChatMessage. ` +
+                `Dropping ${droppedCount} oldest messages, keeping the most recent ${MAX_CHAT_MESSAGES}.`,
+            );
+          }
+        }),
+
+      clearChatMessages: () =>
+        set((state) => {
+          state.chatMessages = [];
+        }),
+
+      setChatMessages: (messages) =>
+        set((state) => {
+          state.chatMessages = messages;
+        }),
+
+      setIsFetchingSolution: (isFetching) =>
+        set((state) => {
+          state.isFetchingSolution = isFetching;
+        }),
+
+      setIsStartingServer: (isStarting) =>
+        set((state) => {
+          state.isStartingServer = isStarting;
+        }),
+
+      setIsInitializingServer: (isInitializing) =>
+        set((state) => {
+          state.isInitializingServer = isInitializing;
+        }),
+
+      setIsWaitingForUserInteraction: (isWaiting) =>
+        set((state) => {
+          state.isWaitingForUserInteraction = isWaiting;
+        }),
+
+      setIsProcessingQueuedMessages: (isProcessing) =>
+        set((state) => {
+          state.isProcessingQueuedMessages = isProcessing;
+        }),
+
+      setBatchOperationInProgress: (isInProgress) =>
+        set((state) => {
+          state.isBatchOperationInProgress = isInProgress;
+        }),
+
+      setActiveDecorators: (decorators) =>
+        set((state) => {
+          state.activeDecorators = decorators;
+        }),
+
+      deleteActiveDecorator: (streamId) =>
+        set((state) => {
+          if (state.activeDecorators && state.activeDecorators[streamId]) {
+            delete state.activeDecorators[streamId];
+          }
+        }),
+
+      setConfigErrors: (errors) =>
+        set((state) => {
+          state.configErrors = errors;
+        }),
+
+      addConfigError: (error) =>
+        set((state) => {
+          state.configErrors.push(error);
+        }),
+
+      clearConfigErrors: () =>
+        set((state) => {
+          state.configErrors = [];
+        }),
+
+      setSolutionState: (solutionState) =>
+        set((state) => {
+          state.solutionState = solutionState;
+        }),
+
+      setSolutionScope: (scope) =>
+        set((state) => {
+          state.solutionScope = scope;
+        }),
+
+      setSolutionServerConnected: (connected) =>
+        set((state) => {
+          state.solutionServerConnected = connected;
+        }),
+
+      setSolutionServerEnabled: (enabled) =>
+        set((state) => {
+          state.solutionServerEnabled = enabled;
+        }),
+
+      setIsAgentMode: (isAgentMode) =>
+        set((state) => {
+          state.isAgentMode = isAgentMode;
+        }),
+
+      setIsContinueInstalled: (isInstalled) =>
+        set((state) => {
+          state.isContinueInstalled = isInstalled;
+        }),
+
+      setHubConfig: (config) =>
+        set((state) => {
+          state.hubConfig = config;
+        }),
+
+      setWorkspaceRoot: (root) =>
+        set((state) => {
+          state.workspaceRoot = root;
+        }),
+
+      setProfileSyncEnabled: (enabled) =>
+        set((state) => {
+          state.profileSyncEnabled = enabled;
+        }),
+
+      setProfileSyncConnected: (connected) =>
+        set((state) => {
+          state.profileSyncConnected = connected;
+        }),
+
+      setIsSyncingProfiles: (isSyncing) =>
+        set((state) => {
+          state.isSyncingProfiles = isSyncing;
+        }),
+
+      setLlmProxyAvailable: (available) =>
+        set((state) => {
+          state.llmProxyAvailable = available;
+        }),
+
+      clearAnalysisData: () =>
+        set((state) => {
+          state.ruleSets = [];
+          state.enhancedIncidents = [];
+        }),
+
+      batchUpdate: (updates) =>
+        set((state) => {
+          Object.assign(state, updates);
+        }),
+    })),
   ),
 );
 
-/**
- * ✅ BENEFIT: Can create derived selectors (like Redux)
- * But without the boilerplate
- */
 export const selectIncidentCount = (state: ExtensionStore) => state.enhancedIncidents.length;
 
 export const selectIncidentsByFile = (state: ExtensionStore) => {


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/a5cc0915-bd98-4b74-8594-4913a3c76c8a



After:


https://github.com/user-attachments/assets/8bc0041a-c2f6-4707-be59-e70251192b8d

Resolves https://github.com/konveyor/editor-extensions/issues/1151
Resolves https://github.com/konveyor/editor-extensions/issues/1133

--
isFullStateUpdate() was a catch-all that matched ANY unknown message. When VS Code's internal ads#INIT message came in(only happens in devspaces env. Not sure what is triggering this message, but it did expose this bug for all uncaught webview messages), it triggered a full state update with profiles: [], resetting the store.

Also a part of this PR aside from the above bugfix is the removal of zustand persist.

All persisted values came from the backend anyway - isAgentMode, solutionServerEnabled, etc. are all in konveyorInitialData. Removed this in favor of a single source of truth - The backend (globalState/workspaceState) is authoritative for profiles and settings. This should eliminate potential future race conditions - Even with the fix, localStorage could still show stale data briefly. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tree mode functionality

* **Refactor**
  * Optimized message type discrimination logic
  * Simplified state management by removing persistence middleware

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->