### PR TITLE
:bug: Ignore files outside workspace in analysis trigger

### DIFF
--- a/changes/unreleased/1343-ignore-non-workspace-files.yaml
+++ b/changes/unreleased/1343-ignore-non-workspace-files.yaml
@@ -1,0 +1,3 @@
+kind: bugfix
+description: >
+  ignore files outside workspace in analysis trigger

--- a/vscode/core/src/analysis/batchedAnalysisTrigger.ts
+++ b/vscode/core/src/analysis/batchedAnalysisTrigger.ts
@@ -22,6 +22,12 @@ export class BatchedAnalysisTrigger {
   }
 
   async notifyFileChanges(change: FileChange) {
+    // Don't schedule analysis if server is not running - it's pointless
+    const serverState = this.extensionState.analyzerClient?.serverState;
+    if (serverState !== "running") {
+      return;
+    }
+
     if (this.enableHotRerun) {
       this.extensionState.mutateAnalysisState((draft) => {
         draft.isAnalysisScheduled = true;

--- a/vscode/core/src/analysis/batchedAnalysisTrigger.ts
+++ b/vscode/core/src/analysis/batchedAnalysisTrigger.ts
@@ -22,9 +22,8 @@ export class BatchedAnalysisTrigger {
   }
 
   async notifyFileChanges(change: FileChange) {
-    // Don't schedule analysis if server is not running - it's pointless
-    const serverState = this.extensionState.analyzerClient?.serverState;
-    if (serverState !== "running") {
+    // Don't schedule analysis for ignored files (e.g., files outside workspace)
+    if (isUriIgnored(change.path)) {
       return;
     }
 

--- a/vscode/core/src/paths.ts
+++ b/vscode/core/src/paths.ts
@@ -1,4 +1,4 @@
-import { relative, dirname, join } from "node:path";
+import { relative, dirname, join, isAbsolute, sep } from "node:path";
 import { createWriteStream, createReadStream } from "node:fs";
 import { globbySync, isIgnoredByIgnoreFilesSync } from "globby";
 import * as vscode from "vscode";
@@ -446,8 +446,8 @@ export const isUriIgnored = (uri: vscode.Uri): boolean => {
     `isUriIgnored: path=${uri.fsPath}, relative=${f}, workspaceRepo=${fsPaths().workspaceRepo}`,
   );
 
-  // Ignore files outside the workspace (relative path starts with ..)
-  if (f.startsWith("..")) {
+  // Ignore files outside the workspace
+  if (f === ".." || f.startsWith(".." + sep) || isAbsolute(f)) {
     return true;
   }
 

--- a/vscode/core/src/paths.ts
+++ b/vscode/core/src/paths.ts
@@ -442,7 +442,14 @@ export const isUriIgnored = (uri: vscode.Uri): boolean => {
   }
 
   const f = relative(fsPaths().workspaceRepo, uri.fsPath);
-  _logger?.debug(`isUriIgnored: ${f}`);
+  _logger?.debug(
+    `isUriIgnored: path=${uri.fsPath}, relative=${f}, workspaceRepo=${fsPaths().workspaceRepo}`,
+  );
+
+  // Ignore files outside the workspace (relative path starts with ..)
+  if (f.startsWith("..")) {
+    return true;
+  }
 
   // Always ignore .konveyor directory
   if (f.startsWith(".konveyor/") || f === ".konveyor") {


### PR DESCRIPTION
Resolves #1343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Files outside your workspace are now properly ignored, preventing them from triggering unnecessary analysis and improving overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->