### PR TITLE
:bug: fully reset workflow state when batch review completes (#1363)

### DIFF
--- a/changes/unreleased/fix-stale-workflow-state-after-revert.yaml
+++ b/changes/unreleased/fix-stale-workflow-state-after-revert.yaml
@@ -1,0 +1,15 @@
+kind: bugfix
+
+description: >
+  Fix analysis being blocked after accepting a solution and reverting the file.
+  When the batch review completed (all files accepted/rejected/continued),
+  checkBatchReviewComplete only cleared pendingBatchReview but did not reset
+  the workflow state flags (isFetchingSolution, solutionState,
+  isWaitingForUserInteraction, isProcessingQueuedMessages). This left the
+  extension in a broken state where analysis could not run because it thought
+  a resolution was still in progress. Now checkBatchReviewComplete fully resets
+  all workflow flags when the batch is done, and also cleans up stale workflow
+  resources (queue manager, pending interactions, modified files cache).
+
+extensions:
+  - core

--- a/vscode/core/src/webviewMessageHandler.ts
+++ b/vscode/core/src/webviewMessageHandler.ts
@@ -756,18 +756,63 @@ const actions: {
   },
 };
 
-// Helper function to check if batch review is complete
+/**
+ * Check if batch review is complete and fully reset workflow state.
+ *
+ * Previously this only cleared pendingBatchReview but did NOT reset the
+ * workflow flags (isFetchingSolution, solutionState, isWaitingForUserInteraction,
+ * isProcessingQueuedMessages). This left the extension in a broken state where
+ * analysis could not run because it thought a resolution was still in progress.
+ *
+ * Now when the batch is done, we reset ALL workflow state to ensure a clean
+ * slate for the next analysis run. This fixes the bug where accepting a
+ * solution and then reverting the file left the extension stuck (#1363).
+ */
 const checkBatchReviewComplete = (state: ExtensionState, logger: winston.Logger) => {
   const hasPendingBatchReview =
     state.data.pendingBatchReview && state.data.pendingBatchReview.length > 0;
 
   if (!hasPendingBatchReview) {
-    logger.info("Batch review complete");
+    logger.info("Batch review complete — resetting all workflow state");
 
-    // Clear any remaining state
+    // Reset all solution workflow flags to unblock analysis
     state.mutateSolutionWorkflow((draft) => {
       draft.pendingBatchReview = [];
+      draft.isFetchingSolution = false;
+      draft.solutionState = "none";
+      draft.isWaitingForUserInteraction = false;
+      draft.isProcessingQueuedMessages = false;
     });
+
+    // Reset analysis flags in case they're stale
+    state.mutateAnalysisState((draft) => {
+      draft.isAnalyzing = false;
+      draft.isAnalysisScheduled = false;
+    });
+
+    // Clean up stale workflow resources that may have been left behind
+    // by the SolutionWorkflowOrchestrator
+    if (state.currentQueueManager) {
+      logger.debug("Disposing stale queue manager after batch review complete");
+      state.currentQueueManager.dispose();
+      state.currentQueueManager = undefined;
+    }
+
+    if (state.pendingInteractionsMap && state.pendingInteractionsMap.size > 0) {
+      logger.debug("Clearing stale pending interactions after batch review complete");
+      state.pendingInteractionsMap.clear();
+      state.pendingInteractionsMap = undefined;
+    }
+
+    state.resolvePendingInteraction = undefined;
+
+    // Clear the modified files cache — the batch is done, these are no longer needed
+    state.modifiedFiles.clear();
+
+    // Reset the kaiFsCache
+    state.kaiFsCache.reset();
+
+    logger.info("Workflow state fully reset — analysis is now unblocked");
   }
 };
 


### PR DESCRIPTION
## Summary

Fixes the extension getting stuck in "resolution is in progress" after accepting a solution and reverting the file, preventing analysis from running.

## Problem

When the user completes a batch review (accepts/rejects all files), `checkBatchReviewComplete` only cleared `pendingBatchReview` but did **not** reset the workflow state flags:

- `isFetchingSolution` stayed `true`
- `solutionState` stayed on `"started"` or `"received"`
- `isWaitingForUserInteraction` could be stuck `true`
- `isProcessingQueuedMessages` could be stuck `true`

This caused `SolutionWorkflowOrchestrator.validatePreconditions()` to reject new solution requests (`"Solution already being fetched"`), and the UI to report resolution was in progress indefinitely.

### Why this happens:

1. `SolutionWorkflowOrchestrator.workflowCleanup()` runs when `workflow.run()` completes AND the queue drains
2. But the batch review UI **outlives** the workflow — individual file accept/reject/continue actions go through `webviewMessageHandler`
3. After the orchestrator cleans up, the webview message handler removes files from `pendingBatchReview` one at a time
4. When the last file is removed, `checkBatchReviewComplete` fires — but it only cleared the array, not the workflow flags
5. If the orchestrator's cleanup missed any flags (race condition, error path, etc.), they stay stuck forever

## Fix

`checkBatchReviewComplete` now performs a **full workflow state reset** when the batch is done:

1. **Reset all solution workflow flags** — `isFetchingSolution=false`, `solutionState="none"`, `isWaitingForUserInteraction=false`, `isProcessingQueuedMessages=false`
2. **Reset analysis flags** — `isAnalyzing=false`, `isAnalysisScheduled=false`
3. **Dispose stale workflow resources** — queue manager, pending interactions map, resolver function
4. **Clear caches** — `modifiedFiles`, `kaiFsCache`

This acts as a safety net: even if the orchestrator's cleanup missed something, the batch review completion guarantees a clean slate.

## Testing

1. Run analysis and receive a solution suggestion
2. Open the solution in review mode
3. Accept the solution (or Accept All)
4. Revert the file (`git checkout`, undo, etc.)
5. Attempt to run analysis again
6. ✅ Analysis should run without issues — no "resolution in progress" error

Also verify normal flow still works:
1. Run analysis → get solution → accept/reject all files → batch review completes
2. ✅ Can immediately start a new solution workflow

Fixes: https://github.com/konveyor/editor-extensions/issues/1363
Jira: [MTA-6862](https://redhat.atlassian.net/browse/MTA-6862)