### PR TITLE
:sparkles: Add violation specific search on open details command

### DIFF
--- a/shared/src/types/messages.ts
+++ b/shared/src/types/messages.ts
@@ -30,6 +30,7 @@ export const MessageTypes = {
   CONFIG_ERRORS_UPDATE: "CONFIG_ERRORS_UPDATE",
   DECORATORS_UPDATE: "DECORATORS_UPDATE",
   SETTINGS_UPDATE: "SETTINGS_UPDATE",
+  FOCUS_VIOLATION: "FOCUS_VIOLATION",
 } as const;
 
 export type MessageType = (typeof MessageTypes)[keyof typeof MessageTypes];
@@ -139,6 +140,13 @@ export interface SettingsUpdateMessage {
   timestamp: string;
 }
 
+export interface FocusViolationMessage {
+  type: "FOCUS_VIOLATION";
+  violationId: string;
+  violationMessage: string;
+  timestamp: string;
+}
+
 /**
  * Union type of all possible webview messages
  */
@@ -153,7 +161,8 @@ export type WebviewMessage =
   | ProfilesUpdateMessage
   | ConfigErrorsUpdateMessage
   | DecoratorsUpdateMessage
-  | SettingsUpdateMessage;
+  | SettingsUpdateMessage
+  | FocusViolationMessage;
 
 /**
  * Type guards for message discrimination
@@ -204,4 +213,8 @@ export function isSettingsUpdate(msg: WebviewMessage): msg is SettingsUpdateMess
 
 export function isFullStateUpdate(msg: WebviewMessage): msg is FullStateUpdateMessage {
   return (msg as any).type === MessageTypes.FULL_STATE_UPDATE;
+}
+
+export function isFocusViolation(msg: WebviewMessage): msg is FocusViolationMessage {
+  return (msg as any).type === MessageTypes.FOCUS_VIOLATION;
 }

--- a/vscode/core/src/commands.ts
+++ b/vscode/core/src/commands.ts
@@ -454,10 +454,16 @@ const commandsMap: (
       resolutionProvider?.showWebviewPanel();
     },
     [`${EXTENSION_NAME}.openAnalysisDetails`]: async (item: IncidentTypeItem) => {
-      //TODO: pass the item to webview and move the focus
       logger.info("Open details for item", { item });
-      const resolutionProvider = state.webviewProviders?.get("sidebar");
-      resolutionProvider?.showWebviewPanel();
+      const sidebarProvider = state.webviewProviders?.get("sidebar");
+      sidebarProvider?.showWebviewPanel();
+
+      sidebarProvider?.sendMessageToWebview({
+        type: "FOCUS_VIOLATION",
+        violationId: item.msg,
+        violationMessage: item.msg,
+        timestamp: new Date().toISOString(),
+      });
     },
     [`${EXTENSION_NAME}.fixGroupOfIncidents`]: fixGroupOfIncidents,
     [`${EXTENSION_NAME}.fixIncident`]: fixGroupOfIncidents,

--- a/webview-ui/src/components/ViolationIncidentsList.tsx
+++ b/webview-ui/src/components/ViolationIncidentsList.tsx
@@ -37,6 +37,7 @@ import { IncidentTableGroup } from "./IncidentTable";
 import { EnhancedIncident, Incident, Category } from "@editor-extensions/shared";
 import GetSolutionDropdown from "./GetSolutionDropdown";
 import { getIncidentFile } from "../utils/incident";
+import { useExtensionStore } from "../store/store";
 
 type GroupByOption = "none" | "file" | "violation";
 
@@ -66,6 +67,29 @@ const ViolationIncidentsList = ({
     groupBy: "violation" as GroupByOption,
     hasSuccessRate: false,
   });
+
+  const focusedViolationFilter = useExtensionStore((state) => state.focusedViolationFilter);
+  const setFocusedViolationFilter = useExtensionStore((state) => state.setFocusedViolationFilter);
+
+  React.useEffect(() => {
+    if (focusedViolationFilter) {
+      setSearchTerm(focusedViolationFilter);
+
+      const matchingIds = enhancedIncidents
+        .filter(
+          (incident) =>
+            incident.message.toLowerCase().includes(focusedViolationFilter.toLowerCase()) ||
+            incident.violation_description?.toLowerCase().includes(focusedViolationFilter.toLowerCase()),
+        )
+        .map((incident) => incident.violationId);
+
+      if (matchingIds.length > 0) {
+        setExpandedViolations(new Set(matchingIds));
+      }
+
+      setFocusedViolationFilter(null);
+    }
+  }, [focusedViolationFilter, setFocusedViolationFilter, enhancedIncidents, setExpandedViolations]);
 
   const onCategorySelect = (
     _event: React.MouseEvent | undefined,

--- a/webview-ui/src/hooks/useVSCodeMessageHandler.ts
+++ b/webview-ui/src/hooks/useVSCodeMessageHandler.ts
@@ -11,6 +11,7 @@ import {
   isConfigErrorsUpdate,
   isDecoratorsUpdate,
   isSettingsUpdate,
+  isFocusViolation,
   ConfigErrorType,
 } from "@editor-extensions/shared";
 import { useExtensionStore } from "../store/store";
@@ -215,6 +216,12 @@ export function useVSCodeMessageHandler() {
             isSyncingProfiles: message.isSyncingProfiles,
             llmProxyAvailable: message.llmProxyAvailable,
           });
+          return;
+        }
+
+        // Handle focus violation (from tree view "Open Details" action)
+        if (isFocusViolation(message)) {
+          store.setFocusedViolationFilter(message.violationMessage);
           return;
         }
 

--- a/webview-ui/src/store/store.ts
+++ b/webview-ui/src/store/store.ts
@@ -59,6 +59,9 @@ interface ExtensionStore {
   pendingBatchReview: PendingBatchReviewFile[];
   isBatchOperationInProgress: boolean;
 
+  // Focus/filter state (from tree view "Open Details")
+  focusedViolationFilter: string | null;
+
   setRuleSets: (ruleSets: RuleSet[]) => void;
   setEnhancedIncidents: (incidents: EnhancedIncident[]) => void;
   setIsAnalyzing: (isAnalyzing: boolean) => void;
@@ -97,6 +100,7 @@ interface ExtensionStore {
   setProfileSyncConnected: (connected: boolean) => void;
   setIsSyncingProfiles: (isSyncing: boolean) => void;
   setLlmProxyAvailable: (available: boolean) => void;
+  setFocusedViolationFilter: (filter: string | null) => void;
 
   // Utility
   clearAnalysisData: () => void;
@@ -143,6 +147,9 @@ export const useExtensionStore = create<ExtensionStore>()(
       // Batch review state
       pendingBatchReview: [],
       isBatchOperationInProgress: false,
+
+      // Focus/filter state
+      focusedViolationFilter: null,
 
       setRuleSets: (ruleSets) =>
         set((state) => {
@@ -328,6 +335,11 @@ export const useExtensionStore = create<ExtensionStore>()(
       setLlmProxyAvailable: (available) =>
         set((state) => {
           state.llmProxyAvailable = available;
+        }),
+
+      setFocusedViolationFilter: (filter) =>
+        set((state) => {
+          state.focusedViolationFilter = filter;
         }),
 
       clearAnalysisData: () =>


### PR DESCRIPTION
https://github.com/user-attachments/assets/c28ac0d4-e311-4165-868b-bd293261ae07

Resolves [Clicking the incident in the issue view does not open the corresponding section in the webview](https://github.com/konveyor/editor-extensions/issues/183)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Violations are now automatically focused when opening analysis details—matching violations are highlighted, scrolled into view, and their groups are expanded.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->