### PR TITLE
:sparkles: Skill loader and prompt builder integration

### DIFF
--- a/vscode/core/src/clients/ProfileSyncClient.ts
+++ b/vscode/core/src/clients/ProfileSyncClient.ts
@@ -729,14 +729,19 @@ export class ProfileSyncClient {
     try {
       await fs.writeFile(tempTarFile, tarBuffer);
 
-      // Extract tar bundle to profile directory
+      // Extract tar bundle to profile directory.
+      // The TAR pipeline extracts all file types including:
+      // - rules/*.yaml (analysis rules)
+      // - skills/*/SKILL.md (migration skills for the agent)
+      // - prompts/*.md (prompt templates for the agent)
       await tar.extract({
         file: tempTarFile,
         cwd: profileDir,
         strip: 0,
-        filter: (path) => {
-          // Security filter: prevent path traversal attacks
-          const normalized = path.replace(/\\/g, "/");
+        filter: (entryPath) => {
+          // Security filter: prevent path traversal attacks.
+          // No file type filtering - we allow all files including .md for skills/prompts.
+          const normalized = entryPath.replace(/\\/g, "/");
 
           // Block relative path traversal attempts
           if (normalized.includes("../") || normalized.startsWith("..")) {
@@ -754,6 +759,21 @@ export class ProfileSyncClient {
         fileCount: extractedFiles.length,
         files: extractedFiles,
       });
+
+      // Check for skills and prompts directories in the extracted bundle
+      const hasSkills = extractedFiles.some(
+        (f) => typeof f === "string" && f.startsWith("skills/"),
+      );
+      const hasPrompts = extractedFiles.some(
+        (f) => typeof f === "string" && f.startsWith("prompts/"),
+      );
+      if (hasSkills || hasPrompts) {
+        this.logger.info("Profile bundle includes agent resources", {
+          profileId,
+          hasSkills,
+          hasPrompts,
+        });
+      }
     } finally {
       // Clean up temp file
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/vscode/core/src/features/agent/index.ts
+++ b/vscode/core/src/features/agent/index.ts
@@ -4,6 +4,14 @@ import { KonveyorGUIWebviewViewProvider } from "../../KonveyorGUIWebviewViewProv
 import type { AgentClient } from "../../client/agentClient";
 import { policyToGooseMode } from "./toolPermissionHandler";
 
+// Re-export skill loader types and functions
+export { buildSkillIndex, loadSkillContent, loadPrompt, getSkillWithContent } from "./skillLoader";
+export type { SkillEntry, SkillIndex } from "./skillLoader";
+
+// Re-export prompt builder
+export { buildMigrationPrompt } from "./promptBuilder";
+export type { BuildMigrationPromptOptions } from "./promptBuilder";
+
 export const agentFeatureModule: FeatureModule = {
   id: "agent",
   name: "Migration Assistant Chat",

--- a/vscode/core/src/features/agent/promptBuilder.ts
+++ b/vscode/core/src/features/agent/promptBuilder.ts
@@ -2,15 +2,29 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import type { KaiInteractiveWorkflowInput } from "@editor-extensions/agentic";
 import type { EnhancedIncident } from "@editor-extensions/shared";
+import { buildSkillIndex, getSkillWithContent } from "./skillLoader";
+
+/**
+ * Options for building a migration prompt.
+ */
+export interface BuildMigrationPromptOptions {
+  /** Path to the VS Code extension root (for loading packaged skills) */
+  extensionPath?: string;
+}
 
 /**
  * Builds a self-contained migration prompt for goose from the same
  * KaiInteractiveWorkflowInput that the LangGraph workflow consumes.
+ *
+ * If an extensionPath is provided, attempts to load the `execute-migration-phase`
+ * skill from the skill loader and prepends it as context. Falls back to a
+ * hardcoded prompt if the skill is not found.
  */
 export async function buildMigrationPrompt(
   input: KaiInteractiveWorkflowInput,
   workspaceDir: string,
   fileContentCache?: ReadonlyMap<string, string>,
+  options?: BuildMigrationPromptOptions,
 ): Promise<string> {
   const { incidents = [], migrationHint, programmingLanguage } = input;
 
@@ -34,19 +48,48 @@ export async function buildMigrationPrompt(
         `Do not skip unchanged files. Only call write_file for files that need modifications.`,
       ];
 
-  return [
-    `You are a migration assistant. Apply the following migration to the codebase.`,
-    ``,
-    `**Migration**: ${migrationHint}`,
-    `**Language**: ${programmingLanguage}`,
-    ``,
-    `## Incidents to fix`,
-    ``,
-    ...fileBlocks,
-    `## Instructions`,
-    ``,
-    ...instructions,
-  ].join("\n");
+  // Try to load skill-based prompt if extensionPath is provided
+  let systemPrompt: string | null = null;
+  if (options?.extensionPath) {
+    try {
+      const skillIndex = await buildSkillIndex(options.extensionPath, workspaceDir);
+      const skill = await getSkillWithContent(skillIndex, "execute-migration-phase");
+      if (skill) {
+        systemPrompt = skill.content;
+      }
+    } catch {
+      // Skill loading failed, fall back to hardcoded prompt
+    }
+  }
+
+  // Build the prompt parts
+  const promptParts: string[] = [];
+
+  if (systemPrompt) {
+    // Use skill content as the base prompt
+    promptParts.push(systemPrompt);
+    promptParts.push("");
+    promptParts.push(`**Migration**: ${migrationHint}`);
+    promptParts.push(`**Language**: ${programmingLanguage}`);
+  } else {
+    // Fallback to hardcoded prompt
+    promptParts.push(
+      `You are a migration assistant. Apply the following migration to the codebase.`,
+    );
+    promptParts.push("");
+    promptParts.push(`**Migration**: ${migrationHint}`);
+    promptParts.push(`**Language**: ${programmingLanguage}`);
+  }
+
+  promptParts.push("");
+  promptParts.push(`## Incidents to fix`);
+  promptParts.push("");
+  promptParts.push(...fileBlocks);
+  promptParts.push(`## Instructions`);
+  promptParts.push("");
+  promptParts.push(...instructions);
+
+  return promptParts.join("\n");
 }
 
 function groupByUri(incidents: EnhancedIncident[]): Map<string, EnhancedIncident[]> {

--- a/vscode/core/src/features/agent/skillLoader.ts
+++ b/vscode/core/src/features/agent/skillLoader.ts
@@ -1,0 +1,267 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+
+/**
+ * Represents a single skill entry with metadata and location.
+ */
+export interface SkillEntry {
+  /** Unique skill name from YAML frontmatter */
+  name: string;
+  /** Human-readable description from YAML frontmatter */
+  description: string;
+  /** Directory containing the SKILL.md file */
+  skillDir: string;
+  /** Absolute path to the SKILL.md file */
+  skillMdPath: string;
+  /** Source layer where this skill was loaded from */
+  source: "package" | "hub" | "workspace";
+}
+
+/**
+ * Map of skill name to SkillEntry.
+ */
+export type SkillIndex = Map<string, SkillEntry>;
+
+/**
+ * YAML frontmatter extracted from a SKILL.md file.
+ */
+interface SkillFrontmatter {
+  name?: string;
+  description?: string;
+}
+
+/**
+ * Parses YAML frontmatter from markdown content.
+ * Frontmatter is enclosed between `---` delimiters at the start of the file.
+ *
+ * @param content - The markdown file content
+ * @returns Parsed frontmatter object or null if not found
+ */
+function parseFrontmatter(content: string): SkillFrontmatter | null {
+  // Match frontmatter between --- delimiters at the start of the file
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) {
+    return null;
+  }
+
+  const yamlContent = match[1];
+  const result: SkillFrontmatter = {};
+
+  // Simple YAML parsing for name and description fields
+  for (const line of yamlContent.split(/\r?\n/)) {
+    const nameMatch = line.match(/^name:\s*(.+)$/);
+    if (nameMatch) {
+      result.name = nameMatch[1].trim().replace(/^["']|["']$/g, "");
+    }
+
+    const descMatch = line.match(/^description:\s*(.+)$/);
+    if (descMatch) {
+      result.description = descMatch[1].trim().replace(/^["']|["']$/g, "");
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Checks if a directory exists and is accessible.
+ *
+ * @param dirPath - Path to check
+ * @returns True if directory exists
+ */
+async function directoryExists(dirPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(dirPath);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Loads skill entries from a single directory.
+ * Each subdirectory containing a SKILL.md file is treated as a skill.
+ *
+ * @param skillsDir - Directory to scan for skills
+ * @param source - Source layer for these skills
+ * @returns Array of skill entries found
+ */
+async function loadSkillsFromDir(
+  skillsDir: string,
+  source: SkillEntry["source"],
+): Promise<SkillEntry[]> {
+  if (!(await directoryExists(skillsDir))) {
+    return [];
+  }
+
+  const entries: SkillEntry[] = [];
+
+  try {
+    const items = await fs.readdir(skillsDir, { withFileTypes: true });
+
+    for (const item of items) {
+      if (!item.isDirectory()) {
+        continue;
+      }
+
+      const skillDir = path.join(skillsDir, item.name);
+      const skillMdPath = path.join(skillDir, "SKILL.md");
+
+      try {
+        const content = await fs.readFile(skillMdPath, "utf-8");
+        const frontmatter = parseFrontmatter(content);
+
+        if (frontmatter?.name) {
+          entries.push({
+            name: frontmatter.name,
+            description: frontmatter.description ?? "",
+            skillDir,
+            skillMdPath,
+            source,
+          });
+        }
+      } catch {
+        // SKILL.md doesn't exist or is unreadable, skip this directory
+      }
+    }
+  } catch {
+    // Directory unreadable, return empty
+  }
+
+  return entries;
+}
+
+/**
+ * Builds a SkillIndex by loading skills from three layers in priority order.
+ * Later layers override earlier ones (workspace > hub > package).
+ *
+ * Layer order (earlier = lower priority):
+ * 1. Package defaults: `<extensionPath>/packages/migration-intelligence/skills/`
+ * 2. Hub-distributed: `.konveyor/profiles/<id>/skills/` (all profile subdirectories)
+ * 3. Workspace-local: `.konveyor/skills/`
+ *
+ * @param extensionPath - Path to the VS Code extension
+ * @param workspaceRoot - Path to the workspace root directory
+ * @returns Map of skill name to SkillEntry
+ */
+export async function buildSkillIndex(
+  extensionPath: string,
+  workspaceRoot: string,
+): Promise<SkillIndex> {
+  const index: SkillIndex = new Map();
+
+  // Layer 1: Package defaults
+  const packageSkillsDir = path.join(extensionPath, "packages", "migration-intelligence", "skills");
+  const packageSkills = await loadSkillsFromDir(packageSkillsDir, "package");
+  for (const skill of packageSkills) {
+    index.set(skill.name, skill);
+  }
+
+  // Layer 2: Hub-distributed profiles
+  const profilesDir = path.join(workspaceRoot, ".konveyor", "profiles");
+  if (await directoryExists(profilesDir)) {
+    try {
+      const profileItems = await fs.readdir(profilesDir, { withFileTypes: true });
+      for (const profileItem of profileItems) {
+        if (!profileItem.isDirectory()) {
+          continue;
+        }
+        const profileSkillsDir = path.join(profilesDir, profileItem.name, "skills");
+        const hubSkills = await loadSkillsFromDir(profileSkillsDir, "hub");
+        for (const skill of hubSkills) {
+          index.set(skill.name, skill);
+        }
+      }
+    } catch {
+      // Profiles directory unreadable
+    }
+  }
+
+  // Layer 3: Workspace-local
+  const workspaceSkillsDir = path.join(workspaceRoot, ".konveyor", "skills");
+  const workspaceSkills = await loadSkillsFromDir(workspaceSkillsDir, "workspace");
+  for (const skill of workspaceSkills) {
+    index.set(skill.name, skill);
+  }
+
+  return index;
+}
+
+/**
+ * Loads the full content of a SKILL.md file.
+ *
+ * @param skillMdPath - Absolute path to the SKILL.md file
+ * @returns The full file content as a string
+ * @throws Error if file cannot be read
+ */
+export async function loadSkillContent(skillMdPath: string): Promise<string> {
+  return fs.readFile(skillMdPath, "utf-8");
+}
+
+/**
+ * Loads a prompt file by name from available locations.
+ *
+ * Search order (first found wins):
+ * 1. Workspace-local: `.konveyor/prompts/{promptName}.md`
+ * 2. Package defaults: `<extensionPath>/packages/migration-intelligence/prompts/{promptName}.md`
+ *
+ * @param promptName - Name of the prompt (without .md extension)
+ * @param extensionPath - Path to the VS Code extension
+ * @param workspaceRoot - Path to the workspace root directory
+ * @returns The prompt content or null if not found
+ */
+export async function loadPrompt(
+  promptName: string,
+  extensionPath: string,
+  workspaceRoot: string,
+): Promise<string | null> {
+  const filename = `${promptName}.md`;
+
+  // Try workspace-local first (higher priority)
+  const workspacePromptPath = path.join(workspaceRoot, ".konveyor", "prompts", filename);
+  try {
+    return await fs.readFile(workspacePromptPath, "utf-8");
+  } catch {
+    // Not found in workspace, try package
+  }
+
+  // Try package defaults
+  const packagePromptPath = path.join(
+    extensionPath,
+    "packages",
+    "migration-intelligence",
+    "prompts",
+    filename,
+  );
+  try {
+    return await fs.readFile(packagePromptPath, "utf-8");
+  } catch {
+    // Not found
+  }
+
+  return null;
+}
+
+/**
+ * Gets a skill by name from the index and loads its content.
+ *
+ * @param skillIndex - The skill index to search
+ * @param skillName - Name of the skill to load
+ * @returns Object with skill entry and content, or null if not found
+ */
+export async function getSkillWithContent(
+  skillIndex: SkillIndex,
+  skillName: string,
+): Promise<{ entry: SkillEntry; content: string } | null> {
+  const entry = skillIndex.get(skillName);
+  if (!entry) {
+    return null;
+  }
+
+  try {
+    const content = await loadSkillContent(entry.skillMdPath);
+    return { entry, content };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Wires the migration intelligence package (#1353) into the extension by replacing hardcoded prompt strings with skill-based loading. Introduces a three-layer skill discovery system following the architecture described in [konveyor/enhancements#274](https://github.com/konveyor/enhancements/pull/274).

## What this PR adds

### `skillLoader.ts` — new module

Three-layer skill discovery (later layers override earlier):
1. **Package defaults** — `<extensionPath>/packages/migration-intelligence/skills/`
2. **Hub-distributed** — `.konveyor/profiles/<id>/skills/` (all profiles)
3. **Workspace-local** — `.konveyor/skills/`

Key exports:
- `buildSkillIndex(extensionPath, workspaceRoot)` — scans all layers, returns `Map<name, SkillEntry>`
- `loadSkillContent(skillMdPath)` — reads full SKILL.md on activation
- `loadPrompt(name, extensionPath, workspaceRoot)` — loads prompt templates (workspace overrides package)
- `getSkillWithContent(index, skillName)` — convenience: lookup + load in one call

YAML frontmatter parsing uses a simple regex (no extra deps). Missing directories are handled gracefully.

### `promptBuilder.ts` — updated

Accepts optional `extensionPath` via `BuildMigrationPromptOptions`. When provided:
- Builds skill index
- Looks up `execute-migration-phase` skill
- Prepends skill content as the system prompt
- Falls back to existing hardcoded prompt if skill not found

The incident/file block building logic is unchanged.

### `ProfileSyncClient.ts` — updated

Added logging when profile bundles include `skills/` or `prompts/` directories. The existing TAR extract pipeline already handles all file types — no filter changes needed.

## Depends on

- #1351 — pluggable agent backend (base branch)
- #1353 — migration intelligence package (provides the skills this loader reads)

## What`s still deferred

- Passing `extensionPath` from the orchestrator to `buildMigrationPrompt` (needs call-site update in `agentOrchestrator.ts`)
- Guided phase flow UI (skill creation → plan generation → phased execution)
- Hub API for skill CRUD