### PR TITLE
:bug: fix: Only use env var overrides when explicitly set

### DIFF
--- a/vscode/core/src/utilities/hubConfigStorage.ts
+++ b/vscode/core/src/utilities/hubConfigStorage.ts
@@ -85,10 +85,12 @@ export function getDefaultHubConfig(): HubConfig {
     },
     features: {
       solutionServer: {
-        enabled: env.solutionServerEnabled,
+        enabled:
+          process.env.HUB_SOLUTION_SERVER_ENABLED !== undefined ? env.solutionServerEnabled : true, // Default to true for new configs
       },
       profileSync: {
-        enabled: hubEnabled ? env.profileSyncEnabled : false,
+        enabled:
+          process.env.HUB_PROFILE_SYNC_ENABLED !== undefined ? env.profileSyncEnabled : hubEnabled, // Default to enabled when hub is enabled
       },
     },
   };
@@ -120,12 +122,16 @@ export async function initializeHubConfig(context: vscode.ExtensionContext): Pro
     },
     features: {
       solutionServer: {
-        enabled: hubEnabled
-          ? env.solutionServerEnabled
-          : savedConfig.features.solutionServer.enabled,
+        enabled:
+          process.env.HUB_SOLUTION_SERVER_ENABLED !== undefined
+            ? env.solutionServerEnabled
+            : savedConfig.features.solutionServer.enabled,
       },
       profileSync: {
-        enabled: hubEnabled ? env.profileSyncEnabled : savedConfig.features.profileSync.enabled,
+        enabled:
+          process.env.HUB_PROFILE_SYNC_ENABLED !== undefined
+            ? env.profileSyncEnabled
+            : savedConfig.features.profileSync.enabled,
       },
     },
   };


### PR DESCRIPTION
The previous implementation always used env var defaults when hub was enabled, preventing users from toggling features off in the UI. Now:

- Only override feature settings when env vars are explicitly set
- When no env vars are set, use saved config values
- For new configs (no saved state), default solutionServer to true and profileSync to match hub enabled state

This ensures manual hub configuration works correctly even when no environment variables are defined.

Closes #1216 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hub feature toggles can now be configured via environment variables for enhanced deployment flexibility, allowing override of default settings without code changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->