### PR TITLE
:bug: better useDefaultRules logic

### DIFF
--- a/vscode/core/src/clients/ProfileSyncClient.ts
+++ b/vscode/core/src/clients/ProfileSyncClient.ts
@@ -746,9 +746,10 @@ export class ProfileSyncClient {
           this.logger.warn("Failed to find ruleset files in bundle", { profileId, globError });
         }
 
-        // Determine useDefaultRules based on Hub profile mode
-        // If mode.withDeps is true, we likely want default rules too
-        const useDefaultRules = parsed.mode?.withDeps ?? false;
+        // Determine useDefaultRules based on whether targets are specified
+        // useDefaultRules should be true iff .rules.targets is not empty
+        const useDefaultRules =
+          Array.isArray(parsed.rules?.targets) && parsed.rules.targets.length > 0;
 
         // Transform to standard format matching the spec
         const standardProfile = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated profile synchronization logic to determine whether default rules should be applied based on the presence of target rule definitions rather than profile mode settings. This affects how standard profiles are configured when synchronized.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->