### PR TITLE
:bug: moving notify changes out of conditional block

### DIFF
--- a/vscode/core/src/utilities/ModifiedFiles/handleFileResponse.ts
+++ b/vscode/core/src/utilities/ModifiedFiles/handleFileResponse.ts
@@ -161,22 +161,29 @@ export async function handleFileResponse(
           await updateExistingFile(uri, path, fileContent, state);
         }
 
+        // Notify providers about file changes
+        // This is critical for providers like c-sharp-analyzer that cache the code graph
+        if (state.analyzerClient) {
+          try {
+            logger.info(`Calling notifyFileChanges for file: ${path}`);
+            await state.analyzerClient.notifyFileChanges([
+              {
+                path: uri,
+                content: fileContent,
+                saved: true,
+              },
+            ]);
+            logger.info(`notifyFileChanges completed for file: ${path}`);
+          } catch (notifyError) {
+            logger.warn(`Failed to notify file changes for ${path}:`, notifyError);
+          }
+        }
+
         // Trigger analysis after file changes are applied in agentic mode or when analyze on save is enabled
         // This ensures that the tasks interaction can detect new diagnostic issues
         // Skip analysis if explicitly requested (e.g., from decorator review flow where analysis runs on save)
         if (!skipAnalysis) {
           try {
-            // Notify providers about file changes first so they can invalidate their caches
-            // This is critical for providers like c-sharp-analyzer that cache the code graph
-            if (state.analyzerClient) {
-              await state.analyzerClient.notifyFileChanges([
-                {
-                  path: uri,
-                  content: fileContent,
-                  saved: true,
-                },
-              ]);
-            }
             await runPartialAnalysis(state, [uri]);
           } catch (analysisError) {
             logger.warn(


### PR DESCRIPTION
I had to move this out to avoid race conditions when I click accept all button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved file change handling to ensure modifications are properly tracked and processed more efficiently during analysis operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->