### PR TITLE
:bug: defer webview CSS loading to fix Firefox in DevSpaces

### DIFF
--- a/vscode/core/src/KonveyorGUIWebviewViewProvider.ts
+++ b/vscode/core/src/KonveyorGUIWebviewViewProvider.ts
@@ -231,13 +231,55 @@ export class KonveyorGUIWebviewViewProvider implements WebviewViewProvider {
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta http-equiv="Content-Security-Policy" content="${this._getContentSecurityPolicy(nonce, webview)}">
-        <link rel="stylesheet" type="text/css" href="${stylesUri}">
         <title>${EXTENSION_SHORT_NAME} IDE Extension</title>
         <script nonce="${nonce}">
           const vscode = acquireVsCodeApi();
           window.vscode = vscode;
           window.viewType = "${this._viewType}";
           window.konveyorInitialData = ${jsesc(data, { json: true, isScriptContext: true })};
+        </script>
+        <script nonce="${nonce}">
+          // CSS loading with service worker controller change recovery.
+          //
+          // In Eclipse Che / DevSpaces, webview resources are served by a
+          // service worker that intercepts requests to synthetic hostnames
+          // (*.vscode-resource.vscode-cdn.net). When a stale service worker
+          // is controlling the page, Firefox lets CSS fetch requests fall
+          // through to real DNS -- which fails because the hostname exceeds
+          // DNS label limits and contains invalid characters. The stylesheet
+          // transfers 0 bytes and the webview renders completely unstyled.
+          //
+          // The fix: inject the <link> immediately (works in Chromium and
+          // Electron where the SW handoff is fast or not involved), and
+          // listen for the 'controllerchange' event which fires when the
+          // correct service worker takes control. On controllerchange,
+          // re-inject the stylesheet so it loads through the new SW.
+          (function() {
+            var STYLES_URI = "${stylesUri}";
+
+            function injectStylesheet() {
+              var old = document.getElementById('konveyor-styles');
+              if (old) old.remove();
+              var link = document.createElement('link');
+              link.id = 'konveyor-styles';
+              link.rel = 'stylesheet';
+              link.type = 'text/css';
+              link.href = STYLES_URI;
+              document.head.appendChild(link);
+            }
+
+            // Inject immediately -- works in Chromium / Electron.
+            injectStylesheet();
+
+            // In VS Code Web / DevSpaces, also listen for service worker
+            // controller changes and re-inject when the correct SW takes
+            // over from a stale one.
+            if (typeof navigator !== 'undefined' && navigator.serviceWorker) {
+              navigator.serviceWorker.addEventListener('controllerchange', function() {
+                injectStylesheet();
+              });
+            }
+          })();
         </script>
       </head>
       <body>


### PR DESCRIPTION
In VS Code Web (Eclipse Che / DevSpaces), webview resources are served by a service worker that intercepts requests to synthetic hostnames. When a stale service worker is still controlling the page during a controller handoff, Firefox lets fetch requests fall through to real DNS resolution -- which fails because the hostname exceeds the 63-char DNS label limit and contains invalid characters (+). This causes the stylesheet to transfer 0 bytes, leaving the webview completely unstyled.

Replace the static <link> tag with a script that:
- Defers stylesheet injection until navigator.serviceWorker.ready resolves (when a service worker controller is present)
- Loads immediately in desktop VS Code (Electron) where no service worker is involved
- Retries up to 3 times on load failure with 1.5s delays

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated stylesheet handling: the app now injects the stylesheet dynamically and re-injects it when the active service worker controller changes to help maintain consistent styling across service-worker-driven loads. Removed the prior static stylesheet link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->