### PR TITLE
:test_tube: Update output channel name

### DIFF
--- a/tests/e2e/enums/output.enum.ts
+++ b/tests/e2e/enums/output.enum.ts
@@ -1,4 +1,6 @@
-export enum OutputChannel {
-  KonveyorExtensionForVSCode = 'Konveyor Extension for VSCode',
-  ExtensionHost = 'Extension Host',
-}
+import { extensionShortName } from '../utilities/utils';
+
+export const OutputChannels = {
+  CoreExtension: `${extensionShortName} Core Extension`,
+  ExtensionHost: 'Extension Host',
+} as const;

--- a/tests/e2e/pages/output.page.ts
+++ b/tests/e2e/pages/output.page.ts
@@ -1,7 +1,7 @@
 import { expect, Page } from '@playwright/test';
-import { OutputChannel } from '../enums/output.enum';
 import { VSCode } from './vscode.page';
 import { SCREENSHOTS_FOLDER } from '../utilities/consts';
+import { OutputChannels } from '../enums/output.enum';
 
 export class OutputPanel {
   private static instance: OutputPanel;
@@ -24,7 +24,10 @@ export class OutputPanel {
    * @param channel - The channel to open.
    * @param filterText - The text to filter the output.
    */
-  public async openOutputView(channel: OutputChannel, filterText?: string): Promise<void> {
+  public async openOutputView(
+    channel: (typeof OutputChannels)[keyof typeof OutputChannels],
+    filterText?: string
+  ): Promise<void> {
     console.log(`Opening output view for channel: [${channel}]`);
     if (this.outputOpened) {
       console.log(`Output view already opened for channel: [${channel}]`);
@@ -62,7 +65,7 @@ export class OutputPanel {
    * @returns The content of the output channel.
    */
   public async getOutputChannelContent(
-    channel: OutputChannel,
+    channel: (typeof OutputChannels)[keyof typeof OutputChannels],
     filterText?: string
   ): Promise<string> {
     await this.openOutputView(channel, filterText);
@@ -87,7 +90,7 @@ export class OutputPanel {
    * @returns The content of the output channel.
    */
   public async getOutputChannelContentByRegex(
-    channel: OutputChannel,
+    channel: (typeof OutputChannels)[keyof typeof OutputChannels],
     regex: RegExp
   ): Promise<string> {
     const content = await this.getOutputChannelContent(channel);

--- a/tests/e2e/tests/base/fix-one-issue.test.ts
+++ b/tests/e2e/tests/base/fix-one-issue.test.ts
@@ -7,7 +7,7 @@ import * as VSCodeFactory from '../../utilities/vscode.factory';
 import { Configuration } from '../../pages/configuration.page';
 import { logLevel } from '../../enums/configuration-options.enum';
 import { LogLevel } from '../../enums/Log-level.enum';
-import { OutputChannel } from '../../enums/output.enum';
+import { OutputChannels } from '../../enums/output.enum';
 import { ResolutionAction } from '../../enums/resolution-action.enum';
 import { SCREENSHOTS_FOLDER } from '../../utilities/consts';
 
@@ -29,7 +29,7 @@ getAvailableProviders().forEach((provider) => {
       const configPage = await Configuration.open(vscodeApp);
       await configPage.setDropdownConfiguration(logLevel, LogLevel.INFO);
       // open output view and clear it
-      await vscodeApp.outputPanel.openOutputView(OutputChannel.KonveyorExtensionForVSCode);
+      await vscodeApp.outputPanel.openOutputView(OutputChannels.CoreExtension);
       await vscodeApp.outputPanel.clearOutputChannel();
       await vscodeApp.outputPanel.closeOutputView();
       await vscodeApp.runAnalysis();
@@ -71,7 +71,7 @@ getAvailableProviders().forEach((provider) => {
       console.log('Analysis completed');
       await vscodeApp.waitDefault();
       const logOutput = await vscodeApp.outputPanel.getOutputChannelContent(
-        OutputChannel.KonveyorExtensionForVSCode
+        OutputChannels.CoreExtension
       );
       const logEntries = parseLogEntries(logOutput);
       expect(logEntries.length).toBeGreaterThanOrEqual(1);


### PR DESCRIPTION
CI started to fail after the renaming of "konveyor" to "konveyor core"

Check run from this branch [here](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/kai-e2e-nightly-linux/295/) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test output handling utilities for improved test infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->