### PR TITLE
:bug: Add new smoke test instead base to save time

### DIFF
--- a/changes/unreleased/0000-smoke-test.yaml
+++ b/changes/unreleased/0000-smoke-test.yaml
@@ -1,0 +1,3 @@
+kind: enhancement
+description: >
+  Add a minimal smoke E2E flow and decouple heavy base tests from tiered runs.

--- a/tests/e2e/tests/smoke/minimal-core.test.ts
+++ b/tests/e2e/tests/smoke/minimal-core.test.ts
@@ -1,0 +1,54 @@
+import { RepoData, expect, test } from '../../fixtures/test-repo-fixture';
+import { VSCode } from '../../pages/vscode.page';
+import { DEFAULT_PROVIDER } from '../../fixtures/provider-configs.fixture';
+import { generateRandomString } from '../../utilities/utils';
+import * as VSCodeFactory from '../../utilities/vscode.factory';
+
+test.describe.serial('Minimal core smoke flow', { tag: ['@tier0', '@smoke'] }, () => {
+  let vscodeApp: VSCode;
+  let repoInfo: RepoData[string];
+  const profileName = `smoke-${generateRandomString()}`;
+
+  test.beforeAll(async ({ testRepoData }) => {
+    test.setTimeout(600000);
+    repoInfo = testRepoData['coolstore'];
+    if (!repoInfo) {
+      throw new Error("'coolstore' fixture is missing from test-repos.json");
+    }
+    vscodeApp = await VSCodeFactory.open(repoInfo.repoUrl, repoInfo.repoName);
+    await vscodeApp.waitDefault();
+  });
+
+  test('GenAI configuration', async () => {
+    await vscodeApp.configureGenerativeAI(DEFAULT_PROVIDER.config);
+  });
+
+  test('Create profile', async () => {
+    await vscodeApp.createProfile(repoInfo.sources, repoInfo.targets, profileName);
+  });
+
+  test('Start server', async () => {
+    await vscodeApp.startServer();
+  });
+
+  test('Run analysis', async () => {
+    test.setTimeout(300000);
+    await vscodeApp.runAnalysis();
+    await vscodeApp.waitForAnalysisCompleted();
+  });
+
+  test('Verify analysis returns results', async () => {
+    await vscodeApp.openAnalysisView();
+    await vscodeApp.waitDefault();
+    const issuesCount = await vscodeApp.getIssuesCount();
+    expect(issuesCount).toBeGreaterThan(0);
+  });
+
+  test('Delete the profile', async () => {
+    await vscodeApp.deleteProfile(profileName);
+  });
+
+  test.afterAll(async () => {
+    await vscodeApp.closeVSCode();
+  });
+});

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -30,6 +30,10 @@ export default defineConfig({
   },
   projects: [
     {
+      name: 'smoke',
+      testMatch: ['**/smoke/**/*.test.ts'],
+    },
+    {
       name: 'base',
       testMatch: ['**/base/**/*.test.ts'],
     },
@@ -44,7 +48,7 @@ export default defineConfig({
     {
       name: 'analysis-tests',
       testMatch: /.*analyze.+\.test\.ts/,
-      dependencies: ['base'],
+      dependencies: ['smoke'],
     },
     {
       name: 'agent-flow-tests',


### PR DESCRIPTION
Remove 'base' suite test from dependency and, add quick a smoke test to save time. This avoid running base suite in tier3 which has intensive core-extension functionality testing when it is not needed.
#1211 
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new end-to-end smoke test flow to verify core workflows: profile lifecycle, server startup, analysis run, and result validation.
  * Improved robustness with error handling, randomized profile names, and extended timeouts for long-running steps.
  * Introduced a dedicated smoke test project to run lightweight tiered E2E checks.
* **Chores**
  * Updated test configuration to decouple heavy base tests from smoke runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->