### PR TITLE
:bug: fix analyzer download bugs

### DIFF
--- a/changes/unreleased/analyzer-download-bugs.yaml
+++ b/changes/unreleased/analyzer-download-bugs.yaml
@@ -1,0 +1,5 @@
+kind: bugfix
+description: >
+  Fix analyzer binary download to track version metadata for outdated binary
+  detection and provide actionable error messages in network-restricted
+  environments.


### PR DESCRIPTION
Fixes #1260
Fixes #942 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust detection of up-to-date analyzer binaries to avoid unnecessary re-downloads.
  * Preserve existing binaries when metadata is missing/invalid or when no platform fallback is available.
  * Improved checksum validation and clearer, actionable error messages for download failures and network-restricted environments.

* **Chores**
  * Write/update install metadata after successful installs and add more detailed logging around binary status, download outcomes, and version mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->