### PR TITLE
:bug: fix: add configurable LLM request timeout to prevent hanging

### DIFF
--- a/agentic/src/nodes/analysisIssueFix.ts
+++ b/agentic/src/nodes/analysisIssueFix.ts
@@ -325,7 +325,10 @@ If you have any additional details or steps that need to be performed, put it he
     );
 
     if (!response) {
-      this.logger.silly("AnalysisIssueFix returned undefined response");
+      this.logger.warn(
+        `AnalysisIssueFix: LLM returned no response for file "${fileName}". ` +
+          `This may indicate a model provider configuration issue.`,
+      );
       return {
         outputAdditionalInfo: undefined,
         outputUpdatedFile: undefined,
@@ -460,6 +463,9 @@ ${state.inputAllReasoning}`,
     );
 
     if (!response) {
+      this.logger.warn(
+        "SummarizeHistory: LLM returned no response. This may indicate a model provider configuration issue.",
+      );
       return {
         summarizedHistory: "",
         iterationCount: state.iterationCount,

--- a/agentic/src/nodes/base.ts
+++ b/agentic/src/nodes/base.ts
@@ -22,6 +22,8 @@ import {
 import { KaiWorkflowEventEmitter } from "../eventEmitter";
 
 export abstract class BaseNode extends KaiWorkflowEventEmitter {
+  private static readonly DEFAULT_LLM_TIMEOUT_MS = 300_000; // 5 minutes
+
   constructor(
     private readonly name: string,
     protected readonly modelProvider: KaiModelProvider,
@@ -55,6 +57,9 @@ export abstract class BaseNode extends KaiWorkflowEventEmitter {
    * Falls back to invoke() when native tools are supported but not in streaming.
    * If native tools are not supported, parses response on-the-fly and assembles
    * into tool_call_chunks making it transparent to callers.
+   *
+   * Includes a configurable timeout (default 5 min) to prevent hanging when
+   * the model provider is misconfigured or unreachable.
    */
   protected async streamOrInvoke(
     input: BaseLanguageModelInput,
@@ -64,6 +69,8 @@ export abstract class BaseNode extends KaiWorkflowEventEmitter {
       emitResponseChunks?: boolean;
       // toolsSelector matches tool names to enable
       toolsSelectors?: string[];
+      // timeout in ms for the entire LLM request (default: 5 minutes)
+      timeoutMs?: number;
     },
     options?: KaiModelProviderInvokeCallOptions | undefined,
   ): Promise<AIMessage | AIMessageChunk | undefined> {
@@ -72,50 +79,75 @@ export abstract class BaseNode extends KaiWorkflowEventEmitter {
       enableTools = true,
       emitResponseChunks = true,
       toolsSelectors = [],
+      timeoutMs = BaseNode.DEFAULT_LLM_TIMEOUT_MS,
     } = streamOptions || {};
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
     try {
-      // if we don't have tools enabled or registered, we should be able to stream without any issues
-      if (!enableTools || !this.tools.length) {
+      const executeRequest = async (): Promise<AIMessage | AIMessageChunk | undefined> => {
+        // if we don't have tools enabled or registered, we should be able to stream without any issues
+        if (!enableTools || !this.tools.length) {
+          return this.process_stream(
+            messageId,
+            enableTools,
+            emitResponseChunks,
+            await this.modelProvider.stream(input, options),
+          );
+        }
+
+        let runnable: KaiModelProvider = this.modelProvider;
+        let processedInput: BaseLanguageModelInput = input;
+
+        if (this.modelProvider.toolCallsSupported()) {
+          runnable = this.modelProvider.bindTools(this.tools);
+        } else {
+          // use custom tool parsing if model does not support tool calls
+          processedInput = this.getInputWithTools(input, toolsSelectors);
+        }
+
+        // use invoke if the model does not support streaming tool calls but supports normal tool calls
+        if (
+          this.modelProvider.toolCallsSupported() &&
+          !this.modelProvider.toolCallsSupportedInStreaming()
+        ) {
+          const fullResponse = await runnable.invoke(processedInput, options);
+          if (emitResponseChunks) {
+            this.emitWorkflowMessage({
+              id: messageId,
+              type: KaiWorkflowMessageType.LLMResponse,
+              data: fullResponse,
+            });
+          }
+          return fullResponse;
+        }
+
         return this.process_stream(
           messageId,
           enableTools,
           emitResponseChunks,
-          await this.modelProvider.stream(input, options),
+          await runnable.stream(processedInput, options),
         );
+      };
+
+      const requestPromise = executeRequest();
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(
+            new Error(
+              `LLM request timed out after ${timeoutMs / 1000}s. ` +
+                `Verify your provider-settings.yaml configuration is correct.`,
+            ),
+          );
+        }, timeoutMs);
+      });
+
+      try {
+        return await Promise.race([requestPromise, timeoutPromise]);
+      } finally {
+        // Suppress unhandled rejection from the request if it settles after the timeout
+        requestPromise.catch(() => {});
       }
-
-      let runnable: KaiModelProvider = this.modelProvider;
-      let processedInput: BaseLanguageModelInput = input;
-
-      if (this.modelProvider.toolCallsSupported()) {
-        runnable = this.modelProvider.bindTools(this.tools);
-      } else {
-        // use custom tool parsing if model does not support tool calls
-        processedInput = this.getInputWithTools(input, toolsSelectors);
-      }
-
-      // use invoke if the model does not support streaming tool calls but supports normal tool calls
-      if (
-        this.modelProvider.toolCallsSupported() &&
-        !this.modelProvider.toolCallsSupportedInStreaming()
-      ) {
-        const fullResponse = await runnable.invoke(processedInput, options);
-        if (emitResponseChunks) {
-          this.emitWorkflowMessage({
-            id: messageId,
-            type: KaiWorkflowMessageType.LLMResponse,
-            data: fullResponse,
-          });
-        }
-        return fullResponse;
-      }
-
-      return this.process_stream(
-        messageId,
-        enableTools,
-        emitResponseChunks,
-        await runnable.stream(processedInput, options),
-      );
     } catch (err) {
       this.logger.error(
         `Error calling stream(): ${err instanceof Error ? err.message : String(err)}`,
@@ -130,6 +162,10 @@ export abstract class BaseNode extends KaiWorkflowEventEmitter {
           type: KaiWorkflowMessageType.Error,
           data: `Failed to get llm response - ${String(err)}`,
         });
+      }
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
       }
     }
   }

--- a/agentic/src/nodes/diagnosticsIssueFix.ts
+++ b/agentic/src/nodes/diagnosticsIssueFix.ts
@@ -343,7 +343,9 @@ Instructions for Agent B to solve Issue 3, Issue 4, etc. (mention specific issue
     );
 
     if (!response) {
-      this.logger.silly("PlanFixes returned undefined response");
+      this.logger.warn(
+        "PlanFixes: LLM returned no response. This may indicate a model provider configuration issue.",
+      );
       return {
         plannerOutputNominatedAgents: [],
         iterationCount: state.iterationCount,
@@ -401,7 +403,9 @@ ${
     );
 
     if (!response) {
-      this.logger.silly("FixGeneralIssues returned undefined response");
+      this.logger.warn(
+        "FixGeneralIssues: LLM returned no response. This may indicate a model provider configuration issue.",
+      );
       return {
         messages: [new AIMessage(`DONE`)],
         outputModifiedFilesFromGeneralFix: [],
@@ -471,7 +475,9 @@ ${state.inputInstructionsForGeneralFix}
     );
 
     if (!response) {
-      this.logger.silly("FixJavaDependencyIssues returned undefined response");
+      this.logger.warn(
+        "FixJavaDependencyIssues: LLM returned no response. This may indicate a model provider configuration issue.",
+      );
       return {
         messages: [new AIMessage(`DONE`)],
         outputModifiedFilesFromGeneralFix: [],

--- a/changes/unreleased/1392-llm-request-timeout.yaml
+++ b/changes/unreleased/1392-llm-request-timeout.yaml
@@ -1,0 +1,5 @@
+kind: bugfix
+description: >
+  Add configurable timeout (default 5 minutes) to LLM requests in streamOrInvoke
+  to prevent indefinite hanging when the model provider is misconfigured or unreachable.
+  Upgrade no-response logging from silly to warn with actionable error messages.


### PR DESCRIPTION
## Summary

Adds a configurable timeout (default 5 minutes) to all LLM requests in `streamOrInvoke`. Previously, a misconfigured or unreachable model provider would hang `streamOrInvoke` indefinitely with no error.

### Changes

- `agentic/src/nodes/base.ts` — wraps LLM execution in `Promise.race` with a timeout
  - Default: 5 minutes (`DEFAULT_LLM_TIMEOUT_MS = 300_000`)
  - Configurable per-call via `timeoutMs` option in `streamOptions`
  - Clear error message: "Verify your provider-settings.yaml configuration is correct"
  - Properly cleans up timer and suppresses unhandled rejection from the racing promise
  - Error workflow message emission gated on `emitResponseChunks` flag (prevents internal "thinking" operations from leaking errors to the user-facing stream)

### Testing
- No new tests (existing tests unaffected — timeout only fires on actual provider hangs)
- Verified locally with misconfigured provider ✅