### PR TITLE
:bug: capture in-place user edits when sending accepted solution to solution server

### DIFF
--- a/changes/unreleased/fix-solution-server-inline-edit-capture.yaml
+++ b/changes/unreleased/fix-solution-server-inline-edit-capture.yaml
@@ -1,0 +1,11 @@
+kind: bugfix
+
+description: >
+  Fix solution server not receiving user's in-place edits when accepting a solution.
+  Previously, when a user edited the LLM-suggested fix directly in the editor before
+  clicking Accept, the solution server received the original LLM-generated content
+  instead of the user's modified version. The fix now reads the file from disk at
+  accept time, capturing any edits made between fix generation and acceptance.
+
+extensions:
+  - core

--- a/vscode/core/src/utilities/ModifiedFiles/handleFileResponse.ts
+++ b/vscode/core/src/utilities/ModifiedFiles/handleFileResponse.ts
@@ -204,11 +204,20 @@ export async function handleFileResponse(
       }
 
       // Notify solution server of the change
+      // Read from disk to capture any in-place edits the user made before accepting
       try {
         if (isDeleted) {
           await executeExtensionCommand("changeDiscarded", path);
         } else {
-          await executeExtensionCommand("changeApplied", path, fileContent);
+          let finalContent = fileContent;
+          try {
+            const diskBytes = await vscode.workspace.fs.readFile(uri);
+            finalContent = new TextDecoder().decode(diskBytes);
+            logger.info(`Using on-disk content for solution server (captures in-place edits): ${path}`);
+          } catch (readError) {
+            logger.warn(`Could not read disk content, using original content: ${path}`, readError);
+          }
+          await executeExtensionCommand("changeApplied", path, finalContent);
         }
       } catch (error) {
         logger.error("Error notifying solution server:", error);


### PR DESCRIPTION
Resolves https://github.com/konveyor/editor-extensions/issues/1362 
## Problem

When the LLM proposes a fix and the user edits the suggested file directly in the editor before clicking **Accept**, the solution server was receiving the **original LLM-generated content** rather than the user's modified version. This meant user edits were silently discarded from the solution server's learning loop — the solution server would never see the human-corrected version of the fix.

This was reported by a consultant who noted that in-place editing didn't result in modifications being sent to the solution server, so his edits wouldn't get turned into hints for future migrations.

## Root Cause

In `handleFileResponse.ts`, when notifying the solution server of an accepted change, the code was passing `fileContent` — the LLM-generated content captured at fix generation time and stored in the chat message state:

```typescript
// Before: sends stale LLM content, ignores user edits
await executeExtensionCommand("changeApplied", path, fileContent);
```

This content is never updated when the user makes edits to the file in the editor after the fix is generated.

## Fix

Read the file from disk immediately before notifying the solution server. This captures any edits the user made between fix generation and acceptance:

```typescript
// After: reads current on-disk content, capturing in-place edits
let finalContent = fileContent;
try {
  const diskBytes = await vscode.workspace.fs.readFile(uri);
  finalContent = new TextDecoder().decode(diskBytes);
  logger.info(`Using on-disk content for solution server (captures in-place edits): ${path}`);
} catch (readError) {
  logger.warn(`Could not read disk content, using original content: ${path}`, readError);
}
await executeExtensionCommand("changeApplied", path, finalContent);
```

The disk read falls back to the original LLM content if the file cannot be read, preserving existing behavior for error cases.

## Testing

Verified end-to-end locally:
1. Run analysis on coolstore
2. Get Solution for `jms-to-reactive-quarkus-00010`
3. Edit the suggested fix in the editor before clicking Accept
4. Click Accept
5. Extension log confirms: `Using on-disk content for solution server (captures in-place edits): .../OrderServiceMDB.java`
6. Solution server stores the user-edited version (`Solution N status: modified`)
7. Subsequent "Get Solution" on same violation returns the stored hint ✅

## Related

- Related: https://github.com/konveyor/kai/issues/923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where user edits to generated solutions were not being captured when accepted. The system now properly reads the latest file content at acceptance time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->