### PR TITLE
:bug: Add enabled property to llm proxy client

### DIFF
--- a/changes/unreleased/1374-add-enavled-property-to-llmproxy-client.yaml
+++ b/changes/unreleased/1374-add-enavled-property-to-llmproxy-client.yaml
@@ -1,3 +1,3 @@
 kind: bugfix
 description: >
-  TODO: Describe your change here.
+  Add enabled property to LLM proxy client.

--- a/changes/unreleased/1374-add-enavled-property-to-llmproxy-client.yaml
+++ b/changes/unreleased/1374-add-enavled-property-to-llmproxy-client.yaml
@@ -1,0 +1,3 @@
+kind: bugfix
+description: >
+  TODO: Describe your change here.

--- a/vscode/core/src/clients/ProfileSyncClient.ts
+++ b/vscode/core/src/clients/ProfileSyncClient.ts
@@ -186,7 +186,7 @@ export class ProfileSyncClient {
         enabled: config.enabled,
       });
 
-      if (!config.enabled === false) {
+      if (config.enabled === false) {
         this.logger.info("LLM proxy is not enabled");
         this.llmProxyConfig = {
           available: false,

--- a/vscode/core/src/clients/ProfileSyncClient.ts
+++ b/vscode/core/src/clients/ProfileSyncClient.ts
@@ -179,8 +179,12 @@ export class ProfileSyncClient {
       // The Hub API returns the config.json content as a JSON-encoded string,
       // so we need to parse it twice: once from the response, once from the string
       const rawConfig = await response.json();
-      const config: { model?: string; enabled?: boolean } =
+      const parsedConfig: { model?: string; enabled?: boolean | string } =
         typeof rawConfig === "string" ? JSON.parse(rawConfig) : rawConfig;
+      const config = {
+        ...parsedConfig,
+        enabled: parsedConfig.enabled !== "false" && parsedConfig.enabled !== false,
+      };
       this.logger.info("LLM proxy configuration fetched successfully", {
         model: config.model,
         enabled: config.enabled,

--- a/vscode/core/src/clients/ProfileSyncClient.ts
+++ b/vscode/core/src/clients/ProfileSyncClient.ts
@@ -179,11 +179,21 @@ export class ProfileSyncClient {
       // The Hub API returns the config.json content as a JSON-encoded string,
       // so we need to parse it twice: once from the response, once from the string
       const rawConfig = await response.json();
-      const config: { model?: string } =
+      const config: { model?: string; enabled?: boolean } =
         typeof rawConfig === "string" ? JSON.parse(rawConfig) : rawConfig;
       this.logger.info("LLM proxy configuration fetched successfully", {
         model: config.model,
+        enabled: config.enabled,
       });
+
+      if (!config.enabled === false) {
+        this.logger.info("LLM proxy is not enabled");
+        this.llmProxyConfig = {
+          available: false,
+          endpoint: `${this.baseUrl}/llm-proxy/v1`,
+        };
+        return;
+      }
 
       // Use external Hub URL with /llm-proxy/v1 path
       this.llmProxyConfig = {


### PR DESCRIPTION
Resolves #1365 

Operator PR with new configmap property: https://github.com/konveyor/operator/pull/558

If the `enabled` property is not present in the configmap, it is assumed to be true to ensure compatibility with older versions of the operator. To prevent the bug from occurring, both the operator and the extension will need to be updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The LLM proxy client now supports an `enabled` configuration setting to control whether the proxy is active in your environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->