### PR TITLE
:bug: notify providers when a file changes

### DIFF
--- a/vscode/core/src/utilities/ModifiedFiles/handleFileResponse.ts
+++ b/vscode/core/src/utilities/ModifiedFiles/handleFileResponse.ts
@@ -166,6 +166,17 @@ export async function handleFileResponse(
         // Skip analysis if explicitly requested (e.g., from decorator review flow where analysis runs on save)
         if (!skipAnalysis) {
           try {
+            // Notify providers about file changes first so they can invalidate their caches
+            // This is critical for providers like c-sharp-analyzer that cache the code graph
+            if (state.analyzerClient) {
+              await state.analyzerClient.notifyFileChanges([
+                {
+                  path: uri,
+                  content: fileContent,
+                  saved: true,
+                },
+              ]);
+            }
             await runPartialAnalysis(state, [uri]);
           } catch (analysisError) {
             logger.warn(


### PR DESCRIPTION
fixes https://github.com/konveyor/c-sharp-analyzer-provider/pull/89



When accepting a solution fix for C# incidents, the incident count doesn't decrease because the analyzer's cached code graph is not invalidated when files change.  `handleFileResponse.ts` calls `runPartialAnalysis` without first calling `notifyFileChanges`, so C# provider is not notified about file changes and continue to use the cached code graph 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file change handling to ensure all edits are properly analyzed and processed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->