### PR TITLE
:bug: upgrade agentic no-response logging from silly to warn

### DIFF
--- a/agentic/src/nodes/analysisIssueFix.ts
+++ b/agentic/src/nodes/analysisIssueFix.ts
@@ -325,7 +325,10 @@ If you have any additional details or steps that need to be performed, put it he
     );
 
     if (!response) {
-      this.logger.silly("AnalysisIssueFix returned undefined response");
+      this.logger.warn(
+        `AnalysisIssueFix: LLM returned no response for file "${fileName}". ` +
+          `This may indicate a model provider configuration issue.`,
+      );
       return {
         outputAdditionalInfo: undefined,
         outputUpdatedFile: undefined,
@@ -460,6 +463,9 @@ ${state.inputAllReasoning}`,
     );
 
     if (!response) {
+      this.logger.warn(
+        "SummarizeHistory: LLM returned no response. This may indicate a model provider configuration issue.",
+      );
       return {
         summarizedHistory: "",
         iterationCount: state.iterationCount,

--- a/agentic/src/nodes/diagnosticsIssueFix.ts
+++ b/agentic/src/nodes/diagnosticsIssueFix.ts
@@ -343,7 +343,9 @@ Instructions for Agent B to solve Issue 3, Issue 4, etc. (mention specific issue
     );
 
     if (!response) {
-      this.logger.silly("PlanFixes returned undefined response");
+      this.logger.warn(
+        "PlanFixes: LLM returned no response. This may indicate a model provider configuration issue.",
+      );
       return {
         plannerOutputNominatedAgents: [],
         iterationCount: state.iterationCount,
@@ -401,7 +403,9 @@ ${
     );
 
     if (!response) {
-      this.logger.silly("FixGeneralIssues returned undefined response");
+      this.logger.warn(
+        "FixGeneralIssues: LLM returned no response. This may indicate a model provider configuration issue.",
+      );
       return {
         messages: [new AIMessage(`DONE`)],
         outputModifiedFilesFromGeneralFix: [],
@@ -471,7 +475,9 @@ ${state.inputInstructionsForGeneralFix}
     );
 
     if (!response) {
-      this.logger.silly("FixJavaDependencyIssues returned undefined response");
+      this.logger.warn(
+        "FixJavaDependencyIssues: LLM returned no response. This may indicate a model provider configuration issue.",
+      );
       return {
         messages: [new AIMessage(`DONE`)],
         outputModifiedFilesFromGeneralFix: [],

--- a/changes/unreleased/1391-agentic-no-response-logging.yaml
+++ b/changes/unreleased/1391-agentic-no-response-logging.yaml
@@ -1,0 +1,4 @@
+kind: bugfix
+description: >
+  Upgrade no-response logging from silly to warn in agentic workflow nodes
+  so silent LLM failures are visible in normal log output.


### PR DESCRIPTION
## Summary

Upgrades no-response logging from `logger.silly()` to `logger.warn()` in agentic workflow nodes. When the LLM returns no response (undefined), the previous `silly` level logging made it invisible in normal log output, making misconfigured model providers very hard to diagnose.

### Changes

- `analysisIssueFix.ts` — `AnalysisIssueFix` and `SummarizeHistory` nodes now log at warn level with file name context
- `diagnosticsIssueFix.ts` — `PlanFixes`, `FixGeneralIssues`, `FixJavaDependencyIssues` nodes now log at warn level

All messages include "This may indicate a model provider configuration issue" to guide debugging.

### Testing
- No behavior change — only log level and message content
- Existing tests unaffected