### PR TITLE
:bug: restore clean buffer on tab close via tabGroups.onDidChangeTabs (#1362)

### DIFF
--- a/changes/unreleased/1410-fix-dirty-buffer-on-tab-close.yaml
+++ b/changes/unreleased/1410-fix-dirty-buffer-on-tab-close.yaml
@@ -1,0 +1,6 @@
+kind: bugfix
+description: >
+  Fix file showing patched content after closing review editor tab without
+  accepting. Use tabGroups.onDidChangeTabs to restore the clean on-disk buffer
+  via WorkspaceEdit instead of the unreliable onDidCloseTextDocument + revert
+  approach.

--- a/vscode/core/src/commands.ts
+++ b/vscode/core/src/commands.ts
@@ -37,6 +37,7 @@ import { fixGroupOfIncidents, IncidentTypeItem } from "./issueView";
 import { paths } from "./paths";
 import { checkIfExecutable, copySampleProviderSettings } from "./utilities/fileUtils";
 import { handleConfigureCustomRules } from "./utilities/profiles/profileActions";
+import { handleFileResponse } from "./utilities/ModifiedFiles/handleFileResponse";
 import { VerticalDiffCodeLensProvider } from "./diff/verticalDiffCodeLens";
 import type { Logger } from "winston";
 import { parseModelConfig, getProviderConfigKeys } from "./modelProvider/config";
@@ -900,47 +901,102 @@ const commandsMap: (
       }
     },
 
-    [`${EXTENSION_NAME}.acceptDiff`]: async (filePath?: string) => {
-      if (!filePath) {
+    [`${EXTENSION_NAME}.acceptDiff`]: async (fileUri?: string) => {
+      if (!fileUri) {
         const editor = vscode.window.activeTextEditor;
         if (!editor) {
           return;
         }
-        filePath = editor.document.fileName;
+        fileUri = editor.document.uri.toString();
       }
       if (!state.staticDiffAdapter) {
         vscode.window.showErrorMessage("Vertical diff system not initialized");
         return;
       }
-      await state.staticDiffAdapter.acceptAll(filePath);
+
+      // Capture the messageToken (streamId) before accepting clears it
+      const messageToken = state.verticalDiffManager?.getStreamIdForFile(fileUri);
+
+      await state.staticDiffAdapter.acceptAll(fileUri);
 
       // Save the document after accepting changes
       const editor = vscode.window.activeTextEditor;
-      if (editor && editor.document.fileName === filePath) {
+      if (editor && editor.document.uri.toString() === fileUri) {
         await editor.document.save();
+      }
+
+      // If this file was part of batch review, advance it
+      if (messageToken) {
+        const filePath = vscode.Uri.parse(fileUri).fsPath;
+        const content = editor?.document.getText() || "";
+        try {
+          await handleFileResponse(messageToken, "apply", filePath, content, state, true);
+        } catch (err) {
+          logger.debug("[acceptDiff] handleFileResponse error (may not be in batch)", err);
+        }
+        state.mutateSolutionWorkflow((draft) => {
+          if (draft.pendingBatchReview) {
+            draft.pendingBatchReview = draft.pendingBatchReview.filter(
+              (file) => file.messageToken !== messageToken,
+            );
+          }
+        });
+        // Clear decorator after batch removal to avoid race
+        state.mutateDecorators((draft) => {
+          if (draft.activeDecorators && draft.activeDecorators[messageToken]) {
+            delete draft.activeDecorators[messageToken];
+          }
+        });
       }
 
       vscode.window.showInformationMessage("Changes accepted and document saved");
     },
 
-    [`${EXTENSION_NAME}.rejectDiff`]: async (filePath?: string) => {
-      if (!filePath) {
+    [`${EXTENSION_NAME}.rejectDiff`]: async (fileUri?: string) => {
+      if (!fileUri) {
         const editor = vscode.window.activeTextEditor;
         if (!editor) {
           return;
         }
-        filePath = editor.document.fileName;
+        fileUri = editor.document.uri.toString();
       }
       if (!state.staticDiffAdapter) {
         vscode.window.showErrorMessage("Vertical diff system not initialized");
         return;
       }
-      await state.staticDiffAdapter.rejectAll(filePath);
+
+      // Capture the messageToken (streamId) before rejecting clears it
+      const messageToken = state.verticalDiffManager?.getStreamIdForFile(fileUri);
+
+      await state.staticDiffAdapter.rejectAll(fileUri);
 
       // Save the document after rejecting changes
       const editor = vscode.window.activeTextEditor;
-      if (editor && editor.document.fileName === filePath) {
+      if (editor && editor.document.uri.toString() === fileUri) {
         await editor.document.save();
+      }
+
+      // If this file was part of batch review, advance it
+      if (messageToken) {
+        const filePath = vscode.Uri.parse(fileUri).fsPath;
+        try {
+          await handleFileResponse(messageToken, "reject", filePath, undefined, state, true);
+        } catch (err) {
+          logger.debug("[rejectDiff] handleFileResponse error (may not be in batch)", err);
+        }
+        state.mutateSolutionWorkflow((draft) => {
+          if (draft.pendingBatchReview) {
+            draft.pendingBatchReview = draft.pendingBatchReview.filter(
+              (file) => file.messageToken !== messageToken,
+            );
+          }
+        });
+        // Clear decorator after batch removal to avoid race
+        state.mutateDecorators((draft) => {
+          if (draft.activeDecorators && draft.activeDecorators[messageToken]) {
+            delete draft.activeDecorators[messageToken];
+          }
+        });
       }
 
       vscode.window.showInformationMessage("Changes rejected and document saved");

--- a/vscode/core/src/diff/staticDiffAdapter.ts
+++ b/vscode/core/src/diff/staticDiffAdapter.ts
@@ -153,17 +153,17 @@ export class StaticDiffAdapter {
 
   /**
    * Accept all changes in a file
+   * @param fileUri - A file URI string (e.g. file:///path/to/file.ts)
    */
-  async acceptAll(filePath: string): Promise<void> {
-    const fileUri = vscode.Uri.file(filePath).toString();
+  async acceptAll(fileUri: string): Promise<void> {
     await this.verticalDiffManager.clearForFileUri(fileUri, true);
   }
 
   /**
    * Reject all changes in a file
+   * @param fileUri - A file URI string (e.g. file:///path/to/file.ts)
    */
-  async rejectAll(filePath: string): Promise<void> {
-    const fileUri = vscode.Uri.file(filePath).toString();
+  async rejectAll(fileUri: string): Promise<void> {
     await this.verticalDiffManager.clearForFileUri(fileUri, false);
   }
 

--- a/vscode/core/src/diff/vertical/manager.ts
+++ b/vscode/core/src/diff/vertical/manager.ts
@@ -19,13 +19,16 @@ export interface VerticalDiffCodeLens {
 export class VerticalDiffManager {
   public refreshCodeLens: () => void = () => {};
   public onDiffStatusChange: ((fileUri: string) => void) | undefined;
+  public onAllBlocksResolved:
+    | ((streamId: string, fileUri: string, fileContent: string) => void)
+    | undefined;
 
   private fileUriToHandler: Map<string, VerticalDiffHandler> = new Map();
   fileUriToCodeLens: Map<string, VerticalDiffCodeLens[]> = new Map();
   private fileUriToStreamId: Map<string, string> = new Map();
 
   private userChangeListener: vscode.Disposable | undefined;
-  private closeDocumentListener: vscode.Disposable | undefined;
+  private tabCloseListener: vscode.Disposable | undefined;
 
   logDiffs: DiffLine[] | undefined;
 
@@ -47,20 +50,33 @@ export class VerticalDiffManager {
 
     this.userChangeListener = undefined;
 
-    // Listen for editor tab closes to clean up diff state.
-    // Without this, closing a tab with active code lenses leaves
-    // activeDecorators populated, which keeps the chat continue
-    // button disabled (see #1362).
-    this.closeDocumentListener = vscode.workspace.onDidCloseTextDocument((doc) => {
-      const fileUri = doc.uri.toString();
-      if (this.fileUriToHandler.has(fileUri)) {
-        this.logger.info(
-          `[Manager] Editor closed for file with active diff, cleaning up: ${fileUri}`,
-        );
-        // Use the tab-close-specific cleanup that avoids editor edits
-        // (which silently fail on a closing document) and instead reverts
-        // the file from disk.
-        this.clearForClosedDocument(fileUri);
+    // Listen for tab close events to clean up diff state.
+    // When the user closes a tab with active diff decorations without
+    // accepting/rejecting, handler.clear() does editor edits to undo the
+    // diff — but those edits silently fail because the editor is gone.
+    // This leaves VS Code's in-memory buffer dirty with patched content
+    // (even though git status shows clean). The only workaround was to
+    // reopen VS Code.
+    //
+    // onDidCloseTextDocument fires too late — the document is already
+    // detached and workbench.action.files.revert has no editor to target.
+    //
+    // tabGroups.onDidChangeTabs fires when tabs change, and at that point
+    // the document is still in VS Code's model. We can open it via
+    // openTextDocument, read the clean on-disk content, and replace the
+    // buffer via WorkspaceEdit — making it non-dirty so hot-exit won't
+    // preserve the patched state.
+    this.tabCloseListener = vscode.window.tabGroups.onDidChangeTabs(async (event) => {
+      for (const closedTab of event.closed) {
+        if (closedTab.input instanceof vscode.TabInputText) {
+          const fileUri = closedTab.input.uri.toString();
+          if (this.fileUriToHandler.has(fileUri)) {
+            this.logger.info(
+              `[Manager] Tab closed for file with active diff, cleaning up: ${fileUri}`,
+            );
+            await this.clearForClosedTab(fileUri, closedTab.input.uri);
+          }
+        }
       }
     });
   }
@@ -222,39 +238,40 @@ export class VerticalDiffManager {
   }
 
   /**
-   * Clean up diff state when a document is closed by the user (tab close).
+   * Clean up diff state when a tab is closed by the user.
    *
-   * Unlike clearForFileUri, this does NOT attempt editor edits (which silently
-   * fail on a closing/closed document and leave the in-memory buffer dirty with
-   * patched content).  Instead it:
-   *  1. Clears all internal state maps (handler, codelens, streamId, decorators)
-   *  2. Disposes the handler without running accept/reject edits
-   *  3. Reverts the file so VS Code drops its dirty buffer and reloads from disk
+   * Unlike clearForFileUri, this does NOT call handler.clear() because the
+   * editor is gone and editor edits would silently fail, leaving the in-memory
+   * buffer dirty with patched content.
    *
-   * See #1362 — without the revert, closing the tab left the file showing the
-   * patched content even though git status showed no changes.
+   * Instead it:
+   * 1. Clears all internal state (handler, codelens, streamId, decorators)
+   * 2. Disposes the handler without running accept/reject edits
+   * 3. Reads the clean on-disk content and replaces the document buffer via
+   *    WorkspaceEdit — this makes the document non-dirty so VS Code's hot-exit
+   *    won't preserve the patched state
+   *
+   * See #1362 — without this, closing the tab left the file showing patched
+   * content even though git status showed no changes.
    */
-  private async clearForClosedDocument(fileUri: string): Promise<void> {
-    // --- 1. Clear activeDecorators (same as clearForFileUri) ---
+  private async clearForClosedTab(fileUri: string, uri: vscode.Uri): Promise<void> {
+    // --- 1. Clear activeDecorators ---
     const streamId = this.fileUriToStreamId.get(fileUri);
     if (streamId) {
       this.mutateDecorators((draft) => {
         if (draft.activeDecorators && draft.activeDecorators[streamId]) {
           delete draft.activeDecorators[streamId];
           this.logger.info(
-            `[Manager] Cleared activeDecorators for streamId: ${streamId} via clearForClosedDocument`,
+            `[Manager] Cleared activeDecorators for streamId: ${streamId} via clearForClosedTab`,
           );
         }
       });
       this.fileUriToStreamId.delete(fileUri);
     }
 
-    // --- 2. Dispose handler without running editor edits ---
+    // --- 2. Dispose handler without editor edits ---
     const handler = this.fileUriToHandler.get(fileUri);
     if (handler) {
-      // Just dispose listeners/decorations — do NOT call handler.clear()
-      // because the editor is gone and edits would silently fail, leaving
-      // a dirty in-memory buffer with patched content.
       handler.dispose();
       this.fileUriToHandler.delete(fileUri);
     }
@@ -265,19 +282,35 @@ export class VerticalDiffManager {
     this.refreshCodeLens();
     void vscode.commands.executeCommand("setContext", `${EXTENSION_NAME}.diffVisible`, false);
 
-    // --- 4. Revert the file to its on-disk content ---
-    // The diff decorations inserted/deleted lines in the editor buffer but never
-    // saved.  VS Code's hot-exit may preserve this dirty buffer across reloads.
-    // Reverting forces VS Code to drop it and re-read from disk (the clean version).
+    // --- 4. Restore the document buffer to on-disk content ---
+    // The diff handler inserted/deleted lines in the editor buffer but never
+    // saved. VS Code's hot-exit may preserve this dirty buffer across reloads.
+    // By reading the clean disk content and applying it via WorkspaceEdit, the
+    // document content matches disk -> isDirty becomes false -> hot-exit ignores it.
     try {
-      const uri = vscode.Uri.parse(fileUri);
-      await vscode.commands.executeCommand("workbench.action.files.revert", uri);
-      this.logger.info(`[Manager] Reverted file to disk content after tab close: ${fileUri}`);
+      const diskBytes = await vscode.workspace.fs.readFile(uri);
+      const diskContent = new TextDecoder().decode(diskBytes);
+
+      // Open the document in memory (not in a visible editor)
+      const doc = await vscode.workspace.openTextDocument(uri);
+
+      if (doc.isDirty) {
+        const fullRange = new vscode.Range(0, 0, doc.lineCount, 0);
+        const wsEdit = new vscode.WorkspaceEdit();
+        wsEdit.replace(uri, fullRange, diskContent);
+        await vscode.workspace.applyEdit(wsEdit);
+        this.logger.info(
+          `[Manager] Restored document buffer to disk content after tab close: ${fileUri}`,
+        );
+      } else {
+        this.logger.debug(
+          `[Manager] Document not dirty after tab close, no restore needed: ${fileUri}`,
+        );
+      }
     } catch (error) {
-      // Revert may fail if the document is fully disposed — that's fine,
-      // the next open will read from disk anyway.
+      // If the document is fully disposed, the next open will read from disk.
       this.logger.debug(
-        `[Manager] Could not revert file (may already be fully closed): ${fileUri}`,
+        `[Manager] Could not restore document buffer (may already be fully closed): ${fileUri}`,
         error,
       );
     }
@@ -293,26 +326,14 @@ export class VerticalDiffManager {
       return;
     }
 
-    // Get the streamId for this file to clear activeDecorators
+    // Clean up streamId mapping (but do NOT clear activeDecorators here —
+    // the batch review webview uses activeDecorators to determine if a diff
+    // is still in-progress. Clearing it here races with pendingBatchReview
+    // removal and causes buttons to flash. activeDecorators is only cleared
+    // in clearForClosedTab for the tab-close case.)
     const streamId = this.fileUriToStreamId.get(fileUri);
     if (streamId) {
-      this.mutateDecorators((draft) => {
-        if (draft.activeDecorators && draft.activeDecorators[streamId]) {
-          delete draft.activeDecorators[streamId];
-          this.logger.info(
-            `[Manager] Cleared activeDecorators for streamId: ${streamId} via clearForFileUri`,
-          );
-          this.logger.info(`[Manager] Remaining activeDecorators:`, draft.activeDecorators);
-        } else {
-          this.logger.warn(
-            `[Manager] No activeDecorators found for streamId: ${streamId}, current:`,
-            draft.activeDecorators,
-          );
-        }
-      });
       this.fileUriToStreamId.delete(fileUri);
-    } else {
-      this.logger.warn(`[Manager] No streamId found for fileUri: ${fileUri} in clearForFileUri`);
     }
 
     const handler = this.fileUriToHandler.get(fileUri);
@@ -382,19 +403,20 @@ export class VerticalDiffManager {
           }
         }
 
-        // Clear activeDecorators when all decorators are resolved
+        // Do NOT clear activeDecorators here — it races with
+        // pendingBatchReview removal and causes the webview to flash
+        // "Accept/Reject/Review" buttons. Decorator cleanup is handled:
+        //  - Tab close: clearForClosedTab clears it
+        //  - Accept/reject: batch removal makes the entry irrelevant
         if ((status === "closed" || numDiffs === 0) && streamId) {
-          this.mutateDecorators((draft) => {
-            if (draft.activeDecorators && draft.activeDecorators[streamId]) {
-              delete draft.activeDecorators[streamId];
-            }
-          });
-          this.logger.debug(`[Manager] Cleared activeDecorators for streamId: ${streamId}`);
-
           // Auto-save the document when all decorators are resolved
-          // This provides the same behavior as "Apply All Changes" but for manual decoration clearing
           if (status === "closed" && fileContent) {
             this.autoSaveDocument(fileUri, fileContent);
+          }
+
+          // Notify that all blocks are resolved (for batch review advancement)
+          if (status === "closed" && fileContent && this.onAllBlocksResolved) {
+            this.onAllBlocksResolved(streamId, fileUri, fileContent);
           }
         }
       },
@@ -500,9 +522,9 @@ export class VerticalDiffManager {
     this.disableDocumentChangeListener();
 
     // Dispose close document listener
-    if (this.closeDocumentListener) {
-      this.closeDocumentListener.dispose();
-      this.closeDocumentListener = undefined;
+    if (this.tabCloseListener) {
+      this.tabCloseListener.dispose();
+      this.tabCloseListener = undefined;
     }
 
     // Clear callback references

--- a/vscode/core/src/diff/vertical/manager.ts
+++ b/vscode/core/src/diff/vertical/manager.ts
@@ -20,7 +20,7 @@ export class VerticalDiffManager {
   public refreshCodeLens: () => void = () => {};
   public onDiffStatusChange: ((fileUri: string) => void) | undefined;
   public onAllBlocksResolved:
-    | ((streamId: string, fileUri: string, fileContent: string) => void)
+    | ((streamId: string, fileUri: string, fileContent: string, accepted: boolean) => void)
     | undefined;
 
   private fileUriToHandler: Map<string, VerticalDiffHandler> = new Map();
@@ -223,6 +223,14 @@ export class VerticalDiffManager {
     await handler.acceptRejectBlock(accept, block.start, block.numGreen, block.numRed);
 
     if (blocks.length === 1) {
+      // All blocks resolved via individual codelens — notify before cleanup.
+      // We fire onAllBlocksResolved here (not from onStatusUpdate) to avoid
+      // double-fires and to have direct access to the accept/reject flag.
+      const streamId = this.fileUriToStreamId.get(fileUri);
+      if (streamId && this.onAllBlocksResolved) {
+        const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(fileUri));
+        this.onAllBlocksResolved(streamId, fileUri, doc.getText(), accept);
+      }
       await this.clearForFileUri(fileUri, true);
     } else {
       // Re-enable listener for user changes to file
@@ -414,10 +422,11 @@ export class VerticalDiffManager {
             this.autoSaveDocument(fileUri, fileContent);
           }
 
-          // Notify that all blocks are resolved (for batch review advancement)
-          if (status === "closed" && fileContent && this.onAllBlocksResolved) {
-            this.onAllBlocksResolved(streamId, fileUri, fileContent);
-          }
+          // NOTE: onAllBlocksResolved is NOT fired here. It is called
+          // directly from acceptRejectVerticalDiffBlock with the correct
+          // accept/reject flag. Firing it from onStatusUpdate caused
+          // double-fires (once from acceptRejectBlock, once from clear())
+          // and had no way to know accept vs reject.
         }
       },
       streamId,

--- a/vscode/core/src/diff/verticalDiffCodeLens.ts
+++ b/vscode/core/src/diff/verticalDiffCodeLens.ts
@@ -28,12 +28,12 @@ export class VerticalDiffCodeLensProvider implements vscode.CodeLensProvider, vs
       new vscode.CodeLens(topRange, {
         title: `✓ Accept All Changes (${blocks.reduce((sum, b) => sum + b.numGreen, 0)}+, ${blocks.reduce((sum, b) => sum + b.numRed, 0)}-)`,
         command: `${EXTENSION_NAME}.acceptDiff`,
-        arguments: [document.uri.fsPath],
+        arguments: [fileUri],
       }),
       new vscode.CodeLens(topRange, {
         title: "✗ Reject All Changes",
         command: `${EXTENSION_NAME}.rejectDiff`,
-        arguments: [document.uri.fsPath],
+        arguments: [fileUri],
       }),
     );
 

--- a/vscode/core/src/extension.ts
+++ b/vscode/core/src/extension.ts
@@ -935,10 +935,18 @@ class VsCodeExtension {
       streamId: string,
       fileUri: string,
       fileContent: string,
+      accepted: boolean,
     ) => {
       const filePath = vscode.Uri.parse(fileUri).fsPath;
       try {
-        await handleFileResponse(streamId, "apply", filePath, fileContent, this.state, true);
+        await handleFileResponse(
+          streamId,
+          accepted ? "apply" : "reject",
+          filePath,
+          accepted ? fileContent : undefined,
+          this.state,
+          true,
+        );
       } catch (err) {
         this.state.logger.debug(
           "[Extension] onAllBlocksResolved handleFileResponse error (may not be in batch)",

--- a/vscode/core/src/extension.ts
+++ b/vscode/core/src/extension.ts
@@ -69,6 +69,7 @@ import { StaticDiffAdapter } from "./diff/staticDiffAdapter";
 import { FileEditor } from "./utilities/ideUtils";
 import { ProviderRegistry, HealthCheckRegistry, createCoreApi } from "./api";
 import { KonveyorCoreApi } from "@editor-extensions/shared";
+import { handleFileResponse } from "./utilities/ModifiedFiles/handleFileResponse";
 
 class VsCodeExtension {
   public state: ExtensionState;
@@ -927,6 +928,39 @@ class VsCodeExtension {
     // Set up the diff status change callback
     this.state.verticalDiffManager.onDiffStatusChange = (fileUri: string) => {
       this.updateDiffStatusBarForFile(fileUri);
+    };
+
+    // When all blocks are resolved via individual accept/reject, advance batch review
+    this.state.verticalDiffManager.onAllBlocksResolved = async (
+      streamId: string,
+      fileUri: string,
+      fileContent: string,
+    ) => {
+      const filePath = vscode.Uri.parse(fileUri).fsPath;
+      try {
+        await handleFileResponse(streamId, "apply", filePath, fileContent, this.state, true);
+      } catch (err) {
+        this.state.logger.debug(
+          "[Extension] onAllBlocksResolved handleFileResponse error (may not be in batch)",
+          err,
+        );
+      }
+      // Remove from pending FIRST, then clear decorator.
+      // Order matters: if decorator clears first, the webview useEffect resets
+      // viewingInEditor before the file is gone from pendingBatchReview.
+      this.state.mutateSolutionWorkflow((draft) => {
+        if (draft.pendingBatchReview) {
+          draft.pendingBatchReview = draft.pendingBatchReview.filter(
+            (file) => file.messageToken !== streamId,
+          );
+        }
+      });
+      // Now safe to clear decorator (file is already gone from pending)
+      this.state.mutateDecorators((draft) => {
+        if (draft.activeDecorators && draft.activeDecorators[streamId]) {
+          delete draft.activeDecorators[streamId];
+        }
+      });
     };
 
     this.state.staticDiffAdapter = new StaticDiffAdapter(


### PR DESCRIPTION
## Summary

Fixes the remaining issue from #1362 where closing a tab with active diff decorations (review mode) leaves the file showing patched content — even though `git status` shows clean. The only workaround was reopening VS Code.

Additionally fixes a pre-existing bug where the codelens "Accept All Changes" / "Reject All Changes" buttons silently failed and never advanced the batch review.

## Problems Fixed

### 1. Dirty buffer on tab close
The previous fix (PR #1369) used `onDidCloseTextDocument` + `workbench.action.files.revert`. However, `onDidCloseTextDocument` fires **after** the document is detached from VS Code's editor model — `revert` has no active editor to target and silently fails. The dirty buffer persists in VS Code's hot-exit cache.

### 2. Accept/Reject All codelens not working (path vs URI mismatch)
The codelens provider passed `document.uri.fsPath` (a filesystem path like `/path/to/file.ts`) to the `acceptDiff`/`rejectDiff` commands, but `acceptAll`/`rejectAll` look up handlers by URI string (`file:///path/to/file.ts`). The mismatch caused handler lookups to always fail silently.

### 3. Batch review not advancing after codelens accept/reject
Even after fixing the URI mismatch, the codelens accept/reject cleared `activeDecorators` (sending `DECORATORS_UPDATE` to the webview) before removing the file from `pendingBatchReview`. The webview's `useEffect` reacted to the decorator clearing by resetting `viewingInEditor` to null, causing the "Accept/Reject/Review in Editor" buttons to flash back before the batch removal arrived.

## Fix

### Tab close cleanup
Replace `onDidCloseTextDocument` with `tabGroups.onDidChangeTabs` (VS Code 1.77+), which fires while the document is still in the model. On tab close:

1. Dispose the diff handler **without** running editor edits (they'd silently fail)
2. Clear all internal state (activeDecorators, codelens, streamId)
3. Read clean on-disk content via `workspace.fs.readFile`
4. Replace the document buffer via `WorkspaceEdit` — content matches disk → `isDirty` = false → hot-exit won't preserve the patched state

### Codelens URI fix
Pass `fileUri` (from `document.uri.toString()`) instead of `document.uri.fsPath` for the Accept All / Reject All codelens arguments, and update the command handlers consistently.

### Batch review advancement
- Remove `activeDecorators` clearing from `clearForFileUri` and `onStatusUpdate("closed")` — only `clearForClosedTab` clears it now (for the tab-close → "Review in Editor" re-show behavior)
- `acceptDiff`/`rejectDiff` commands capture the `messageToken` before clearing, then call `handleFileResponse` + remove from `pendingBatchReview` + clear decorator (in that order)
- Added `onAllBlocksResolved` callback on the manager for the individual block-by-block case

This ensures the file is removed from `pendingBatchReview` **before** the decorator is cleared, so the webview never re-renders buttons for a file that's already gone.

## Testing

### Tab close scenario
1. Run analysis, receive a solution
2. Click "Review in Editor" to open the vertical diff
3. Close the editor tab (X) without accepting or rejecting
4. Reopen the file — should show original clean content (no patched lines)

### Accept/Reject All scenario
1. Run analysis, receive a solution with diff blocks
2. Click "Review in Editor" to open the vertical diff
3. Click "✓ Accept All Changes" or "✗ Reject All Changes" at the top
4. Changes should apply/revert, codelens disappears, batch review advances to next file

### Individual block scenario
1. Open diff with multiple blocks
2. Accept/reject blocks one by one via per-block codelens
3. After last block is resolved, batch review should advance

Refs: #1362

---
`cherry-pick`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restores documents to their on-disk state when closing a review editor tab without accepting changes.

* **Improvements**
  * More robust batch-review flow to avoid race conditions when accepting or rejecting changes.
  * Automatically saves resolved files and shows success notifications when changes are applied or rejected.

* **Refactor**
  * Tab-close and diff-resolution handling updated for more reliable behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konveyor/editor-extensions/pull/1412)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->