### PR TITLE
:bug: remove onStartupFinished from activation events

### DIFF
--- a/vscode/csharp/package.json
+++ b/vscode/csharp/package.json
@@ -36,7 +36,6 @@
   ],
   "activationEvents": [
     "onLanguage:csharp",
-    "onStartupFinished",
     "workspaceContains:*.csproj",
     "workspaceContains:**/*.csproj",
     "workspaceContains:*.sln",


### PR DESCRIPTION
The C# extension was activating on every VS Code startup due to the onStartupFinished activation event. This caused users who only want to use other language providers (e.g., Java) to see warnings about missing C# tools (ilspycmd, paket).

Remove onStartupFinished so the extension only activates when:
- A C# file is opened
- The workspace contains .csproj or .sln files
https://github.com/konveyor/editor-extensions/issues/1221


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized the C# extension's startup behavior to reduce startup time and improve system resource efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->