### PR TITLE
:bug: Remove hardcoded "Konveyor" references from hub configuration UI

### DIFF
--- a/changes/unreleased/remove-hardcoded-konveyor-hub.yaml
+++ b/changes/unreleased/remove-hardcoded-konveyor-hub.yaml
@@ -1,0 +1,3 @@
+kind: bugfix
+description: >
+  Replaced hardcoded "Konveyor Hub" references in configuration UI with dynamic branding to support downstream rebranding.

--- a/webview-ui/src/components/AnalysisPage/WalkthroughDrawer/WalkthroughDrawer.tsx
+++ b/webview-ui/src/components/AnalysisPage/WalkthroughDrawer/WalkthroughDrawer.tsx
@@ -81,9 +81,8 @@ export function WalkthroughDrawer({
   const disabledDescription = "This feature is disabled based on your configuration.";
   const disabledFullDescription =
     "This feature is disabled because the values are managed by the in-tree profile currently selected.";
-  const genaiManagedByHubDescription = "GenAI is configured via Konveyor Hub.";
-  const genaiManagedByHubFullDescription =
-    "GenAI is configured via Konveyor Hub. The LLM proxy provides centralized AI capabilities without requiring local API key configuration. Your requests are routed through the Hub's managed service.";
+  const genaiManagedByHubDescription = `GenAI is configured via ${getBrandName()} Hub.`;
+  const genaiManagedByHubFullDescription = `GenAI is configured via ${getBrandName()} Hub. The LLM proxy provides centralized AI capabilities without requiring local API key configuration. Your requests are routed through the Hub's managed service.`;
 
   // Determine hub status message
   const getHubStatus = () => {
@@ -120,9 +119,8 @@ export function WalkthroughDrawer({
       id: "hub-config",
       title: "Hub Configuration",
       status: getHubStatus(),
-      description: "Connect to Konveyor Hub for advanced features.",
-      fullDescription:
-        "Connect to Konveyor Hub to enable profile synchronization, solution server capabilities, and other advanced features. The Hub provides centralized management and enhanced collaboration capabilities for your migration projects.",
+      description: `Connect to ${getBrandName()} Hub for advanced features.`,
+      fullDescription: `Connect to ${getBrandName()} Hub to enable profile synchronization, solution server capabilities, and other advanced features. The Hub provides centralized management and enhanced collaboration capabilities for your migration projects.`,
     },
     {
       id: "select-profile",

--- a/webview-ui/src/components/HubSettings/HubSettingsForm.tsx
+++ b/webview-ui/src/components/HubSettings/HubSettingsForm.tsx
@@ -15,6 +15,7 @@ import {
 import { ExclamationCircleIcon, InfoCircleIcon } from "@patternfly/react-icons";
 import { sendVscodeMessage as dispatch } from "../../utils/vscodeMessaging";
 import { HubConfig } from "@editor-extensions/shared";
+import { getBrandName } from "../../utils/branding";
 
 export const HubSettingsForm: React.FC<{
   initialConfig: HubConfig;
@@ -225,7 +226,7 @@ export const HubSettingsForm: React.FC<{
         <FormGroup label="Enable Hub" fieldId="hub-enabled">
           <Switch
             id="hub-enabled"
-            label="Enable connection to Konveyor Hub"
+            label={`Enable connection to ${getBrandName()} Hub`}
             isChecked={formData.enabled}
             onChange={(_e, checked) => updateField("enabled", checked)}
             isDisabled={hubForced}
@@ -235,7 +236,7 @@ export const HubSettingsForm: React.FC<{
               <HelperTextItem icon={<InfoCircleIcon />}>
                 {hubForced
                   ? "Hub connection is enforced by environment configuration"
-                  : "Enable connection to Konveyor Hub for advanced features"}
+                  : `Enable connection to ${getBrandName()} Hub for advanced features`}
               </HelperTextItem>
             </HelperText>
           </FormHelperText>
@@ -273,7 +274,7 @@ export const HubSettingsForm: React.FC<{
             <FormHelperText>
               <HelperText>
                 <HelperTextItem icon={<InfoCircleIcon />}>
-                  The URL of your Konveyor Hub instance (use https:// for production)
+                  {`The URL of your ${getBrandName()} Hub instance (use https:// for production)`}
                 </HelperTextItem>
               </HelperText>
             </FormHelperText>

--- a/webview-ui/src/components/ProfileManager/ProfileList.tsx
+++ b/webview-ui/src/components/ProfileManager/ProfileList.tsx
@@ -137,7 +137,7 @@ export const ProfileList: React.FC<{
                         >
                           Duplicate
                         </DropdownItem>
-                       <DropdownItem
+                        <DropdownItem
                           key="delete"
                           onClick={() => {
                             setProfileToDelete(profile);

--- a/webview-ui/src/components/ResolutionsPage/BatchReview/BatchReviewExpandable.tsx
+++ b/webview-ui/src/components/ResolutionsPage/BatchReview/BatchReviewExpandable.tsx
@@ -62,8 +62,8 @@ export const BatchReviewExpandable: React.FC = () => {
     }
     const decoratorStillActive = Boolean(
       activeDecorators &&
-        typeof activeDecorators === "object" &&
-        viewingInEditor in activeDecorators,
+      typeof activeDecorators === "object" &&
+      viewingInEditor in activeDecorators,
     );
     if (!decoratorStillActive) {
       console.log(
@@ -184,9 +184,9 @@ export const BatchReviewExpandable: React.FC = () => {
   // Check if decorators are ACTIVE for this file (not just opened, but has unresolved decorators)
   const hasActiveDecorators = Boolean(
     activeDecorators &&
-      typeof activeDecorators === "object" &&
-      currentFile.messageToken in activeDecorators &&
-      activeDecorators[currentFile.messageToken] === currentFile.path,
+    typeof activeDecorators === "object" &&
+    currentFile.messageToken in activeDecorators &&
+    activeDecorators[currentFile.messageToken] === currentFile.path,
   );
 
   // Track if we've opened the file (for UI state), but decorators might be resolved
@@ -437,12 +437,7 @@ export const BatchReviewExpandable: React.FC = () => {
           {/* Stop workflow button - shown when workflow is still running */}
           {isFetchingSolution && (
             <FlexItem>
-              <Button
-                variant="danger"
-                size="sm"
-                icon={<StopIcon />}
-                onClick={handleStopWorkflow}
-              >
+              <Button variant="danger" size="sm" icon={<StopIcon />} onClick={handleStopWorkflow}>
                 Stop
               </Button>
             </FlexItem>
@@ -509,12 +504,7 @@ export const BatchReviewExpandable: React.FC = () => {
           {/* Stop workflow button - shown when workflow is still running */}
           {isFetchingSolution && (
             <FlexItem>
-              <Button
-                variant="danger"
-                size="sm"
-                icon={<StopIcon />}
-                onClick={handleStopWorkflow}
-              >
+              <Button variant="danger" size="sm" icon={<StopIcon />} onClick={handleStopWorkflow}>
                 Stop
               </Button>
             </FlexItem>
@@ -580,9 +570,7 @@ export const BatchReviewExpandable: React.FC = () => {
               </Button>
             </FlexItem>
             <FlexItem flex={{ default: "flex_1" }}>
-              <span className="batch-review-info-text">
-                ✨ This is a new file
-              </span>
+              <span className="batch-review-info-text">✨ This is a new file</span>
             </FlexItem>
             <FlexItem>
               <Button variant="danger" onClick={handleReject} size="sm" isDisabled={isProcessing}>

--- a/webview-ui/src/components/ViolationIncidentsList.tsx
+++ b/webview-ui/src/components/ViolationIncidentsList.tsx
@@ -79,7 +79,9 @@ const ViolationIncidentsList = ({
         .filter(
           (incident) =>
             incident.message.toLowerCase().includes(focusedViolationFilter.toLowerCase()) ||
-            incident.violation_description?.toLowerCase().includes(focusedViolationFilter.toLowerCase()),
+            incident.violation_description
+              ?.toLowerCase()
+              .includes(focusedViolationFilter.toLowerCase()),
         )
         .map((incident) => incident.violationId);
 


### PR DESCRIPTION
Replace hardcoded "Konveyor Hub" strings with dynamic branding using getBrandName() utility to support downstream rebranding. Updates hub settings form and walkthrough drawer.

