### PR TITLE
:bug: (backport) honor CA_BUNDLE and ALLOW_INSECURE for Google GenAI provider

### DIFF
--- a/changes/unreleased/fix-google-genai-ca-bundle.yaml
+++ b/changes/unreleased/fix-google-genai-ca-bundle.yaml
@@ -1,0 +1,3 @@
+kind: bugfix
+description: >
+  Fixed CA_BUNDLE and ALLOW_INSECURE settings being ignored for the Google GenAI provider by configuring the global fetch dispatcher with custom TLS certificates.


### PR DESCRIPTION
#1272 

The ChatGoogleGenerativeAI provider uses the global fetch() internally and does not accept a custom fetch function. This meant CA_BUNDLE and ALLOW_INSECURE environment settings were silently ignored, causing TLS errors when connecting to endpoints with custom or self-signed certs.

Fix this by using undici's setGlobalDispatcher() to configure Node's global fetch with a custom dispatcher that includes the CA bundle certificates merged with system root CAs. Also adds test coverage for the Google GenAI provider TLS path alongside the existing OpenAI tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
* Fixed CA_BUNDLE and ALLOW_INSECURE environment variable settings for the Google GenAI provider, which were previously ignored.

* **Tests**
* Extended test coverage for Google GenAI provider with self-signed certificate scenarios to ensure secure connections work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
