### PR TITLE
:seedling: parallel AND SKIPPABLE publish

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -8,6 +8,16 @@ on:
         required: false
         type: boolean
         default: false
+      skip_vscode_publish:
+        description: "Skip publishing to VS Code Marketplace"
+        required: false
+        type: boolean
+        default: false
+      skip_openvsx_publish:
+        description: "Skip publishing to Open VSX"
+        required: false
+        type: boolean
+        default: false
 
 env:
   HUSKY: 0
@@ -86,6 +96,8 @@ jobs:
       tag: ${{ needs.validate.outputs.tag }}
       prerelease: false
       ref: main
+      skip_vscode_publish: ${{ inputs.skip_vscode_publish }}
+      skip_openvsx_publish: ${{ inputs.skip_openvsx_publish }}
     secrets: inherit
 
   housekeeping:

--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: boolean
         default: false
+      skip_vscode_publish:
+        description: "Skip publishing to VS Code Marketplace"
+        required: false
+        type: boolean
+        default: false
+      skip_openvsx_publish:
+        description: "Skip publishing to Open VSX"
+        required: false
+        type: boolean
+        default: false
 
 env:
   HUSKY: 0
@@ -75,6 +85,8 @@ jobs:
       tag: ${{ needs.compute-version.outputs.tag }}
       prerelease: false
       ref: ${{ inputs.branch }}
+      skip_vscode_publish: ${{ inputs.skip_vscode_publish }}
+      skip_openvsx_publish: ${{ inputs.skip_openvsx_publish }}
     secrets: inherit
 
   housekeeping:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,16 @@ on:
         description: "Git ref to build from (e.g., main, release-0.4)"
         required: true
         type: string
+      skip_vscode_publish:
+        description: "Skip publishing to VS Code Marketplace"
+        required: false
+        type: boolean
+        default: false
+      skip_openvsx_publish:
+        description: "Skip publishing to Open VSX"
+        required: false
+        type: boolean
+        default: false
 
 env:
   HUSKY: 0
@@ -115,10 +125,11 @@ jobs:
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
-  publish:
-    name: Publish to Marketplaces
+  publish-vscode:
+    name: Publish to VS Code Marketplace
     runs-on: ubuntu-latest
     needs: e2e
+    if: ${{ !inputs.skip_vscode_publish }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -151,6 +162,29 @@ jobs:
             fi
           done
 
+  publish-openvsx:
+    name: Publish to Open VSX
+    runs-on: ubuntu-latest
+    needs: e2e
+    if: ${{ !inputs.skip_openvsx_publish }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Download VSIX artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: vsix-artifacts
+          path: ./artifacts
+
+      - name: Verify artifacts
+        run: ls -R ./artifacts/
+
       - name: Publish to Open VSX
         run: |
           for vsix in ./artifacts/*.vsix; do
@@ -168,7 +202,8 @@ jobs:
   github-release:
     name: Create Tag & GitHub Release
     runs-on: ubuntu-latest
-    needs: [package, publish]
+    needs: [package, publish-vscode, publish-openvsx]
+    if: ${{ always() && !failure() && !cancelled() }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to conditionally skip publishing to VS Code Marketplace or Open VSX during releases
  * Added support for publishing to Open VSX marketplace alongside VS Code Marketplace

<!-- end of auto-generated comment: release notes by coderabbit.ai -->