### PR TITLE
:sparkles: Migration intelligence package skeleton

### DIFF
--- a/changes/unreleased/1352-migration-intelligence-package.yaml
+++ b/changes/unreleased/1352-migration-intelligence-package.yaml
@@ -1,0 +1,10 @@
+kind: feature
+
+description: >
+  Add migration intelligence package with built-in skills and prompts for
+  Konveyor-guided migrations. Includes three workflow skills (create-migration-guide,
+  generate-migration-plan, execute-migration-phase) and prompt templates, following
+  the Agent Skills format for consumption by any MCP-compatible agent.
+
+extensions:
+  - core

--- a/packages/migration-intelligence/AGENTS.md
+++ b/packages/migration-intelligence/AGENTS.md
@@ -1,0 +1,52 @@
+# Migration Intelligence — Agent Instructions
+
+This package provides migration intelligence for Konveyor-guided migrations.
+It is consumed by agents running in the IDE (VS Code), CLI, or hub containers.
+
+## What This Package Contains
+
+- **Skills** (`skills/`) — reusable migration workflows in the [Agent Skills](https://agentskills.io) format
+- **Prompts** (`prompts/`) — workflow prompt templates for skill creation, plan generation, and phased execution
+- **This file** — agent instructions for Claude Code, Cursor, and similar agents
+
+## How to Use This Package
+
+When working on a Konveyor migration, you have access to three migration workflows
+defined as skills in this package. Read each skill's `SKILL.md` to understand when
+and how to activate it.
+
+### Available Skills
+
+1. **create-migration-guide** — Interview the user, explore the codebase, and produce
+   a migration guide skill saved to `.konveyor/skills/`. Use this when no migration
+   guide exists yet for the current project.
+
+2. **generate-migration-plan** — Read existing skills and analysis results, then produce
+   a phased migration plan. Use this when a migration guide exists and the user wants
+   a plan for how to execute the migration.
+
+3. **execute-migration-phase** — Execute one phase of an approved migration plan,
+   re-analyze, and prompt the user before proceeding. Use this when a plan exists
+   and the user is ready to start or continue execution.
+
+### Intelligence Layering
+
+Context is assembled from three sources (later sources extend or override earlier ones):
+
+1. **This package** — built-in skills and prompts (defaults)
+2. **Hub-distributed** — architect-authored skills from `.konveyor/profiles/{id}/skills/`
+3. **Workspace-local** — user or agent-created skills from `.konveyor/skills/`
+
+### Analysis Tools
+
+Analysis capabilities (run_analysis, get_analysis_results, get_incidents_by_file)
+come from the Konveyor MCP server — not from this package. This package provides
+migration context and workflow instructions only.
+
+## Format
+
+Skills follow the [Agent Skills](https://agentskills.io) format:
+
+- Each skill is a directory containing a `SKILL.md` with YAML frontmatter
+- Agents load only `name` and `description` at discovery time
+- Full instructions are read only when the skill is activated

--- a/packages/migration-intelligence/SKILL.md
+++ b/packages/migration-intelligence/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: migration-intelligence
+description: >
+  Konveyor migration intelligence workflows. Use when helping a user plan or
+  execute a migration guided by Konveyor analysis results. Provides three
+  workflows: creating a migration guide, generating a phased plan, and executing
+  migration phases.
+---
+
+# Migration Intelligence
+
+This package provides migration intelligence for Konveyor-guided migrations.
+See `AGENTS.md` for full agent instructions.
+
+## Quick Reference
+
+| Skill                     | When to use                                                         |
+| ------------------------- | ------------------------------------------------------------------- |
+| `create-migration-guide`  | No migration guide exists yet — interview user and explore codebase |
+| `generate-migration-plan` | Migration guide exists — produce a phased execution plan            |
+| `execute-migration-phase` | Plan approved — execute one phase at a time                         |

--- a/packages/migration-intelligence/package.json
+++ b/packages/migration-intelligence/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@editor-extensions/migration-intelligence",
+  "version": "0.1.0",
+  "description": "Portable migration intelligence package — skills, prompts, and agent instructions for Konveyor-guided migrations",
+  "private": true,
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/konveyor/editor-extensions"
+  },
+  "files": [
+    "AGENTS.md",
+    "SKILL.md",
+    "skills/",
+    "prompts/"
+  ]
+}

--- a/packages/migration-intelligence/prompts/phase-execution.md
+++ b/packages/migration-intelligence/prompts/phase-execution.md
@@ -1,0 +1,20 @@
+# Phase Execution Prompt
+
+Use this prompt template when invoking the `execute-migration-phase` workflow.
+
+```
+You are a migration assistant executing a phase of an approved migration plan.
+
+The migration plan is available in .konveyor/skills/.
+Analysis tools are available via the Konveyor MCP server.
+Your file tools are available for reading and modifying source files.
+
+Follow the `execute-migration-phase` skill instructions to:
+1. Execute all changes for the current phase
+2. Re-analyze after completing changes
+3. Present results and any issues to the user
+4. Wait for explicit user confirmation before proceeding to the next phase
+
+Do not make changes outside the current phase's scope.
+Follow all organizational preferences from the migration guide.
+```

--- a/packages/migration-intelligence/prompts/plan-generation.md
+++ b/packages/migration-intelligence/prompts/plan-generation.md
@@ -1,0 +1,19 @@
+# Plan Generation Prompt
+
+Use this prompt template when invoking the `generate-migration-plan` workflow.
+
+```
+You are a migration assistant helping generate a phased migration plan.
+
+Migration guide skills are available in .konveyor/skills/.
+Analysis results are available via the `get_analysis_results` tool.
+
+Follow the `generate-migration-plan` skill instructions to:
+1. Load the migration guide and analysis results
+2. Group incidents into logical, independently-executable phases
+3. Draft a phased plan with clear acceptance criteria per phase
+4. Present the plan for user review before saving
+
+Each phase should leave the codebase in a compilable, testable state.
+Prefer fewer larger phases over many tiny ones.
+```

--- a/packages/migration-intelligence/prompts/skill-creation.md
+++ b/packages/migration-intelligence/prompts/skill-creation.md
@@ -1,0 +1,19 @@
+# Skill Creation Prompt
+
+Use this prompt template when invoking the `create-migration-guide` workflow.
+
+```
+You are a migration assistant helping create a migration guide for a Konveyor migration.
+
+Analysis results are available via the `get_analysis_results` tool.
+The workspace is available via your file tools.
+
+Follow the `create-migration-guide` skill instructions to:
+1. Understand the migration type from analysis results
+2. Explore the codebase to identify key patterns
+3. Ask the user targeted questions about organizational preferences
+4. Produce a migration guide saved to .konveyor/skills/
+
+Be concise in your questions. Present options when possible.
+Do not ask about things you can determine from the code.
+```

--- a/packages/migration-intelligence/skills/create-migration-guide/SKILL.md
+++ b/packages/migration-intelligence/skills/create-migration-guide/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: create-migration-guide
+description: >
+  Interview the user and explore the codebase to create a migration guide skill.
+  Use when analysis results exist but no migration guide has been created yet.
+  Produces a SKILL.md saved to .konveyor/skills/ capturing migration context,
+  key patterns, and organizational preferences.
+---
+
+# Create Migration Guide
+
+## Purpose
+
+Produce a migration guide skill that captures everything an agent needs to plan
+and execute this migration: what the migration means, what patterns the codebase
+uses, and what the organization's preferences are.
+
+The output is a `SKILL.md` saved to `.konveyor/skills/{migration-name}/` following
+the [Agent Skills](https://agentskills.io) format.
+
+## When to Activate
+
+- Analysis results are available (run `run_analysis` if not)
+- No migration guide exists in `.konveyor/skills/`
+- User wants to start a migration or create a plan
+
+## Workflow
+
+### Step 1: Understand the migration
+
+Read the analysis results to identify the migration type (e.g., Java EE → Quarkus,
+Spring Boot 2 → 3, EAP → JWS). Summarize what you found.
+
+### Step 2: Explore the codebase
+
+Use your file tools to explore the project structure. Focus on:
+
+- Entry points, key services, and domain objects
+- Frameworks, libraries, and patterns in use
+- Anything that looks non-standard or org-specific
+
+### Step 3: Ask structured questions
+
+Ask the user targeted questions about things you cannot infer from the code.
+Present options when possible (don't ask open-ended questions you could answer yourself).
+
+Example questions:
+
+- "I see both Kafka and RabbitMQ dependencies. Which should be used for messaging after migration?"
+- "Should Flyway migrations be preserved as-is, or updated to match the new schema?"
+- "Are there services that should NOT be migrated in this pass?"
+
+### Step 4: Write the migration guide
+
+Create `.konveyor/skills/{migration-slug}/SKILL.md` with:
+
+```markdown
+---
+name: { migration-slug }
+description: >
+  Migration plan for {source} to {target}. Use when planning or executing
+  a migration from {source} to {target} for this application.
+---
+
+# {Migration Title}
+
+## Application Context
+
+{Brief description of the application and its current state}
+
+## Key Patterns
+
+{Bullet list of patterns discovered in the codebase that affect the migration}
+
+## Organizational Preferences
+
+{Bullet list of preferences gathered from the user}
+
+## Things to Watch
+
+{Specific files, classes, or patterns that need special attention}
+```
+
+### Step 5: Confirm
+
+Show the guide to the user and ask if they want to adjust anything before saving.
+
+## References
+
+See `references/example-migration-guide.md` for a complete example.

--- a/packages/migration-intelligence/skills/create-migration-guide/references/example-migration-guide.md
+++ b/packages/migration-intelligence/skills/create-migration-guide/references/example-migration-guide.md
@@ -1,0 +1,42 @@
+# Example Migration Guide
+
+This is an example of a well-formed migration guide skill.
+
+```markdown
+---
+name: java-ee-to-quarkus
+description: >
+  Migration plan for Java EE to Quarkus. Use when planning or executing
+  a migration from JBoss EAP 7.4 / Java EE to Quarkus 3.x for the
+  coolstore e-commerce application.
+---
+
+# Java EE to Quarkus Migration Plan
+
+## Application Context
+
+Monolith e-commerce application on JBoss EAP 7.4, migrating to Quarkus 3.x.
+Uses EJB, JPA, JMS, and JAX-RS. ~45 services, ~200k LOC.
+
+## Key Patterns
+
+- Services use @Stateless — convert to @ApplicationScoped
+- ShippingService uses @Remote — refactor to REST endpoint
+- JMS with JMSContext — migrate to SmallRye Reactive Messaging with RabbitMQ
+- EntityManager injected via @PersistenceContext — replace with @Inject
+- JNDI lookups in DataSourceConfig — replace with application.properties
+
+## Organizational Preferences
+
+- Use RabbitMQ (not Kafka) for messaging
+- Use RESTEasy Reactive (not Classic)
+- Preserve Flyway migrations — do not modify schema files
+- Use Quarkus Panache for new repository code where possible
+
+## Things to Watch
+
+- OrderService.save() needs explicit @Transactional
+- CatalogService.updateInventoryItems() needs @Transactional
+- CartService uses a custom session management pattern — discuss with team before migrating
+- SecurityConfig extends a proprietary EAP base class — needs manual rewrite
+```

--- a/packages/migration-intelligence/skills/execute-migration-phase/SKILL.md
+++ b/packages/migration-intelligence/skills/execute-migration-phase/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: execute-migration-phase
+description: >
+  Execute one phase of an approved migration plan. Re-analyzes after each phase
+  and prompts the user before proceeding to the next. Use when a migration plan
+  exists and the user is ready to start or continue execution.
+---
+
+# Execute Migration Phase
+
+## Purpose
+
+Execute migration changes one phase at a time, with user review and re-analysis
+between phases. Ensures changes are correct before proceeding and catches
+cascading issues early.
+
+## When to Activate
+
+- An approved migration plan exists in `.konveyor/skills/`
+- User wants to start or continue executing the migration
+
+## Workflow
+
+### Step 1: Load the plan
+
+Read the migration plan skill from `.konveyor/skills/`. Identify:
+
+- Which phase to execute (ask the user if unclear)
+- What files are in scope
+- What the acceptance criteria are
+
+### Step 2: Execute the phase
+
+Apply all changes for this phase using your file tools. Follow the migration
+guide's organizational preferences. Do not make changes outside this phase's scope.
+
+### Step 3: Re-analyze
+
+Run `run_analysis` after completing the phase's changes. Compare results to
+the pre-phase baseline:
+
+- How many incidents were resolved?
+- Did any new incidents appear?
+- Are there cascading issues that affect the next phase?
+
+### Step 4: Present results
+
+Show the user:
+
+- What changed (summary of files modified)
+- Analysis delta (incidents resolved vs. new incidents)
+- Any issues that need attention before proceeding
+
+Ask structured questions if input is needed:
+
+- "3 new incidents appeared in OrderService. Should I fix these now or defer to Phase 3?"
+- "CartService has a pattern that doesn't match the migration guide. Here are two options: [A] or [B]. Which do you prefer?"
+
+### Step 5: Confirm before next phase
+
+Do not proceed to the next phase without explicit user confirmation.
+Present: "Phase {N} complete. Ready to start Phase {N+1}: {name}? ({M} incidents, {K} files)"
+
+## Important Constraints
+
+- Never modify files outside the current phase's scope
+- Always re-analyze before asking the user to confirm
+- If analysis fails, report the error and wait for user input
+- Preserve all organizational preferences from the migration guide

--- a/packages/migration-intelligence/skills/generate-migration-plan/SKILL.md
+++ b/packages/migration-intelligence/skills/generate-migration-plan/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: generate-migration-plan
+description: >
+  Read existing migration guide skills and analysis results to produce a phased
+  migration plan. Use when a migration guide exists in .konveyor/skills/ and the
+  user wants a structured plan for executing the migration in phases.
+---
+
+# Generate Migration Plan
+
+## Purpose
+
+Produce a phased migration plan that breaks the migration into manageable,
+reviewable chunks. Each phase should be independently executable and result
+in a compilable, testable codebase.
+
+The output is a `SKILL.md` saved to `.konveyor/skills/{migration-name}-plan/`
+that captures the full plan and can be referenced during execution.
+
+## When to Activate
+
+- A migration guide exists in `.konveyor/skills/`
+- Analysis results are available
+- User wants a plan before starting execution
+
+## Workflow
+
+### Step 1: Load context
+
+Read all skills in `.konveyor/skills/` and `.konveyor/profiles/*/skills/`.
+Get analysis results via `get_analysis_results`.
+
+### Step 2: Group incidents into phases
+
+Organize incidents into logical phases. Good phase boundaries:
+
+- All changes of one type (e.g., all `@Stateless` → `@ApplicationScoped`)
+- Changes scoped to one layer (e.g., persistence layer only)
+- Changes with no inter-dependencies
+
+Each phase should:
+
+- Be completable in one agent session
+- Leave the codebase in a compilable state
+- Have clear acceptance criteria
+
+### Step 3: Draft the plan
+
+Structure:
+
+```markdown
+# Migration Plan: {title}
+
+## Summary
+
+{2-3 sentences describing the migration and approach}
+
+## Phases
+
+### Phase 1: {name}
+
+**Goal:** {what this phase achieves}
+**Incidents:** {N} incidents across {M} files
+**Files:** {list key files}
+**Acceptance:** {how to verify this phase is complete}
+
+### Phase 2: {name}
+
+...
+```
+
+### Step 4: Present and refine
+
+Show the plan to the user. Ask if they want to:
+
+- Reorder phases
+- Split or merge phases
+- Exclude anything from this pass
+
+### Step 5: Save the plan
+
+Save to `.konveyor/skills/{migration-slug}-plan/SKILL.md` once approved.


### PR DESCRIPTION
## Summary

Adds `packages/migration-intelligence/` — a standalone package containing built-in skills, prompts, and agent instructions for Konveyor-guided migrations. This is the **intelligence layer** described in [konveyor/enhancements#274](https://github.com/konveyor/enhancements/pull/274), built on top of the pluggable agent backend infrastructure from #1351.

## What this PR adds

```
packages/migration-intelligence/
├── package.json                          # Standalone package (@editor-extensions/migration-intelligence)
├── AGENTS.md                             # Agent instructions (Claude Code, Cursor, etc.)
├── SKILL.md                              # Top-level Agent Skills entry point
├── skills/
│   ├── create-migration-guide/
│   │   ├── SKILL.md                      # Workflow: explore codebase + interview user → skill file
│   │   └── references/
│   │       └── example-migration-guide.md
│   ├── generate-migration-plan/
│   │   └── SKILL.md                      # Workflow: guide + analysis results → phased plan
│   └── execute-migration-phase/
│       └── SKILL.md                      # Workflow: execute one phase, re-analyze, prompt user
└── prompts/
    ├── skill-creation.md                 # Prompt template for skill creation workflow
    ├── plan-generation.md                # Prompt template for plan generation workflow
    └── phase-execution.md               # Prompt template for phase execution workflow
```

## Key design decisions

- **Agent Skills format** — skills follow [agentskills.io](https://agentskills.io) for compatibility with Goose, OpenCode, Claude Code, and Codex. No IDE-specific tooling required.
- **Portable by design** — the package has its own `package.json` so any agent can consume it directly by pointing at the package directory, not just the VS Code extension.
- **Markdown-only skeleton** — no code in this PR. Wiring into the extension (skill discovery, prompt loading, profile bundle extraction) follows in subsequent PRs.
- **Three-layer intelligence** — skills from this package are defaults; hub-distributed and workspace-local skills extend or override them (see `AGENTS.md`).

## Relationship to enhancements#274

This PR implements the **Migration Intelligence Package** section of [konveyor/enhancements#274](https://github.com/konveyor/enhancements/pull/274). The three skills map directly to the three phases described in the spec:
- Phase 1 (Skill Creation) → `create-migration-guide`
- Phase 2 (Plan Generation) → `generate-migration-plan`  
- Phase 3 (Phased Execution) → `execute-migration-phase`

## Depends on

- #1351 — pluggable agent backend (provides the runtime this intelligence layer runs on)

## Intentionally deferred

- Skill discovery/loading in the extension (reading from `.konveyor/skills/` + package defaults)
- Profile bundle extraction of `skills/` and `prompts/` directories
- `promptBuilder.ts` replacement with skill-based prompt loading
- Hub API for skill CRUD on profiles