### PR TITLE
:bug: clean up diff state when editor tab is closed (#1362)

### DIFF
--- a/changes/unreleased/fix-review-mode-continue-button-blocked.yaml
+++ b/changes/unreleased/fix-review-mode-continue-button-blocked.yaml
@@ -6,7 +6,9 @@ description: >
   the editor tab without accepting or rejecting, the activeDecorators state was not cleaned
   up. This left the batch review UI in a stuck state where the continue button stayed disabled.
   Added an onDidCloseTextDocument listener to VerticalDiffManager that clears diff state when
-  the editor tab is closed, treating it as a reject/discard.
+  the editor tab is closed, treating it as a reject/discard. Also fixes a related issue where
+  the closed file retained patched content in VS Code's in-memory buffer by reverting the file
+  to its on-disk state, and resets the webview review UI so users can re-open the review.
 
 extensions:
   - core

--- a/changes/unreleased/fix-review-mode-continue-button-blocked.yaml
+++ b/changes/unreleased/fix-review-mode-continue-button-blocked.yaml
@@ -1,0 +1,12 @@
+kind: bugfix
+
+description: >
+  Fix continue button remaining disabled after closing editor tab with active code lenses.
+  When the user opens a solution in review mode (with accept/reject code lenses) and closes
+  the editor tab without accepting or rejecting, the activeDecorators state was not cleaned
+  up. This left the batch review UI in a stuck state where the continue button stayed disabled.
+  Added an onDidCloseTextDocument listener to VerticalDiffManager that clears diff state when
+  the editor tab is closed, treating it as a reject/discard.
+
+extensions:
+  - core

--- a/vscode/core/src/diff/vertical/manager.ts
+++ b/vscode/core/src/diff/vertical/manager.ts
@@ -57,8 +57,10 @@ export class VerticalDiffManager {
         this.logger.info(
           `[Manager] Editor closed for file with active diff, cleaning up: ${fileUri}`,
         );
-        // Reject (discard) the diff since the user closed without accepting
-        this.clearForFileUri(fileUri, false);
+        // Use the tab-close-specific cleanup that avoids editor edits
+        // (which silently fail on a closing document) and instead reverts
+        // the file from disk.
+        this.clearForClosedDocument(fileUri);
       }
     });
   }
@@ -214,6 +216,73 @@ export class VerticalDiffManager {
     this.refreshCodeLens();
 
     // Notify status change
+    if (this.onDiffStatusChange) {
+      this.onDiffStatusChange(fileUri);
+    }
+  }
+
+  /**
+   * Clean up diff state when a document is closed by the user (tab close).
+   *
+   * Unlike clearForFileUri, this does NOT attempt editor edits (which silently
+   * fail on a closing/closed document and leave the in-memory buffer dirty with
+   * patched content).  Instead it:
+   *  1. Clears all internal state maps (handler, codelens, streamId, decorators)
+   *  2. Disposes the handler without running accept/reject edits
+   *  3. Reverts the file so VS Code drops its dirty buffer and reloads from disk
+   *
+   * See #1362 — without the revert, closing the tab left the file showing the
+   * patched content even though git status showed no changes.
+   */
+  private async clearForClosedDocument(fileUri: string): Promise<void> {
+    // --- 1. Clear activeDecorators (same as clearForFileUri) ---
+    const streamId = this.fileUriToStreamId.get(fileUri);
+    if (streamId) {
+      this.mutateDecorators((draft) => {
+        if (draft.activeDecorators && draft.activeDecorators[streamId]) {
+          delete draft.activeDecorators[streamId];
+          this.logger.info(
+            `[Manager] Cleared activeDecorators for streamId: ${streamId} via clearForClosedDocument`,
+          );
+        }
+      });
+      this.fileUriToStreamId.delete(fileUri);
+    }
+
+    // --- 2. Dispose handler without running editor edits ---
+    const handler = this.fileUriToHandler.get(fileUri);
+    if (handler) {
+      // Just dispose listeners/decorations — do NOT call handler.clear()
+      // because the editor is gone and edits would silently fail, leaving
+      // a dirty in-memory buffer with patched content.
+      handler.dispose();
+      this.fileUriToHandler.delete(fileUri);
+    }
+
+    // --- 3. Clean up remaining state ---
+    this.disableDocumentChangeListener();
+    this.fileUriToCodeLens.delete(fileUri);
+    this.refreshCodeLens();
+    void vscode.commands.executeCommand("setContext", `${EXTENSION_NAME}.diffVisible`, false);
+
+    // --- 4. Revert the file to its on-disk content ---
+    // The diff decorations inserted/deleted lines in the editor buffer but never
+    // saved.  VS Code's hot-exit may preserve this dirty buffer across reloads.
+    // Reverting forces VS Code to drop it and re-read from disk (the clean version).
+    try {
+      const uri = vscode.Uri.parse(fileUri);
+      await vscode.commands.executeCommand("workbench.action.files.revert", uri);
+      this.logger.info(`[Manager] Reverted file to disk content after tab close: ${fileUri}`);
+    } catch (error) {
+      // Revert may fail if the document is fully disposed — that's fine,
+      // the next open will read from disk anyway.
+      this.logger.debug(
+        `[Manager] Could not revert file (may already be fully closed): ${fileUri}`,
+        error,
+      );
+    }
+
+    // --- 5. Notify status change ---
     if (this.onDiffStatusChange) {
       this.onDiffStatusChange(fileUri);
     }

--- a/vscode/core/src/diff/vertical/manager.ts
+++ b/vscode/core/src/diff/vertical/manager.ts
@@ -25,6 +25,7 @@ export class VerticalDiffManager {
   private fileUriToStreamId: Map<string, string> = new Map();
 
   private userChangeListener: vscode.Disposable | undefined;
+  private closeDocumentListener: vscode.Disposable | undefined;
 
   logDiffs: DiffLine[] | undefined;
 
@@ -45,6 +46,21 @@ export class VerticalDiffManager {
     this.mutateDecorators = mutateDecorators;
 
     this.userChangeListener = undefined;
+
+    // Listen for editor tab closes to clean up diff state.
+    // Without this, closing a tab with active code lenses leaves
+    // activeDecorators populated, which keeps the chat continue
+    // button disabled (see #1362).
+    this.closeDocumentListener = vscode.workspace.onDidCloseTextDocument((doc) => {
+      const fileUri = doc.uri.toString();
+      if (this.fileUriToHandler.has(fileUri)) {
+        this.logger.info(
+          `[Manager] Editor closed for file with active diff, cleaning up: ${fileUri}`,
+        );
+        // Reject (discard) the diff since the user closed without accepting
+        this.clearForFileUri(fileUri, false);
+      }
+    });
   }
 
   /**
@@ -413,6 +429,12 @@ export class VerticalDiffManager {
 
     // Dispose document change listener
     this.disableDocumentChangeListener();
+
+    // Dispose close document listener
+    if (this.closeDocumentListener) {
+      this.closeDocumentListener.dispose();
+      this.closeDocumentListener = undefined;
+    }
 
     // Clear callback references
     this.onDiffStatusChange = undefined;

--- a/webview-ui/src/components/ResolutionsPage/BatchReview/BatchReviewExpandable.tsx
+++ b/webview-ui/src/components/ResolutionsPage/BatchReview/BatchReviewExpandable.tsx
@@ -52,6 +52,28 @@ export const BatchReviewExpandable: React.FC = () => {
     }
   }, [pendingFiles.length, currentIndex]);
 
+  // Reset viewingInEditor when activeDecorators are cleared for the viewed file.
+  // This handles the case where the user closes the editor tab (which clears
+  // activeDecorators via onDidCloseTextDocument) — the UI reverts back to
+  // showing "Review in Editor" so the user can re-open the review. (#1362)
+  React.useEffect(() => {
+    if (viewingInEditor === null) {
+      return;
+    }
+    const decoratorStillActive = Boolean(
+      activeDecorators &&
+        typeof activeDecorators === "object" &&
+        viewingInEditor in activeDecorators,
+    );
+    if (!decoratorStillActive) {
+      console.log(
+        "[BatchReviewExpandable] Decorator cleared for viewed file, resetting viewingInEditor",
+        { viewingInEditor },
+      );
+      setViewingInEditor(null);
+    }
+  }, [activeDecorators, viewingInEditor]);
+
   // Debug: Log decorator state
   React.useEffect(() => {
     if (pendingFiles.length > 0) {


### PR DESCRIPTION
## Summary

Fixes three related issues when closing an editor tab with active diff decorations (review mode):

1. **Continue button stuck disabled** — `activeDecorators` not cleaned up on tab close
2. **File shows patched content after close** — editor edits silently fail on closing document, leaving dirty buffer
3. **Can't re-open review** — `viewingInEditor` state not reset, UI stuck on "All changes resolved"

## Problem

When the user opens a solution in review mode (vertical diff with accept/reject code lenses) and closes the editor tab without explicitly accepting or rejecting:

- The `activeDecorators` state is not cleaned up → continue button stays disabled
- `handler.clear(false)` tries to run `editor.edit()` on a closing document → edits silently fail → VS Code's in-memory buffer retains the patched content (even though `git status` shows no changes)
- The webview's local `viewingInEditor` state is never reset → UI shows "All changes resolved" instead of returning to "📝 Review in Editor"

## Root Cause

`VerticalDiffManager` had no `onDidCloseTextDocument` listener. It only cleaned up diff state on:
- Explicit accept/reject actions via code lenses
- Active editor switches (`onDidChangeActiveTextEditor`)

Closing an editor tab triggers neither of these.

## Fix

### 1. `onDidCloseTextDocument` listener (`manager.ts`)
Added a listener that detects when a document with an active diff handler is closed.

### 2. `clearForClosedDocument` method (`manager.ts`)
New method specifically for tab-close cleanup that does NOT attempt editor edits (which fail on closing documents). Instead it:
- Clears all internal state maps (handler, codelens, streamId, activeDecorators)
- Disposes the handler without running accept/reject edits
- Reverts the file via `workbench.action.files.revert` so VS Code drops the dirty buffer and reloads clean content from disk

### 3. Reset webview review state (`BatchReviewExpandable.tsx`)
Added a `useEffect` that watches `activeDecorators` and clears the local `viewingInEditor` state when the decorator for the currently viewed file disappears. This drops the UI back to the default state showing "📝 Review in Editor", allowing the user to re-open the review.

## Testing

1. Run analysis and receive a solution suggestion
2. Open the solution in review mode (click to see code lenses)
3. Close the editor tab (X button) without accepting or rejecting
4. Verify:
   - ✅ The continue button in the batch review is re-enabled
   - ✅ The file shows original (clean) content when re-opened
   - ✅ The "📝 Review in Editor" button is shown again (not stuck on "All changes resolved")
   - ✅ Clicking "📝 Review in Editor" re-opens the diff review successfully

Fixes: https://github.com/konveyor/editor-extensions/issues/1362
Jira: [MTA-6862](https://redhat.atlassian.net/browse/MTA-6862), [MTA-6863](https://redhat.atlassian.net/browse/MTA-6863)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed review mode issue where closing an editor tab without acting on accept/reject code lenses would disable the batch review continue button. The review UI now properly resets and files revert to their on-disk state when tabs are closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->