### PR TITLE
:bug:(release0.4) override globalThis.fetch so bundled undici's TLS config reache…

### DIFF
--- a/changes/unreleased/fix-globalfetch-bundled-undici.yaml
+++ b/changes/unreleased/fix-globalfetch-bundled-undici.yaml
@@ -1,0 +1,3 @@
+kind: bugfix
+description: >
+  Fixed CA_BUNDLE and ALLOW_INSECURE not reaching Google GenAI provider due to webpack-bundled undici being separate from Node's built-in fetch.

--- a/vscode/core/src/modelProvider/modelCreator.ts
+++ b/vscode/core/src/modelProvider/modelCreator.ts
@@ -17,6 +17,7 @@ import { ModelCreator, PROVIDER_ENV_CA_BUNDLE, PROVIDER_ENV_INSECURE, type Fetch
 import { getConfigHttpProtocol } from "../utilities/httpProtocol";
 
 const defaultDispatcher = getGlobalDispatcher();
+const originalFetch = globalThis.fetch;
 
 export const ModelCreators: Record<string, (logger: Logger) => ModelCreator> = {
   AzureChatOpenAI: (logger) => new AzureChatOpenAICreator(logger),
@@ -244,13 +245,15 @@ function getCaBundleAndInsecure(env: Record<string, string>): {
 }
 
 /**
- * Unified TLS setup for all model providers. Creates a single dispatcher that:
- * 1. Sets the global fetch dispatcher (for SDKs like Google GenAI that use
- *    global fetch internally and don't accept a custom fetch function)
- * 2. Returns a custom fetch function (for SDKs like OpenAI/Azure that accept one)
+ * Unified TLS setup for all model providers.
  *
- * Every provider calls this same function, so new providers automatically get
- * CA_BUNDLE, ALLOW_INSECURE, and HTTP protocol support.
+ * Webpack bundles our `undici` dependency into the extension, creating a
+ * separate instance from Node's built-in undici (`node:internal/deps/undici`).
+ * `setGlobalDispatcher()` only configures the bundled copy, but
+ * `globalThis.fetch` in Node 22+ is powered by Node's built-in copy —
+ * so SDKs like Google GenAI that call `globalThis.fetch` bypass our
+ * dispatcher entirely. We must also override `globalThis.fetch` with our
+ * bundled undici's fetch to ensure custom CA certs are used.
  */
 async function setupProviderTLS(
   env: Record<string, string>,
@@ -263,13 +266,16 @@ async function setupProviderTLS(
 
   if (!needsCustomDispatcher) {
     setGlobalDispatcher(defaultDispatcher);
+    globalThis.fetch = originalFetch;
     return undefined;
   }
 
   try {
     const dispatcher = await getDispatcherWithCertBundle(caBundle, insecure, allowH2, logger);
+    const customFetch = getFetchWithDispatcher(dispatcher);
     setGlobalDispatcher(dispatcher as any);
-    return getFetchWithDispatcher(dispatcher);
+    globalThis.fetch = customFetch as typeof globalThis.fetch;
+    return customFetch;
   } catch (error) {
     logger.error(error);
     throw new Error(`Failed to setup TLS dispatcher: ${String(error)}`);


### PR DESCRIPTION
…s Google GenAI

Webpack bundles our undici dependency into the extension, creating a separate instance from Node's built-in undici (node:internal/deps/undici). setGlobalDispatcher() from the bundled copy only configures that copy's internal state, but globalThis.fetch in Node 22+ (shipped with VS Code 1.99) is powered by Node's built-in undici — a completely separate instance that knows nothing about our custom dispatcher.

This meant CA_BUNDLE and ALLOW_INSECURE were silently ignored for the Google GenAI provider, which calls globalThis.fetch internally with no custom fetch option. Customer logs confirm the error originates from node:internal/deps/undici/undici (Node's copy), not the bundled copy.

Other providers (OpenAI, Azure, DeepSeek, Ollama) were unaffected because they accept a custom fetch function that calls the bundled undici's fetch directly, bypassing globalThis.fetch entirely.

Fix by also overriding globalThis.fetch with our bundled undici's fetch configured with the custom dispatcher. When no custom TLS is needed, the original fetch is restored.

<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
