### PR TITLE
:bug: support environment variable overrides for fallback assets

### DIFF
--- a/changes/unreleased/fallback-env-override.yaml
+++ b/changes/unreleased/fallback-env-override.yaml
@@ -1,0 +1,3 @@
+kind: bugfix
+description: >
+  Added ANALYZER_FALLBACK_BASE_URL environment variable to override fallback asset download URLs for air-gapped environments.

--- a/vscode/core/src/paths.ts
+++ b/vscode/core/src/paths.ts
@@ -141,8 +141,16 @@ export async function ensureKaiAnalyzerBinary(
     throw new Error(`No fallback asset available for platform: ${platformKey}`);
   }
 
-  const downloadUrl = `${fallbackConfig.baseUrl}${assetConfig.file}`;
-  const sha256sumUrl = `${fallbackConfig.baseUrl}${fallbackConfig.sha256sumFile}`;
+  const baseUrl = (process.env.ANALYZER_FALLBACK_BASE_URL || fallbackConfig.baseUrl).replace(
+    /\/*$/,
+    "/",
+  );
+  const downloadUrl = `${baseUrl}${assetConfig.file}`;
+  const sha256sumUrl = `${baseUrl}${fallbackConfig.sha256sumFile}`;
+
+  if (process.env.ANALYZER_FALLBACK_BASE_URL) {
+    logger.info(`Using environment variable override for fallback base URL: ${baseUrl}`);
+  }
 
   // Check if binary already exists and matches the expected version
   const metadataPath = join(dirname(kaiAnalyzerPath), "kai-analyzer-rpc.meta.json");
@@ -179,8 +187,9 @@ export async function ensureKaiAnalyzerBinary(
   logger.info(`Downloading SHA256 checksums from: ${sha256sumUrl}`);
 
   const networkGuidance =
-    `If you are in a network-restricted environment, configure a local binary path via the "${EXTENSION_NAME}.analyzerPath" setting ` +
-    `or the "Override Analyzer Binary" command.`;
+    `If you are in a network-restricted environment, you can:\n` +
+    `1. Configure a local binary path via the "${EXTENSION_NAME}.analyzerPath" setting or the "Override Analyzer Binary" command\n` +
+    `2. Set ANALYZER_FALLBACK_BASE_URL environment variable to point to an internal artifact repository`;
 
   // Download and parse sha256sum.txt to get expected SHA
   let sha256Response: Response;


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for configuring fallback download URLs via the ANALYZER_FALLBACK_BASE_URL environment variable for restricted-network environments.
  * Logs a clear notice when the environment override is in use.

* **Bug Fixes**
  * Improved multi-line, numbered error guidance with explicit steps for troubleshooting download failures.

* **Chores**
  * Updated unreleased changelog entry documenting the new environment override.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konveyor/editor-extensions/pull/1411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->