### PR TITLE
:bug: (backport) honor CA_BUNDLE and ALLOW_INSECURE for Google GenAI provider

### DIFF
--- a/changes/unreleased/fix-google-genai-ca-bundle.yaml
+++ b/changes/unreleased/fix-google-genai-ca-bundle.yaml
@@ -1,0 +1,3 @@
+kind: bugfix
+description: >
+  Fixed CA_BUNDLE and ALLOW_INSECURE settings being ignored for the Google GenAI provider by configuring the global fetch dispatcher with custom TLS certificates.

--- a/vscode/src/modelProvider/__tests__/modelProvider.test.ts
+++ b/vscode/src/modelProvider/__tests__/modelProvider.test.ts
@@ -123,6 +123,21 @@ describe("model health check test", () => {
         OPENAI_API_KEY: "test-key",
       },
     },
+    googleGenAI: {
+      config: {
+        provider: "ChatGoogleGenerativeAI",
+        args: {
+          model: "test-model",
+          baseUrl: "https://localhost:8443",
+          streaming: false,
+        },
+      },
+      env: {
+        ALLOW_INSECURE: "false",
+        CA_BUNDLE: pathlib.join(certsDir, "ca.crt"),
+        GOOGLE_API_KEY: "test-key",
+      },
+    },
   };
 
   // setting up the server
@@ -235,9 +250,52 @@ describe("model health check test", () => {
       openaiConfig.env.CA_BUNDLE = "";
       const modelCreator = ModelCreators[openaiConfig.config.provider](logger);
       const modelProvider = await modelCreator.create(openaiConfig.config.args, openaiConfig.env);
-      await withTimeout(modelProvider.invoke("Hello, world!"), 5000); // if the response is hanging for 5 seconds, connecton is not established
+      await withTimeout(modelProvider.invoke("Hello, world!"), 5000);
+      throw new Error("Expected connection to fail without CA_BUNDLE, but it succeeded");
     } catch (error) {
       expect(error).toBeDefined();
+    }
+  });
+
+  it("should connect to Google GenAI server when self-signed certs are used", async function (this: Mocha.Context) {
+    this.timeout(8000);
+    try {
+      const googleConfig = JSON.parse(JSON.stringify(configs.googleGenAI));
+      const modelCreator = ModelCreators[googleConfig.config.provider](logger);
+      const modelProvider = await modelCreator.create(googleConfig.config.args, googleConfig.env);
+      await modelProvider.invoke("Hello, world!");
+    } catch (error) {
+      console.error(error);
+      throw new Error("Failed to connect to Google GenAI server with self-signed certs");
+    }
+  });
+
+  it("should error when Google GenAI certs are not used with mock server that expects them", async function (this: Mocha.Context) {
+    this.timeout(7000);
+    try {
+      const googleConfig = JSON.parse(JSON.stringify(configs.googleGenAI));
+      googleConfig.env.CA_BUNDLE = "";
+      const modelCreator = ModelCreators[googleConfig.config.provider](logger);
+      const modelProvider = await modelCreator.create(googleConfig.config.args, googleConfig.env);
+      await withTimeout(modelProvider.invoke("Hello, world!"), 5000);
+      throw new Error("Expected connection to fail without CA_BUNDLE, but it succeeded");
+    } catch (error) {
+      expect(error).toBeDefined();
+    }
+  });
+
+  it("should NOT error when Google GenAI certs are not used but insecure is set", async function (this: Mocha.Context) {
+    this.timeout(7000);
+    try {
+      const googleConfig = JSON.parse(JSON.stringify(configs.googleGenAI));
+      googleConfig.env.CA_BUNDLE = "";
+      googleConfig.env.ALLOW_INSECURE = "true";
+      const modelCreator = ModelCreators[googleConfig.config.provider](logger);
+      const modelProvider = await modelCreator.create(googleConfig.config.args, googleConfig.env);
+      await modelProvider.invoke("Hello, world!");
+    } catch (error) {
+      console.error(error);
+      throw new Error("Failed to connect to Google GenAI server with insecure mode");
     }
   });
 


### PR DESCRIPTION
Backport of #1272 to release-0.2.

The ChatGoogleGenerativeAI provider uses the global fetch() internally and does not accept a custom fetch function. This meant CA_BUNDLE and ALLOW_INSECURE environment settings were silently ignored, causing TLS errors when connecting to endpoints with custom or self-signed certs.

Fix by using undici's setGlobalDispatcher() to configure the global fetch with a custom dispatcher that merges user CA bundles with system root certificates. Unify all providers under a single setupProviderTLS function so new providers automatically inherit TLS support.

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
