### PR TITLE
:bug: Remove trailing slash in hub config form

### DIFF
--- a/webview-ui/src/components/HubSettings/HubSettingsForm.tsx
+++ b/webview-ui/src/components/HubSettings/HubSettingsForm.tsx
@@ -120,11 +120,12 @@ export const HubSettingsForm: React.FC<{
       return;
     }
 
-    formData.url = formData.url.endsWith("/") ? formData.url.slice(0, -1) : formData.url;
-
     dispatch({
       type: "UPDATE_HUB_CONFIG",
-      payload: formData,
+      payload: {
+        ...formData,
+        url: formData.url.endsWith("/") ? formData.url.slice(0, -1) : formData.url,
+      },
     });
 
     setSaveSuccess(true);


### PR DESCRIPTION
Remove extra slash in hub connection form. 
This was handled in the profilesync and Solution server clients but not in the hub manager itself, so the login would fail if the url had a trailing slash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hub URL configuration now automatically normalizes saved URLs by removing trailing slashes, ensuring consistent URL formatting and preventing mismatches when using saved hub addresses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->