### PR TITLE
:test_tube: llemulator for go accept/reject e2e workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1321,6 +1321,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1851,7 +1852,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
@@ -1950,6 +1952,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1973,6 +1976,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2003,7 +2007,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
       "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -2032,7 +2035,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
       "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
@@ -2047,7 +2049,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
       "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
@@ -2062,7 +2063,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
       "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -3630,6 +3630,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.22.tgz",
       "integrity": "sha512-DxXoI8JEg/ocFnC2M5hWK9Fi6VQDjVNZuR5Dpx8LSFmrsI0dp+WfD78g8PSCZwndpVWl0bkYD9Fz+OdHTrwX7A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -3859,6 +3860,7 @@
       "integrity": "sha512-kmnmVs32MFWbV5X6BInC1/TfCs7y1ugwxv1xHsAIj/DyUfoe7vtO0alRUgbQa57+yRGHBBjlNcEk33SCAt5/dA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@microsoft/api-extractor-model": "7.33.4",
         "@microsoft/tsdoc": "~0.16.0",
@@ -4064,6 +4066,7 @@
       "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
       "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@monaco-editor/loader": "^1.5.0"
       },
@@ -4499,6 +4502,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -7033,6 +7037,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -7044,6 +7049,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -7152,6 +7158,7 @@
       "integrity": "sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.55.0",
@@ -7181,6 +7188,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -8203,6 +8211,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8256,6 +8265,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8985,6 +8995,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10575,8 +10586,7 @@
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
       "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/domutils": {
       "version": "3.2.2",
@@ -11024,6 +11034,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -11094,6 +11105,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11154,6 +11166,7 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11637,6 +11650,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -12905,6 +12919,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
       "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -13163,6 +13178,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -14137,6 +14153,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -15107,6 +15124,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -16119,7 +16137,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -17876,6 +17893,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.21.0.tgz",
       "integrity": "sha512-26dQFi76dB8IiN/WKGQOV+yKKTTlRCxQjoi2WLt0kMcH8pvxVyvfdBDkld5GTl7W1qvBpwVOtFcsqktj3fBRpA==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -18460,6 +18478,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18620,6 +18639,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -18840,6 +18860,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -19173,6 +19194,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -19191,6 +19213,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -19594,8 +19617,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -21979,6 +22001,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -22188,6 +22211,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22622,6 +22646,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -23559,6 +23584,7 @@
       "integrity": "sha512-Gdj3X74CLJJ8zy4URmK42W7wTZUJrqL+z8nyGEr4dTN0kb3nVs+ZvjbTOqRYPD7qX4tUmwyHL9Q9K6T1seW6Yw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -23608,6 +23634,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -24193,6 +24220,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -24325,6 +24353,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -24334,6 +24363,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }
@@ -24381,11 +24411,7 @@
       "name": "@editor-extensions/shared",
       "version": "0.6.0"
     },
-    "vscode": {
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
+    "vscode": {},
     "vscode/core": {
       "name": "konveyor-core",
       "version": "0.6.0",

--- a/tests/e2e/fixtures/gotest-llemulator.ts
+++ b/tests/e2e/fixtures/gotest-llemulator.ts
@@ -1,5 +1,7 @@
 /**
  * Deterministic LLM responses for savitharaghunathan/gotest when using llemulator (CI).
+ * Loaded from `02-e2e-workflow.test.ts` when `getDefaultProviderConfig() === LLEMULATOR_PROVIDER`
+ * (same gating idea as `plugin-settings.test.ts`, with payloads extracted here for size).
  * Matches real file shapes so Get Solution → Accept can complete without a live model.
  *
  * The workflow applies two separate fixes (two Get Solution → Accept steps):

--- a/tests/e2e/fixtures/gotest-llemulator.ts
+++ b/tests/e2e/fixtures/gotest-llemulator.ts
@@ -12,9 +12,17 @@
  */
 import {
   buildKaiResponse,
+  getLlemulatorBaseUrl,
   loadLlemulatorResponses,
   type LlemulatorPatternRule,
 } from '../utilities/llemulator.utils';
+
+/** Matches only the first gotest rule (main.go), not the go.mod rule. */
+const MAIN_GO_PROBE_PROMPT =
+  'Migrate deprecated HorizontalPodAutoscaler from autoscaling/v2beta1 for nginx-hpa';
+
+/** Substring from MAIN_GO_MIGRATED — not present in GO_MOD_UPDATED. */
+export const GOTEST_MAIN_GO_RESPONSE_MARKER = 'Creating HPA using autoscaling/v2 API';
 
 /** main.go migrated from autoscaling/v2beta1 to autoscaling/v2 (addresses first two issues). */
 const MAIN_GO_MIGRATED = `package main
@@ -215,4 +223,44 @@ export async function loadGotestWorkflowLlemulatorResponses(): Promise<void> {
     reset: true,
     responses: gotestLlemulatorRules(),
   });
+}
+
+/**
+ * Confirms the main.go Kai script is active: a probe message matches the autoscaling rule and
+ * returns the migrated file body (not go.mod). Call after `loadGotestWorkflowLlemulatorResponses`.
+ */
+export async function verifyGotestMainGoLlemulatorRule(
+  token: string = 'dummy-key-for-llemulator'
+): Promise<void> {
+  const base = getLlemulatorBaseUrl();
+  if (!base) {
+    throw new Error('Llemulator is not configured. Set TEST_LLEMULATOR_URL.');
+  }
+
+  const res = await fetch(`${base}/v1/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: MAIN_GO_PROBE_PROMPT }],
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`main.go llemulator probe failed: ${res.status} ${text}`);
+  }
+
+  const data = (await res.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  const content = data.choices?.[0]?.message?.content ?? '';
+  if (!content.includes(GOTEST_MAIN_GO_RESPONSE_MARKER)) {
+    throw new Error(
+      `Expected gotest main.go Kai body (marker "${GOTEST_MAIN_GO_RESPONSE_MARKER}"). Got: ${content.slice(0, 400)}`
+    );
+  }
 }

--- a/tests/e2e/fixtures/gotest-llemulator.ts
+++ b/tests/e2e/fixtures/gotest-llemulator.ts
@@ -1,0 +1,216 @@
+/**
+ * Deterministic LLM responses for savitharaghunathan/gotest when using llemulator (CI).
+ * Matches real file shapes so Get Solution → Accept can complete without a live model.
+ *
+ * The workflow applies two separate fixes (two Get Solution → Accept steps):
+ * 1. **main.go** — autoscaling/v2beta1 → v2 (covers the two autoscaling-related issues).
+ * 2. **go.mod** — bump k8s.io/client-go (and api/apimachinery) for the dependency issue.
+ *
+ * Each scripted reply has a single `## Updated File` block; Kai applies one target file per solution.
+ */
+import {
+  buildKaiResponse,
+  loadLlemulatorResponses,
+  type LlemulatorPatternRule,
+} from '../utilities/llemulator.utils';
+
+/** main.go migrated from autoscaling/v2beta1 to autoscaling/v2 (addresses first two issues). */
+const MAIN_GO_MIGRATED = `package main
+
+import (
+	"context"
+	"flag"
+	"path/filepath"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+	"k8s.io/klog/v2"
+)
+
+func main() {
+	var kubeconfig *string
+	if home := homedir.HomeDir(); home != "" {
+		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	flag.Parse()
+
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	if err != nil {
+		klog.Fatalf("Error building kubeconfig: %v", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		klog.Fatalf("Error creating Kubernetes client: %v", err)
+	}
+
+	ctx := context.Background()
+	namespace := "default"
+
+	klog.Info("=== Creating Deployment ===")
+	if err := createDeployment(ctx, clientset, namespace); err != nil {
+		klog.Fatalf("Failed to create deployment: %v", err)
+	}
+
+	klog.Info("=== Creating HPA using autoscaling/v2 API ===")
+	if err := createHPA(ctx, clientset, namespace); err != nil {
+		klog.Fatalf("Failed to create HPA: %v", err)
+	}
+
+	klog.Info("Demo completed successfully!")
+}
+
+func createDeployment(ctx context.Context, clientset *kubernetes.Clientset, namespace string) error {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx-deployment",
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(2),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "nginx",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "nginx",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "nginx",
+							Image: "nginx:1.20",
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 80,
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := clientset.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	klog.Info("Created Deployment: nginx-deployment")
+	return nil
+}
+
+func createHPA(ctx context.Context, clientset *kubernetes.Clientset, namespace string) error {
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx-hpa",
+			Namespace: namespace,
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "nginx-deployment",
+			},
+			MinReplicas: int32Ptr(2),
+			MaxReplicas: 10,
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: int32Ptr(70),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := clientset.AutoscalingV2().HorizontalPodAutoscalers(namespace).Create(ctx, hpa, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	klog.Info("Created HPA using autoscaling/v2: nginx-hpa")
+	return nil
+}
+
+func int32Ptr(i int32) *int32 {
+	return &i
+}
+`;
+
+/**
+ * Second solution only: **go.mod** (dependency / client-go issue).
+ * First solution must not touch this; patterns route autoscaling vs dependency requests.
+ */
+const GO_MOD_UPDATED = `module github.com/kai-examples/old
+
+go 1.22
+
+require (
+	k8s.io/api v0.34.0
+	k8s.io/apimachinery v0.34.0
+	k8s.io/client-go v0.34.0
+	k8s.io/klog/v2 v2.130.1
+)
+`;
+
+function gotestLlemulatorRules(): LlemulatorPatternRule[] {
+  return [
+    {
+      pattern: 'v2beta1|autoscaling/v2beta1|HorizontalPodAutoscaler|Migrate deprecated|nginx-hpa',
+      response: buildKaiResponse({
+        reasoning:
+          'Updated **main.go** only: migrated HorizontalPodAutoscaler from autoscaling/v2beta1 to autoscaling/v2 and adjusted metric targets.',
+        language: 'go',
+        fileContent: MAIN_GO_MIGRATED,
+        additionalInfo:
+          'Applies to main.go. Uses AutoscalingV2 and MetricTarget.AverageUtilization.',
+      }),
+      times: -1,
+    },
+    {
+      // Do not match `k8s.io/client-go` alone — main.go imports it; the autoscaling request would get go.mod.
+      pattern: 'Update Kubernetes client-go|v1\\.34 compatible|go\\.mod',
+      response: buildKaiResponse({
+        reasoning:
+          'Updated **go.mod** only: bumped k8s.io/client-go, k8s.io/api, and k8s.io/apimachinery to v0.34.x for Kubernetes 1.34 compatibility.',
+        language: 'go',
+        fileContent: GO_MOD_UPDATED,
+        additionalInfo: 'Applies to go.mod. Run go mod tidy after apply.',
+      }),
+      times: -1,
+    },
+  ];
+}
+
+/** Load scripted responses into llemulator before starting VS Code (same pattern as fix-one-issue). */
+export async function loadGotestWorkflowLlemulatorResponses(): Promise<void> {
+  await loadLlemulatorResponses({
+    reset: true,
+    responses: gotestLlemulatorRules(),
+  });
+}

--- a/tests/e2e/fixtures/gotest-llemulator.ts
+++ b/tests/e2e/fixtures/gotest-llemulator.ts
@@ -17,13 +17,6 @@ import {
   type LlemulatorPatternRule,
 } from '../utilities/llemulator.utils';
 
-/** Matches only the first gotest rule (main.go), not the go.mod rule. */
-const MAIN_GO_PROBE_PROMPT =
-  'Migrate deprecated HorizontalPodAutoscaler from autoscaling/v2beta1 for nginx-hpa';
-
-/** Substring from MAIN_GO_MIGRATED — not present in GO_MOD_UPDATED. */
-export const GOTEST_MAIN_GO_RESPONSE_MARKER = 'Creating HPA using autoscaling/v2 API';
-
 /** main.go migrated from autoscaling/v2beta1 to autoscaling/v2 (addresses first two issues). */
 const MAIN_GO_MIGRATED = `package main
 
@@ -223,44 +216,4 @@ export async function loadGotestWorkflowLlemulatorResponses(): Promise<void> {
     reset: true,
     responses: gotestLlemulatorRules(),
   });
-}
-
-/**
- * Confirms the main.go Kai script is active: a probe message matches the autoscaling rule and
- * returns the migrated file body (not go.mod). Call after `loadGotestWorkflowLlemulatorResponses`.
- */
-export async function verifyGotestMainGoLlemulatorRule(
-  token: string = 'dummy-key-for-llemulator'
-): Promise<void> {
-  const base = getLlemulatorBaseUrl();
-  if (!base) {
-    throw new Error('Llemulator is not configured. Set TEST_LLEMULATOR_URL.');
-  }
-
-  const res = await fetch(`${base}/v1/chat/completions`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({
-      model: 'gpt-4o',
-      messages: [{ role: 'user', content: MAIN_GO_PROBE_PROMPT }],
-    }),
-  });
-
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`main.go llemulator probe failed: ${res.status} ${text}`);
-  }
-
-  const data = (await res.json()) as {
-    choices?: Array<{ message?: { content?: string } }>;
-  };
-  const content = data.choices?.[0]?.message?.content ?? '';
-  if (!content.includes(GOTEST_MAIN_GO_RESPONSE_MARKER)) {
-    throw new Error(
-      `Expected gotest main.go Kai body (marker "${GOTEST_MAIN_GO_RESPONSE_MARKER}"). Got: ${content.slice(0, 400)}`
-    );
-  }
 }

--- a/tests/e2e/tests/golang/02-e2e-workflow.test.ts
+++ b/tests/e2e/tests/golang/02-e2e-workflow.test.ts
@@ -312,6 +312,7 @@ test.describe.serial(
 
     test('Verify issues reduced after autoscaling fix', async () => {
       test.skip(!canRunKaiSolutionE2e(), SKIP_KAI_SOLUTION_REASON);
+      test.setTimeout(600000);
       await vscodeApp.openAnalysisView();
       await vscodeApp.waitDefault();
 
@@ -397,6 +398,7 @@ test.describe.serial(
 
     test('Verify all issues resolved', async () => {
       test.skip(!canRunKaiSolutionE2e(), SKIP_KAI_SOLUTION_REASON);
+      test.setTimeout(600000);
       await vscodeApp.openAnalysisView();
       await vscodeApp.waitDefault();
 

--- a/tests/e2e/tests/golang/02-e2e-workflow.test.ts
+++ b/tests/e2e/tests/golang/02-e2e-workflow.test.ts
@@ -17,7 +17,10 @@ import {
   getDefaultProviderConfig,
   LLEMULATOR_PROVIDER,
 } from '../../fixtures/provider-configs.fixture';
-import { loadGotestWorkflowLlemulatorResponses } from '../../fixtures/gotest-llemulator';
+import {
+  loadGotestWorkflowLlemulatorResponses,
+  verifyGotestMainGoLlemulatorRule,
+} from '../../fixtures/gotest-llemulator';
 import { getLlemulatorBaseUrl } from '../../utilities/llemulator.utils';
 import * as VSCodeFactory from '../../utilities/vscode.factory';
 
@@ -56,6 +59,8 @@ test.describe.serial(
             true
           );
         }
+        // Proves the main.go pattern rule returns the migrated main.go Kai body (not go.mod)
+        await verifyGotestMainGoLlemulatorRule();
         console.log('Llemulator scripts loaded for gotest workflow (see gotest-llemulator.ts)');
       }
       // Use openForRepo which determines initialization based on repo language

--- a/tests/e2e/tests/golang/02-e2e-workflow.test.ts
+++ b/tests/e2e/tests/golang/02-e2e-workflow.test.ts
@@ -304,7 +304,9 @@ test.describe.serial(
       await acceptButton.click();
       console.log('Autoscaling fix accepted');
 
-      await vscodeApp.waitForAnalysisCompleted();
+      // Don't wait for notification — partial analysis fires and auto-dismisses
+      // before waitForAnalysisCompleted() starts watching (race condition).
+      // The next test polls issue count to verify re-analysis completed.
       await vscodeApp.waitDefault();
     });
 
@@ -383,13 +385,14 @@ test.describe.serial(
       await acceptButton.click();
       console.log('Dependency fix accepted');
 
-      await vscodeApp.waitForAnalysisCompleted();
+      // Don't wait for notification — partial analysis fires and auto-dismisses
+      // before waitForAnalysisCompleted() starts watching (race condition).
+      // The next test polls issue count to verify re-analysis completed.
+      await vscodeApp.waitDefault();
 
       await vscodeApp.getWindow().screenshot({
         path: pathlib.join(screenshotDir, 'all-fixes-accepted.png'),
       });
-
-      await vscodeApp.waitDefault();
     });
 
     test('Verify all issues resolved', async () => {

--- a/tests/e2e/tests/golang/02-e2e-workflow.test.ts
+++ b/tests/e2e/tests/golang/02-e2e-workflow.test.ts
@@ -283,6 +283,8 @@ test.describe.serial(
       await acceptButton.click();
       console.log('Autoscaling fix accepted');
 
+      await vscodeApp.waitForFileSolutionAccepted('main.go');
+      await vscodeApp.waitForAnalysisCompleted();
       await vscodeApp.waitDefault();
     });
 
@@ -295,12 +297,17 @@ test.describe.serial(
       await vscodeApp.searchViolation('');
       await vscodeApp.waitDefault();
 
-      // Count issues after autoscaling fix
+      // Re-analysis after Accept can lag; poll until counts reflect the applied fix
+      await expect
+        .poll(async () => vscodeApp.getIssuesCount(), {
+          timeout: 600000,
+          message:
+            'Expected Total Issues to drop after autoscaling fix (wait for save + re-analysis).',
+        })
+        .toBeLessThan(violationCountBefore);
+
       const issueCountAfter = await vscodeApp.getIssuesCount();
       console.log(`Issues after autoscaling fix: ${issueCountAfter}`);
-
-      // Verify issues were reduced (autoscaling fix resolves 2 issues)
-      expect(issueCountAfter).toBeLessThan(violationCountBefore);
       console.log(`Issues reduced from ${violationCountBefore} to ${issueCountAfter}`);
 
       await vscodeApp.getWindow().screenshot({
@@ -356,6 +363,9 @@ test.describe.serial(
       await acceptButton.click();
       console.log('Dependency fix accepted');
 
+      await vscodeApp.waitForFileSolutionAccepted('go.mod');
+      await vscodeApp.waitForAnalysisCompleted();
+
       await vscodeApp.getWindow().screenshot({
         path: pathlib.join(screenshotDir, 'all-fixes-accepted.png'),
       });
@@ -369,12 +379,15 @@ test.describe.serial(
       await vscodeApp.waitDefault();
 
       // When all issues are resolved, the filter button may not be visible
-      // Just verify the issues count is 0
+      await expect
+        .poll(async () => vscodeApp.getIssuesCount(), {
+          timeout: 600000,
+          message: 'Expected Total Issues to reach 0 after dependency fix (re-analysis may lag).',
+        })
+        .toBe(0);
+
       const issueCountAfter = await vscodeApp.getIssuesCount();
       console.log(`Issues after all fixes: ${issueCountAfter}`);
-
-      // Verify all issues are resolved
-      expect(issueCountAfter).toBe(0);
       console.log(`All issues resolved: ${violationCountBefore} -> ${issueCountAfter}`);
 
       await vscodeApp.getWindow().screenshot({

--- a/tests/e2e/tests/golang/02-e2e-workflow.test.ts
+++ b/tests/e2e/tests/golang/02-e2e-workflow.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Golang E2E workflow (gotest repo) — mirrors the llemulator pattern from plugin-settings.test.ts:
+ *
+ * - When `getDefaultProviderConfig() === LLEMULATOR_PROVIDER` (i.e. `TEST_LLEMULATOR_URL` is set),
+ *   we `loadLlemulatorResponses` with scripted Kai markdown for main.go + go.mod (see gotest-llemulator.ts).
+ * - Plugin-settings inlines small Java snippets; here payloads stay in the fixture file for size/clarity.
+ * - `configureGenerativeAI(getDefaultProviderConfig().config)` matches plugin-settings.
+ */
 import * as pathlib from 'path';
 import { RepoData, expect, test } from '../../fixtures/test-repo-fixture';
 import { VSCode } from '../../pages/vscode.page';
@@ -7,9 +15,10 @@ import { generateRandomString } from '../../utilities/utils';
 import {
   getAvailableProviders,
   getDefaultProviderConfig,
+  LLEMULATOR_PROVIDER,
 } from '../../fixtures/provider-configs.fixture';
 import { loadGotestWorkflowLlemulatorResponses } from '../../fixtures/gotest-llemulator';
-import { isLlemulatorConfigured } from '../../utilities/llemulator.utils';
+import { getLlemulatorBaseUrl } from '../../utilities/llemulator.utils';
 import * as VSCodeFactory from '../../utilities/vscode.factory';
 
 /** Get Solution → Accept requires a configured provider (llemulator URL, OpenAI key, or AWS Bedrock). */
@@ -37,10 +46,17 @@ test.describe.serial(
       if (!repoInfo) {
         throw new Error("'gotest' fixture is missing from test-repos.json");
       }
-      if (isLlemulatorConfigured()) {
-        // Two scripted solutions: (1) main.go autoscaling migration, (2) go.mod client-go bump — see gotest-llemulator.ts
+      if (getDefaultProviderConfig() === LLEMULATOR_PROVIDER) {
+        // POST /_emulator/script throws if scripts did not load; registers main.go + go.mod Kai responses
         await loadGotestWorkflowLlemulatorResponses();
-        console.log('Llemulator responses loaded for gotest workflow (CI / TEST_LLEMULATOR_URL)');
+        const base = getLlemulatorBaseUrl();
+        if (base) {
+          const health = await fetch(`${base}/healthz`);
+          expect(health.ok, 'llemulator should be reachable after loading gotest script').toBe(
+            true
+          );
+        }
+        console.log('Llemulator scripts loaded for gotest workflow (see gotest-llemulator.ts)');
       }
       // Use openForRepo which determines initialization based on repo language
       vscodeApp = await VSCodeFactory.openForRepo(repoInfo);
@@ -235,7 +251,7 @@ test.describe.serial(
     test('Fix autoscaling issue and accept solution', async () => {
       test.skip(!canRunKaiSolutionE2e(), SKIP_KAI_SOLUTION_REASON);
       test.setTimeout(600000);
-      if (isLlemulatorConfigured()) {
+      if (getDefaultProviderConfig() === LLEMULATOR_PROVIDER) {
         await loadGotestWorkflowLlemulatorResponses();
       }
       await vscodeApp.openAnalysisView();
@@ -283,7 +299,6 @@ test.describe.serial(
       await acceptButton.click();
       console.log('Autoscaling fix accepted');
 
-      await vscodeApp.waitForFileSolutionAccepted('main.go');
       await vscodeApp.waitForAnalysisCompleted();
       await vscodeApp.waitDefault();
     });
@@ -318,7 +333,7 @@ test.describe.serial(
     test('Fix dependency issue and accept solution', async () => {
       test.skip(!canRunKaiSolutionE2e(), SKIP_KAI_SOLUTION_REASON);
       test.setTimeout(600000);
-      if (isLlemulatorConfigured()) {
+      if (getDefaultProviderConfig() === LLEMULATOR_PROVIDER) {
         await loadGotestWorkflowLlemulatorResponses();
       }
       await vscodeApp.openAnalysisView();
@@ -363,7 +378,6 @@ test.describe.serial(
       await acceptButton.click();
       console.log('Dependency fix accepted');
 
-      await vscodeApp.waitForFileSolutionAccepted('go.mod');
       await vscodeApp.waitForAnalysisCompleted();
 
       await vscodeApp.getWindow().screenshot({

--- a/tests/e2e/tests/golang/02-e2e-workflow.test.ts
+++ b/tests/e2e/tests/golang/02-e2e-workflow.test.ts
@@ -4,12 +4,25 @@ import { VSCode } from '../../pages/vscode.page';
 import { SCREENSHOTS_FOLDER } from '../../utilities/consts';
 import { KAIViews } from '../../enums/views.enum';
 import { generateRandomString } from '../../utilities/utils';
-import { DEFAULT_PROVIDER } from '../../fixtures/provider-configs.fixture';
+import {
+  getAvailableProviders,
+  getDefaultProviderConfig,
+} from '../../fixtures/provider-configs.fixture';
+import { loadGotestWorkflowLlemulatorResponses } from '../../fixtures/gotest-llemulator';
+import { isLlemulatorConfigured } from '../../utilities/llemulator.utils';
 import * as VSCodeFactory from '../../utilities/vscode.factory';
+
+/** Get Solution → Accept requires a configured provider (llemulator URL, OpenAI key, or AWS Bedrock). */
+const SKIP_KAI_SOLUTION_REASON =
+  'No LLM provider available for Get Solution (set TEST_LLEMULATOR_URL, OPENAI_API_KEY, or AWS Bedrock per provider-configs.fixture).';
+
+function canRunKaiSolutionE2e(): boolean {
+  return getAvailableProviders().length > 0;
+}
 
 test.describe.serial(
   'Golang Extension - E2E Workflow',
-  { tag: ['@tier3', '@experimental'] },
+  { tag: ['@tier1', '@experimental'] },
   () => {
     let vscodeApp: VSCode;
     const randomString = generateRandomString();
@@ -23,6 +36,11 @@ test.describe.serial(
       repoInfo = testRepoData['gotest'];
       if (!repoInfo) {
         throw new Error("'gotest' fixture is missing from test-repos.json");
+      }
+      if (isLlemulatorConfigured()) {
+        // Two scripted solutions: (1) main.go autoscaling migration, (2) go.mod client-go bump — see gotest-llemulator.ts
+        await loadGotestWorkflowLlemulatorResponses();
+        console.log('Llemulator responses loaded for gotest workflow (CI / TEST_LLEMULATOR_URL)');
       }
       // Use openForRepo which determines initialization based on repo language
       vscodeApp = await VSCodeFactory.openForRepo(repoInfo);
@@ -51,7 +69,7 @@ test.describe.serial(
     });
 
     test('Configure GenAI Provider', async () => {
-      await vscodeApp.configureGenerativeAI(DEFAULT_PROVIDER.config);
+      await vscodeApp.configureGenerativeAI(getDefaultProviderConfig().config);
       console.log('GenAI provider configured');
     });
 
@@ -215,7 +233,11 @@ test.describe.serial(
     });
 
     test('Fix autoscaling issue and accept solution', async () => {
+      test.skip(!canRunKaiSolutionE2e(), SKIP_KAI_SOLUTION_REASON);
       test.setTimeout(600000);
+      if (isLlemulatorConfigured()) {
+        await loadGotestWorkflowLlemulatorResponses();
+      }
       await vscodeApp.openAnalysisView();
       await vscodeApp.waitDefault();
 
@@ -256,8 +278,8 @@ test.describe.serial(
       const acceptButton = resolutionView.getByRole('button', { name: 'Accept' }).first();
       await expect(
         acceptButton,
-        'Accept button not found. This may occur if the model is unreachable.'
-      ).toBeVisible({ timeout: 30000 });
+        'Accept button not found. This may occur if the model is unreachable, or CI has no OPENAI_API_KEY and TEST_LLEMULATOR_URL (scripted responses).'
+      ).toBeVisible({ timeout: 120000 });
       await acceptButton.click();
       console.log('Autoscaling fix accepted');
 
@@ -265,6 +287,7 @@ test.describe.serial(
     });
 
     test('Verify issues reduced after autoscaling fix', async () => {
+      test.skip(!canRunKaiSolutionE2e(), SKIP_KAI_SOLUTION_REASON);
       await vscodeApp.openAnalysisView();
       await vscodeApp.waitDefault();
 
@@ -286,7 +309,11 @@ test.describe.serial(
     });
 
     test('Fix dependency issue and accept solution', async () => {
+      test.skip(!canRunKaiSolutionE2e(), SKIP_KAI_SOLUTION_REASON);
       test.setTimeout(600000);
+      if (isLlemulatorConfigured()) {
+        await loadGotestWorkflowLlemulatorResponses();
+      }
       await vscodeApp.openAnalysisView();
       await vscodeApp.waitDefault();
 
@@ -325,7 +352,7 @@ test.describe.serial(
 
       // Click Accept button
       const acceptButton = resolutionView.getByRole('button', { name: 'Accept' }).first();
-      await expect(acceptButton).toBeVisible({ timeout: 30000 });
+      await expect(acceptButton).toBeVisible({ timeout: 120000 });
       await acceptButton.click();
       console.log('Dependency fix accepted');
 
@@ -337,6 +364,7 @@ test.describe.serial(
     });
 
     test('Verify all issues resolved', async () => {
+      test.skip(!canRunKaiSolutionE2e(), SKIP_KAI_SOLUTION_REASON);
       await vscodeApp.openAnalysisView();
       await vscodeApp.waitDefault();
 

--- a/tests/e2e/tests/golang/02-e2e-workflow.test.ts
+++ b/tests/e2e/tests/golang/02-e2e-workflow.test.ts
@@ -299,18 +299,23 @@ test.describe.serial(
       await acceptButton.click();
       console.log('Autoscaling fix accepted');
 
+      // TODO: Remove explicit Run Analysis once partial analysis after Accept is fixed.
+      // The Go analyzer does not trigger partial re-analysis after Accept, so we run
+      // a full analysis to pick up the applied fix. See https://github.com/konveyor/editor-extensions/issues/1402
+      await vscodeApp.openAnalysisView();
+      const reAnalysisView = await vscodeApp.getView(KAIViews.analysisView);
+      const runAnalysisBtn = reAnalysisView.getByRole('button', { name: 'Run Analysis' });
+      await expect(runAnalysisBtn).toBeEnabled({ timeout: 60000 });
+      await runAnalysisBtn.click();
       await vscodeApp.waitForAnalysisCompleted();
     });
 
     test('Verify issues reduced after autoscaling fix', async () => {
       test.skip(!canRunKaiSolutionE2e(), SKIP_KAI_SOLUTION_REASON);
-      test.setTimeout(600000);
       await vscodeApp.openAnalysisView();
-      await vscodeApp.waitDefault();
 
       // Clear the search filter to see all remaining issues
       await vscodeApp.searchViolation('');
-      await vscodeApp.waitDefault();
 
       const issueCountAfter = await vscodeApp.getIssuesCount();
       console.log(
@@ -371,6 +376,14 @@ test.describe.serial(
       await acceptButton.click();
       console.log('Dependency fix accepted');
 
+      // TODO: Remove explicit Run Analysis once partial analysis after Accept is fixed.
+      // The Go analyzer does not trigger partial re-analysis after Accept, so we run
+      // a full analysis to pick up the applied fix. See https://github.com/konveyor/editor-extensions/issues/1402
+      await vscodeApp.openAnalysisView();
+      const reAnalysisView = await vscodeApp.getView(KAIViews.analysisView);
+      const runAnalysisBtn = reAnalysisView.getByRole('button', { name: 'Run Analysis' });
+      await expect(runAnalysisBtn).toBeEnabled({ timeout: 60000 });
+      await runAnalysisBtn.click();
       await vscodeApp.waitForAnalysisCompleted();
 
       await vscodeApp.getWindow().screenshot({
@@ -380,9 +393,7 @@ test.describe.serial(
 
     test('Verify all issues resolved', async () => {
       test.skip(!canRunKaiSolutionE2e(), SKIP_KAI_SOLUTION_REASON);
-      test.setTimeout(600000);
       await vscodeApp.openAnalysisView();
-      await vscodeApp.waitDefault();
 
       const issueCountAfter = await vscodeApp.getIssuesCount();
       console.log(

--- a/tests/e2e/tests/golang/02-e2e-workflow.test.ts
+++ b/tests/e2e/tests/golang/02-e2e-workflow.test.ts
@@ -17,10 +17,7 @@ import {
   getDefaultProviderConfig,
   LLEMULATOR_PROVIDER,
 } from '../../fixtures/provider-configs.fixture';
-import {
-  loadGotestWorkflowLlemulatorResponses,
-  verifyGotestMainGoLlemulatorRule,
-} from '../../fixtures/gotest-llemulator';
+import { loadGotestWorkflowLlemulatorResponses } from '../../fixtures/gotest-llemulator';
 import { getLlemulatorBaseUrl } from '../../utilities/llemulator.utils';
 import * as VSCodeFactory from '../../utilities/vscode.factory';
 
@@ -59,8 +56,6 @@ test.describe.serial(
             true
           );
         }
-        // Proves the main.go pattern rule returns the migrated main.go Kai body (not go.mod)
-        await verifyGotestMainGoLlemulatorRule();
         console.log('Llemulator scripts loaded for gotest workflow (see gotest-llemulator.ts)');
       }
       // Use openForRepo which determines initialization based on repo language
@@ -304,10 +299,7 @@ test.describe.serial(
       await acceptButton.click();
       console.log('Autoscaling fix accepted');
 
-      // Don't wait for notification — partial analysis fires and auto-dismisses
-      // before waitForAnalysisCompleted() starts watching (race condition).
-      // The next test polls issue count to verify re-analysis completed.
-      await vscodeApp.waitDefault();
+      await vscodeApp.waitForAnalysisCompleted();
     });
 
     test('Verify issues reduced after autoscaling fix', async () => {
@@ -320,18 +312,11 @@ test.describe.serial(
       await vscodeApp.searchViolation('');
       await vscodeApp.waitDefault();
 
-      // Re-analysis after Accept can lag; poll until counts reflect the applied fix
-      await expect
-        .poll(async () => vscodeApp.getIssuesCount(), {
-          timeout: 600000,
-          message:
-            'Expected Total Issues to drop after autoscaling fix (wait for save + re-analysis).',
-        })
-        .toBeLessThan(violationCountBefore);
-
       const issueCountAfter = await vscodeApp.getIssuesCount();
-      console.log(`Issues after autoscaling fix: ${issueCountAfter}`);
-      console.log(`Issues reduced from ${violationCountBefore} to ${issueCountAfter}`);
+      console.log(
+        `Issues after autoscaling fix: ${issueCountAfter} (started with ${violationCountBefore})`
+      );
+      expect(issueCountAfter).toBeLessThan(violationCountBefore);
 
       await vscodeApp.getWindow().screenshot({
         path: pathlib.join(screenshotDir, 'after-autoscaling-fix-verified.png'),
@@ -386,10 +371,7 @@ test.describe.serial(
       await acceptButton.click();
       console.log('Dependency fix accepted');
 
-      // Don't wait for notification — partial analysis fires and auto-dismisses
-      // before waitForAnalysisCompleted() starts watching (race condition).
-      // The next test polls issue count to verify re-analysis completed.
-      await vscodeApp.waitDefault();
+      await vscodeApp.waitForAnalysisCompleted();
 
       await vscodeApp.getWindow().screenshot({
         path: pathlib.join(screenshotDir, 'all-fixes-accepted.png'),
@@ -402,17 +384,11 @@ test.describe.serial(
       await vscodeApp.openAnalysisView();
       await vscodeApp.waitDefault();
 
-      // When all issues are resolved, the filter button may not be visible
-      await expect
-        .poll(async () => vscodeApp.getIssuesCount(), {
-          timeout: 600000,
-          message: 'Expected Total Issues to reach 0 after dependency fix (re-analysis may lag).',
-        })
-        .toBe(0);
-
       const issueCountAfter = await vscodeApp.getIssuesCount();
-      console.log(`Issues after all fixes: ${issueCountAfter}`);
-      console.log(`All issues resolved: ${violationCountBefore} -> ${issueCountAfter}`);
+      console.log(
+        `Issues after all fixes: ${issueCountAfter} (started with ${violationCountBefore})`
+      );
+      expect(issueCountAfter).toBe(0);
 
       await vscodeApp.getWindow().screenshot({
         path: pathlib.join(screenshotDir, 'analysis-view-all-resolved.png'),

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1172,7 +1172,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.5.0.tgz",
       "integrity": "sha512-bcnbYZvm5Ht1nrHUfWDK4crspiTy1ESJYMApsMiOTUnlKOan0ocRD6m7hZH34iSC2c2XWsoryR80cwsYgCBWzQ==",
-      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -1187,7 +1186,6 @@
       "version": "18.19.86",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.86.tgz",
       "integrity": "sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1197,7 +1195,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -1216,14 +1213,12 @@
     "node_modules/@browserbasehq/sdk/node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "peer": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/@browserbasehq/stagehand": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/@browserbasehq/stagehand/-/stagehand-1.14.0.tgz",
       "integrity": "sha512-Hi/EzgMFWz+FKyepxHTrqfTPjpsuBS4zRy3e9sbMpBgLPv+9c0R+YZEvS7Bw4mTS66QtvvURRT6zgDGFotthVQ==",
-      "peer": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.3",
         "@browserbasehq/sdk": "^2.0.0",
@@ -1243,7 +1238,6 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.27.3.tgz",
       "integrity": "sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -1259,7 +1253,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.121.tgz",
       "integrity": "sha512-bHOrbyztmyYIi4f1R0s17QsPs1uyyYnGcXeZoGEd227oZjry0q6XQBQxd82X1I57zEfwO8h9Xo+Kl5gX1d9MwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1269,7 +1262,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -1289,8 +1281,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
@@ -1358,7 +1349,6 @@
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.6.4.tgz",
       "integrity": "sha512-u0fmXagywjLAd3apZTV6kRQAHjWl3bNKv5422mQJsM/MZB5YPjx28tjEbpoORh15RuWjYyO/wHZACRWBBkNhbQ==",
-      "peer": true,
       "dependencies": {
         "@langchain/textsplitters": "^0.1.0",
         "@types/node": "^18.0.0",
@@ -1373,7 +1363,6 @@
       "version": "18.19.86",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.86.tgz",
       "integrity": "sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1381,8 +1370,7 @@
     "node_modules/@ibm-cloud/watsonx-ai/node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "peer": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
@@ -1934,6 +1922,7 @@
       "version": "0.3.44",
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.44.tgz",
       "integrity": "sha512-3BsSFf7STvPPZyl2kMANgtVnCUvDdyP4k+koP+nY2Tczd5V+RFkuazIn/JOj/xxy/neZjr4PxFU4BFyF1aKXOA==",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -2011,6 +2000,7 @@
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
       "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.51.1"
       },
@@ -2143,6 +2133,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.2.0.tgz",
       "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^2.12.0",
@@ -2574,6 +2565,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
       "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
@@ -2645,6 +2637,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.3.0.tgz",
       "integrity": "sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==",
+      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "@smithy/types": "^2.12.0",
@@ -3021,8 +3014,7 @@
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "peer": true
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -3068,7 +3060,6 @@
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
-      "peer": true,
       "dependencies": {
         "@types/ms": "*"
       }
@@ -3089,8 +3080,7 @@
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "peer": true
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
       "version": "22.7.7",
@@ -3130,8 +3120,7 @@
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "peer": true
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
@@ -3317,6 +3306,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
       "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -3428,7 +3418,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -3445,8 +3434,7 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "peer": true
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -3856,6 +3844,7 @@
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
       "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3881,7 +3870,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -4065,7 +4053,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -4177,8 +4164,7 @@
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "peer": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -4276,7 +4262,6 @@
       "version": "16.5.4",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
       "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
-      "peer": true,
       "dependencies": {
         "readable-web-to-node-stream": "^3.0.0",
         "strtok3": "^6.2.4",
@@ -4760,7 +4745,6 @@
       "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.2.tgz",
       "integrity": "sha512-5VFkKYU/vSIWFJTVt392XEdPmiEwUJqhxjn1MRO3lfELyU2FB+yYi8brbmXUgq+D1acHR1fpS7tIJ6IlnrR9Cg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.12",
         "@types/node": "^18.19.80",
@@ -4786,7 +4770,6 @@
       "version": "18.19.86",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.86.tgz",
       "integrity": "sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -4794,8 +4777,7 @@
     "node_modules/ibm-cloud-sdk-core/node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "peer": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -4826,8 +4808,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -4887,8 +4868,7 @@
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "peer": true
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "node_modules/jpeg-js": {
       "version": "0.4.4",
@@ -4950,7 +4930,6 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
       "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-      "peer": true,
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -4972,7 +4951,6 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4984,7 +4962,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
       "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -4995,7 +4972,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "peer": true,
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -5214,44 +5190,37 @@
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "peer": true
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "peer": true
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "peer": true
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-      "peer": true
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "peer": true
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "peer": true
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-      "peer": true
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -5602,6 +5571,7 @@
       "version": "4.93.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.93.0.tgz",
       "integrity": "sha512-2kONcISbThKLfm7T9paVzg+QCE1FOZtNMMUfXyXckUAoXRRS/mTP89JSDHPMp8uM5s0bz28RISbvQjArD6mgUQ==",
+      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -5766,7 +5736,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
       "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -5816,6 +5785,7 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
       "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.51.1"
       },
@@ -5910,7 +5880,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -5955,7 +5924,6 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
       "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -5998,8 +5966,7 @@
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "peer": true
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -6040,7 +6007,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "peer": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -6056,7 +6022,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
       "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
-      "peer": true,
       "dependencies": {
         "readable-stream": "^4.7.0"
       },
@@ -6071,8 +6036,7 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "peer": true
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
@@ -6128,7 +6092,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-2.6.0.tgz",
       "integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==",
-      "peer": true,
       "engines": {
         "node": ">=10.7.0"
       },
@@ -6451,7 +6414,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -6509,7 +6471,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
       "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
-      "peer": true,
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "peek-readable": "^4.1.0"
@@ -6568,7 +6529,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
       "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
-      "peer": true,
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
@@ -6585,7 +6545,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
-      "peer": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -6600,7 +6559,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -6616,6 +6574,7 @@
       "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
       "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
@@ -6780,7 +6739,6 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "peer": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -6935,6 +6893,7 @@
       "version": "3.24.2",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added deterministic emulator fixture and scripted responses to make Go E2E workflows repeatable and verifiable.
  * Promoted Go workflow tests to a higher tier and added provider-aware setup that conditionally loads and verifies emulator responses.
  * Added gating/skips for solution flows when no provider is available, increased "Accept" timeouts, and improved failure messages.
  * Improved stability with reloads before analysis, polling waits for re-analysis, and stronger acceptance/issue-count checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->