### PR TITLE
:sparkles: improve ToolMessage component UI and styling

### DIFF
--- a/agentic/src/nodes/analysisIssueFix.ts
+++ b/agentic/src/nodes/analysisIssueFix.ts
@@ -325,7 +325,10 @@ If you have any additional details or steps that need to be performed, put it he
     );
 
     if (!response) {
-      this.logger.silly("AnalysisIssueFix returned undefined response");
+      this.logger.warn(
+        `AnalysisIssueFix: LLM returned no response for file "${fileName}". ` +
+          `This may indicate a model provider configuration issue.`,
+      );
       return {
         outputAdditionalInfo: undefined,
         outputUpdatedFile: undefined,
@@ -460,6 +463,9 @@ ${state.inputAllReasoning}`,
     );
 
     if (!response) {
+      this.logger.warn(
+        "SummarizeHistory: LLM returned no response. This may indicate a model provider configuration issue.",
+      );
       return {
         summarizedHistory: "",
         iterationCount: state.iterationCount,

--- a/agentic/src/nodes/diagnosticsIssueFix.ts
+++ b/agentic/src/nodes/diagnosticsIssueFix.ts
@@ -343,7 +343,9 @@ Instructions for Agent B to solve Issue 3, Issue 4, etc. (mention specific issue
     );
 
     if (!response) {
-      this.logger.silly("PlanFixes returned undefined response");
+      this.logger.warn(
+        "PlanFixes: LLM returned no response. This may indicate a model provider configuration issue.",
+      );
       return {
         plannerOutputNominatedAgents: [],
         iterationCount: state.iterationCount,
@@ -401,7 +403,9 @@ ${
     );
 
     if (!response) {
-      this.logger.silly("FixGeneralIssues returned undefined response");
+      this.logger.warn(
+        "FixGeneralIssues: LLM returned no response. This may indicate a model provider configuration issue.",
+      );
       return {
         messages: [new AIMessage(`DONE`)],
         outputModifiedFilesFromGeneralFix: [],
@@ -471,7 +475,9 @@ ${state.inputInstructionsForGeneralFix}
     );
 
     if (!response) {
-      this.logger.silly("FixJavaDependencyIssues returned undefined response");
+      this.logger.warn(
+        "FixJavaDependencyIssues: LLM returned no response. This may indicate a model provider configuration issue.",
+      );
       return {
         messages: [new AIMessage(`DONE`)],
         outputModifiedFilesFromGeneralFix: [],

--- a/changes/unreleased/1394-tool-message-ui.yaml
+++ b/changes/unreleased/1394-tool-message-ui.yaml
@@ -1,0 +1,5 @@
+kind: enhancement
+description: >
+  Redesign ToolMessage component with compact inline indicators, collapsible
+  tool groups, and improved status styling for better readability during
+  multi-tool agent workflows.

--- a/shared/src/types/types.ts
+++ b/shared/src/types/types.ts
@@ -369,7 +369,17 @@ export interface AnalysisProfile {
   syncedAt?: string;
 }
 
-export type ToolMessageValue = { toolName: string; toolStatus: string };
+export type ToolMessageValue = { toolName: string; toolStatus: string; detail?: string };
+
+/** Represents a chat message originating from an agent tool call. */
+export interface AgentChatMessage {
+  id: string;
+  toolCall?: {
+    name: string;
+    status: "running" | "succeeded" | "failed";
+    arguments?: Record<string, unknown>;
+  };
+}
 
 export type ModifiedFileMessageValue = {
   path: string;

--- a/webview-ui/src/components/ResolutionsPage/ToolMessage.tsx
+++ b/webview-ui/src/components/ResolutionsPage/ToolMessage.tsx
@@ -4,177 +4,243 @@ import {
   CheckCircleIcon,
   TimesCircleIcon,
   SyncAltIcon,
-  FileIcon,
-  SearchIcon,
-  CodeIcon,
-  GitAltIcon,
-  CubeIcon,
-  PackageIcon,
-  DatabaseIcon,
+  AngleRightIcon,
 } from "@patternfly/react-icons";
-import { ExpandableSection } from "@patternfly/react-core";
+import type { ChatMessage, ToolMessageValue, AgentChatMessage } from "@editor-extensions/shared";
 
 interface ToolMessageProps {
   toolName: string;
   status: "succeeded" | "failed" | "running";
+  detail?: string;
   timestamp?: string | Date;
   errorDetails?: string;
 }
 
-const getHumanReadableToolName = (toolName: string): string => {
+export const getHumanReadableToolName = (toolName: string): string => {
   const toolNameMap: Record<string, string> = {
-    // File operations
-    writeFile: "Suggesting file changes",
-    readFile: "Reading file",
-    searchFiles: "Searching files",
-    listFiles: "Listing files",
-    deleteFile: "Deleting file",
-    createFile: "Creating file",
-
-    // Code operations
-    analyzeCode: "Analyzing code",
-    searchCode: "Searching code",
-    refactorCode: "Refactoring code",
-    formatCode: "Formatting code",
-
-    // Git operations
-    gitCommit: "Committing changes",
-    gitPush: "Pushing changes",
-    gitPull: "Pulling changes",
-    gitStatus: "Checking git status",
-
-    // Build/Test operations
-    buildProject: "Building project",
-    runTests: "Running tests",
-    lintCode: "Linting code",
-
-    // Package operations
-    installDependencies: "Installing dependencies",
-    updateDependencies: "Updating dependencies",
-    checkDependencies: "Checking dependencies",
-
-    // Network operations
-    searchFqdn: "Searching dependency information",
-
-    // Database operations
-    queryDatabase: "Querying database",
-    migrateDatabase: "Migrating database",
-
-    // Default fallback
-    default: "Processing",
+    writeFile: "Editing file",
+    readFile: "Read file",
+    searchFiles: "Searched files",
+    listFiles: "Listed files",
+    deleteFile: "Deleted file",
+    createFile: "Created file",
+    analyzeCode: "Analyzed code",
+    searchCode: "Searched code",
+    refactorCode: "Refactored code",
+    formatCode: "Formatted code",
+    gitCommit: "Committed changes",
+    gitPush: "Pushed changes",
+    gitPull: "Pulled changes",
+    gitStatus: "Checked git status",
+    buildProject: "Built project",
+    runTests: "Ran tests",
+    lintCode: "Linted code",
+    installDependencies: "Installed dependencies",
+    updateDependencies: "Updated dependencies",
+    checkDependencies: "Checked dependencies",
+    searchFqdn: "Searched dependencies",
+    queryDatabase: "Queried database",
+    migrateDatabase: "Migrated database",
+    text_editor: "Edited file",
+    read_file: "Read file",
+    write_file: "Wrote file",
+    list_directory: "Listed directory",
+    search_replace: "Search & replace",
+    bash: "Ran command",
+    shell: "Ran command",
   };
 
   return toolNameMap[toolName] || toolName;
 };
 
-const getToolIcon = (toolName: string, status: string) => {
-  // Define a mapping of keywords to icons
-  const iconMap: Record<string, React.ComponentType> = {
-    file: FileIcon,
-    search: SearchIcon,
-    code: CodeIcon,
-    git: GitAltIcon,
-    build: CubeIcon,
-    test: CubeIcon,
-    lint: CubeIcon,
-    dependencies: PackageIcon,
-    package: PackageIcon,
-    database: DatabaseIcon,
-  };
-
-  // Normalize toolName to lowercase and handle camelCase by adding spaces
-  const normalizedToolName = toolName
-    .toLowerCase()
-    .replace(/([a-z])([A-Z])/g, "$1 $2")
-    .toLowerCase();
-
-  // Find the matching icon by checking if any key is in the normalized toolName
-  let Icon: React.ComponentType<{ className?: string }> | undefined;
-  for (const [key, icon] of Object.entries(iconMap)) {
-    if (normalizedToolName.includes(key)) {
-      Icon = icon;
-      break;
-    }
+export const extractToolContext = (
+  args?: Record<string, unknown>,
+): { filePath?: string; detail?: string } => {
+  if (!args) {
+    return {};
   }
 
-  // If no specific icon is found, use status-based default icons
-  if (!Icon) {
-    if (status === "succeeded") {
-      return <CheckCircleIcon className="tool-icon success" />;
-    } else if (status === "failed") {
-      return <TimesCircleIcon className="tool-icon error" />;
-    } else {
-      return <SyncAltIcon className="tool-icon running" />;
-    }
+  const rawPath = args.path ?? args.file_path ?? args.filename;
+  const filePath = typeof rawPath === "string" ? rawPath : undefined;
+
+  const rawCommand = args.command ?? args.cmd;
+  const command = typeof rawCommand === "string" ? rawCommand : undefined;
+
+  const rawQuery = args.query ?? args.search ?? args.pattern ?? args.regex;
+  const query = typeof rawQuery === "string" ? rawQuery : undefined;
+
+  const parts: string[] = [];
+  if (filePath) {
+    const basename = filePath.split("/").pop() || filePath;
+    parts.push(basename);
+  }
+  if (command) {
+    const truncated = command.length > 60 ? `${command.substring(0, 57)}...` : command;
+    parts.push(truncated);
+  }
+  if (query) {
+    const truncated = query.length > 60 ? `${query.substring(0, 57)}...` : query;
+    parts.push(truncated);
   }
 
-  // Apply status styling to the category icon
-  const className = `tool-icon ${status === "succeeded" ? "success" : status === "failed" ? "error" : "running"}`;
-  return <Icon className={className} />;
+  return { filePath, detail: parts.length > 0 ? parts.join(" ") : undefined };
 };
 
-export const ToolMessage: React.FC<ToolMessageProps> = ({ toolName, status, errorDetails }) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const humanReadableName = getHumanReadableToolName(toolName);
-  const toolIcon = getToolIcon(toolName, status);
+const StatusIcon: React.FC<{ status: string }> = ({ status }) => {
+  if (status === "succeeded") {
+    return <CheckCircleIcon className="tool-status-icon tool-status-icon--success" />;
+  }
+  if (status === "failed") {
+    return <TimesCircleIcon className="tool-status-icon tool-status-icon--error" />;
+  }
+  return <SyncAltIcon className="tool-status-icon tool-status-icon--running" />;
+};
 
-  // Show additional details if the tool failed and error details are provided
-  const hasAdditionalDetails = status === "failed" && errorDetails;
-
-  const toggleExpand = () => {
-    if (hasAdditionalDetails) {
-      setIsExpanded(!isExpanded);
-    }
-  };
-
-  const toolSummary = (
-    <div
-      className="tool-message-summary"
-      role="button"
-      aria-expanded={isExpanded}
-      aria-controls={`${toolName}-details`}
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          toggleExpand();
-        }
-      }}
-    >
-      {toolIcon}
-      <span className="tool-name">{humanReadableName}</span>
-      {status !== "running" && <span className="tool-status">{status}</span>}
-    </div>
-  );
+export const ToolMessage: React.FC<ToolMessageProps> = ({ toolName, status, detail }) => {
+  const label = getHumanReadableToolName(toolName);
 
   return (
-    <div
-      className={`tool-message-container ${hasAdditionalDetails ? "has-details" : ""}`}
-      role="region"
-      aria-label={`${humanReadableName} tool message`}
-    >
-      {hasAdditionalDetails ? (
-        <ExpandableSection
-          toggleContent={toolSummary}
-          onToggle={toggleExpand}
-          isExpanded={isExpanded}
-          className="tool-expandable"
-        >
-          <div
-            id={`${toolName}-details`}
-            className="tool-details"
-            role="complementary"
-            aria-label="Error details"
-          >
-            {status === "failed" && errorDetails && (
-              <div className="tool-error-details">
-                <p>Error Details:</p>
-                <pre>{errorDetails}</pre>
-              </div>
-            )}
-          </div>
-        </ExpandableSection>
-      ) : (
-        <div className="tool-message-text">{toolSummary}</div>
+    <div className={`tool-indicator tool-indicator--${status}`}>
+      <StatusIcon status={status} />
+      <span className="tool-indicator__label">{label}</span>
+      {detail && <span className="tool-indicator__detail">{detail}</span>}
+    </div>
+  );
+};
+
+const MAX_INLINE_LABELS = 3;
+
+interface CollapsibleToolGroupProps {
+  tools: ChatMessage[];
+  hasFailed?: boolean;
+}
+
+export const CollapsibleToolGroup: React.FC<CollapsibleToolGroupProps> = ({ tools, hasFailed }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const labels = tools.map((t) => getHumanReadableToolName((t.value as ToolMessageValue).toolName));
+
+  const failedCount = hasFailed
+    ? tools.filter((t) => (t.value as ToolMessageValue).toolStatus === "failed").length
+    : 0;
+
+  let summary: string;
+  if (hasFailed) {
+    summary =
+      tools.length === 1
+        ? "Tool call failed"
+        : failedCount === tools.length
+          ? `${tools.length} tool calls failed`
+          : `${tools.length} tool calls (${failedCount} failed)`;
+  } else {
+    summary =
+      labels.length <= MAX_INLINE_LABELS
+        ? labels.join(", ")
+        : `Used ${labels.length} tools`;
+  }
+
+  return (
+    <div className="tool-group">
+      <button
+        className={`tool-group__toggle ${hasFailed ? "tool-group__toggle--failed" : ""}`}
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+      >
+        <AngleRightIcon
+          className={`tool-group__chevron ${expanded ? "tool-group__chevron--open" : ""}`}
+        />
+        {hasFailed && <TimesCircleIcon className="tool-status-icon tool-status-icon--error" />}
+        <span className="tool-group__summary">{summary}</span>
+      </button>
+      {expanded && (
+        <div className="tool-group__detail">
+          {tools.map((t) => {
+            const val = t.value as ToolMessageValue;
+            const status = val.toolStatus === "failed" ? "failed" : "succeeded";
+            return (
+              <ToolMessage
+                key={t.messageToken}
+                toolName={val.toolName}
+                status={status}
+                detail={val.detail}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface AgentToolGroupProps {
+  tools: AgentChatMessage[];
+}
+
+export const AgentToolGroup: React.FC<AgentToolGroupProps> = ({ tools }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const hasRunning = tools.some((t) => t.toolCall?.status === "running");
+  const hasFailed = tools.some((t) => t.toolCall?.status === "failed");
+
+  if (hasRunning) {
+    const runningCount = tools.filter((t) => t.toolCall?.status === "running").length;
+    return (
+      <div className="tool-group">
+        <div className="tool-indicator tool-indicator--running">
+          <SyncAltIcon className="tool-status-icon tool-status-icon--running" />
+          <span className="tool-indicator__label">
+            {runningCount === 1 ? "Running tool call..." : `Running ${runningCount} tool calls...`}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  const labels = tools.map((t) => getHumanReadableToolName(t.toolCall?.name ?? "Tool call"));
+  const failedCount = hasFailed
+    ? tools.filter((t) => t.toolCall?.status === "failed").length
+    : 0;
+
+  let summary: string;
+  if (hasFailed) {
+    summary =
+      tools.length === 1
+        ? "Tool call failed"
+        : failedCount === tools.length
+          ? `${tools.length} tool calls failed`
+          : `${tools.length} tool calls (${failedCount} failed)`;
+  } else {
+    summary =
+      labels.length <= MAX_INLINE_LABELS ? labels.join(", ") : `Used ${labels.length} tools`;
+  }
+
+  return (
+    <div className="tool-group">
+      <button
+        className={`tool-group__toggle ${hasFailed ? "tool-group__toggle--failed" : ""}`}
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+      >
+        <AngleRightIcon
+          className={`tool-group__chevron ${expanded ? "tool-group__chevron--open" : ""}`}
+        />
+        {hasFailed && <TimesCircleIcon className="tool-status-icon tool-status-icon--error" />}
+        <span className="tool-group__summary">{summary}</span>
+      </button>
+      {expanded && (
+        <div className="tool-group__detail">
+          {tools.map((t) => {
+            const tc = t.toolCall;
+            if (!tc) {
+              return null;
+            }
+            const status = tc.status === "failed" ? "failed" : "succeeded";
+            const { detail } = extractToolContext(tc.arguments);
+            return (
+              <ToolMessage key={t.id} toolName={tc.name} status={status} detail={detail} />
+            );
+          })}
+        </div>
       )}
     </div>
   );

--- a/webview-ui/src/components/ResolutionsPage/toolMessage.css
+++ b/webview-ui/src/components/ResolutionsPage/toolMessage.css
@@ -1,124 +1,116 @@
-.tool-message-container {
-  background: var(--vscode-editorWidget-background, rgba(127, 127, 127, 0.08));
-  border: 1px solid var(--vscode-editorWidget-border, rgba(127, 127, 127, 0.3));
-  border-radius: 4px;
-  min-height: 2.5rem; /* Ensure consistent height */
-}
-
-.tool-message-container.has-details {
-  padding: 0;
-}
-
-.tool-message {
+.tool-indicator {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  color: var(--pf-global--Color--300, #8a8d90); /* lighter gray */
-  font-size: 1rem; /* match chat text */
-  font-weight: 400;
-  line-height: 1.5;
+  gap: 6px;
+  padding: 2px 0;
+  font-size: 12px;
+  line-height: 1.3;
+  color: var(--vscode-descriptionForeground, #8a8d90);
+  overflow: hidden;
 }
 
-.tool-icon {
-  width: 1rem;
-  height: 1rem;
+.tool-status-icon {
+  width: 14px;
+  height: 14px;
   flex-shrink: 0;
 }
 
-.tool-icon.success {
+.tool-status-icon--success {
   color: var(--vscode-testing-iconPassed, #73c991);
 }
 
-.tool-icon.error {
+.tool-status-icon--error {
   color: var(--vscode-testing-iconFailed, #f48771);
 }
 
-.tool-icon.running {
+.tool-status-icon--running {
   color: var(--vscode-textLink-foreground, #3794ff);
+  animation: tool-spin 1s linear infinite;
 }
 
-.tool-name {
-  font-weight: 400;
+@keyframes tool-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
-.tool-status {
-  text-transform: capitalize;
-  font-size: 0.95em;
+.tool-indicator__label {
+  flex-shrink: 0;
+  color: var(--vscode-descriptionForeground, #8a8d90);
+}
+
+.tool-indicator__detail {
+  color: var(--vscode-descriptionForeground, #8a8d90);
   opacity: 0.7;
-  margin-left: 0.25em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
-.tool-message-container.minimal-tool-message {
-  padding: 0.5rem;
-  background: var(--vscode-editorWidget-background, rgba(127, 127, 127, 0.08));
-  border: 1px solid var(--vscode-editorWidget-border, rgba(127, 127, 127, 0.3));
-  border-radius: 4px;
-  display: flex;
+/* --- Collapsible tool group (Cursor-like) --- */
+
+.tool-group {
+  padding: 1px 0;
+}
+
+.tool-group__toggle {
+  display: inline-flex;
   align-items: center;
-  min-height: 2.5rem; /* Ensure consistent height */
-}
-
-.tool-message-text {
-  color: var(--vscode-editor-foreground);
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  padding: 0.5rem;
-  margin: 0;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem; /* Add more spacing between icon and text */
-  height: 100%;
-  min-height: 2.5rem;
-}
-
-.tool-message-summary {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  color: var(--vscode-editor-foreground);
-  font-size: 1rem;
-  font-weight: 400;
-  width: 100%;
-  min-height: 2.5rem;
-}
-
-.tool-details {
-  padding: 0.75rem;
-  border-top: 1px solid var(--vscode-editorWidget-border, rgba(127, 127, 127, 0.3));
-  background: var(--vscode-editor-background);
-  color: var(--vscode-editor-foreground);
-}
-
-.tool-error-details {
-  font-size: 0.9rem;
-}
-
-.tool-error-details pre {
-  background: var(--vscode-editor-inactiveSelectionBackground, rgba(127, 127, 127, 0.1));
-  padding: 0.5rem;
+  gap: 4px;
+  padding: 2px 6px;
+  border: none;
   border-radius: 3px;
-  overflow: auto;
-  font-family: var(--vscode-editor-font-family, monospace);
-  font-size: 0.85rem;
+  background: transparent;
+  color: var(--vscode-descriptionForeground, #8a8d90);
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+  line-height: 1.4;
+  user-select: none;
 }
 
-/* Override PatternFly expandable section styles to match our theme */
-.tool-expandable {
-  width: 100%;
+.tool-group__toggle:hover {
+  background: var(--vscode-list-hoverBackground, #2a2d2e);
 }
 
-.tool-expandable button {
-  padding: 0.5rem !important;
-  width: 100%;
-  text-align: left;
-  background: transparent !important;
-  color: var(--vscode-editor-foreground) !important;
-  border: none !important;
-  display: flex;
-  align-items: center;
+.tool-group__toggle--failed {
+  color: var(--vscode-testing-iconFailed, #f48771);
 }
 
-.tool-expandable button:hover {
-  background: var(--vscode-list-hoverBackground, rgba(127, 127, 127, 0.1)) !important;
+.tool-group__toggle--failed .tool-status-icon {
+  width: 12px;
+  height: 12px;
+}
+
+.tool-group__chevron {
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+}
+
+.tool-group__chevron--open {
+  transform: rotate(90deg);
+}
+
+.tool-group__summary {
+  opacity: 0.8;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tool-group__detail {
+  padding: 2px 0 2px 20px;
+}
+
+.tool-group__detail .tool-indicator {
+  font-size: 11px;
+  padding: 1px 0;
+}
+
+.tool-group__detail .tool-status-icon {
+  width: 12px;
+  height: 12px;
 }


### PR DESCRIPTION
## Summary

Redesigns the `ToolMessage` component on the Resolutions page to reduce visual noise and improve readability when the agent is running multiple tool calls.

> **Note:** These changes are also included in #1389 (pluggable agent backend). This PR can merge independently — when #1389 rebases afterward, the overlap resolves cleanly.

**Before:** Each tool call rendered as a full-width card with category-specific icons (file, git, code, etc.) and a PatternFly `ExpandableSection` for error details. Consecutive tool messages stacked vertically and took up significant space.

**After:** Tool calls are displayed as compact inline indicators with a simple status icon (✓ / ✗ / ↻ spinner). Consecutive tool messages are grouped into a collapsible section with a chevron toggle — similar to how Cursor and other AI IDEs present tool activity. The summary line shows either the tool names (≤3) or "Used N tools", with failed counts highlighted.

### Changes

**`webview-ui/src/components/ResolutionsPage/ToolMessage.tsx`**
- Replaced category-specific icon mapping (`FileIcon`, `GitAltIcon`, etc.) with a single `StatusIcon` component based on outcome
- Added `extractToolContext()` helper that pulls file paths, commands, and search queries from tool arguments to show as inline detail text
- New `CollapsibleToolGroup` component — groups `ChatMessage`-based tool calls with expand/collapse
- New `AgentToolGroup` component — same pattern for `AgentChatMessage`-based tool calls, with a "Running N tool calls..." state while in progress
- Switched tool name labels from present-progressive ("Searching files") to past-tense ("Searched files") for completed actions
- Added `text_editor`, `read_file`, `write_file`, `bash`, `shell`, and other MCP-style tool names to the mapping
- Removed `ExpandableSection` dependency from PatternFly

**`webview-ui/src/components/ResolutionsPage/toolMessage.css`**
- Replaced card-based layout (`.tool-message-container`) with compact indicator layout (`.tool-indicator`)
- Added collapsible group styles (`.tool-group`, `.tool-group__toggle`, `.tool-group__chevron`)
- Spinning animation for the running state icon
- Better text overflow handling with `text-overflow: ellipsis`

### Testing
- Manual testing in extension ✅
- No API or state changes — purely presentational