### PR TITLE
:bug: Fix Golang analysis issues on Windows

### DIFF
--- a/changes/unreleased/1427-fix-windows-lsp-proxy-uri-encoding.yaml
+++ b/changes/unreleased/1427-fix-windows-lsp-proxy-uri-encoding.yaml
@@ -1,0 +1,9 @@
+kind: bugfix
+description: >
+  Fixed Go analysis on Windows by correcting URI handling in the
+  LSP proxy: file URIs now use unencoded drive-letter colons (c:/ instead of
+  c%3A/) so that the go-external-provider can
+  correctly match reference locations against the workspace folder and produce
+  analysis violations.
+extensions:
+  - go

--- a/vscode/core/src/commands.ts
+++ b/vscode/core/src/commands.ts
@@ -38,6 +38,7 @@ import { paths } from "./paths";
 import { checkIfExecutable, copySampleProviderSettings } from "./utilities/fileUtils";
 import { handleConfigureCustomRules } from "./utilities/profiles/profileActions";
 import { handleFileResponse } from "./utilities/ModifiedFiles/handleFileResponse";
+import { normalizeFilePath } from "./utilities/pathUtils";
 import { VerticalDiffCodeLensProvider } from "./diff/verticalDiffCodeLens";
 import type { Logger } from "winston";
 import { parseModelConfig, getProviderConfigKeys } from "./modelProvider/config";
@@ -927,7 +928,7 @@ const commandsMap: (
 
       // If this file was part of batch review, advance it
       if (messageToken) {
-        const filePath = vscode.Uri.parse(fileUri).fsPath;
+        const filePath = normalizeFilePath(vscode.Uri.parse(fileUri).fsPath);
         const content = editor?.document.getText() || "";
         try {
           await handleFileResponse(messageToken, "apply", filePath, content, state, true);

--- a/vscode/core/src/utilities/ModifiedFiles/handleFileResponse.ts
+++ b/vscode/core/src/utilities/ModifiedFiles/handleFileResponse.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import { ChatMessageType, ModifiedFileMessageValue } from "@editor-extensions/shared";
 import { executeExtensionCommand } from "../../commands";
 import { runPartialAnalysis } from "../../analysis/runAnalysis";
+import { normalizeFilePath } from "../pathUtils";
 import {
   KaiWorkflowMessage,
   KaiWorkflowMessageType,
@@ -134,11 +135,12 @@ export async function handleFileResponse(
 
     if (responseId === "apply") {
       const uri = vscode.Uri.file(path);
+      const normalizedPath = normalizeFilePath(path);
       const fileMessage = state.data.chatMessages.find(
         (msg) =>
           msg.kind === ChatMessageType.ModifiedFile &&
           msg.messageToken === messageToken &&
-          (msg.value as ModifiedFileMessageValue).path === path,
+          normalizeFilePath((msg.value as ModifiedFileMessageValue).path) === normalizedPath,
       );
 
       if (!fileMessage) {
@@ -213,7 +215,9 @@ export async function handleFileResponse(
           try {
             const diskBytes = await vscode.workspace.fs.readFile(uri);
             finalContent = new TextDecoder().decode(diskBytes);
-            logger.info(`Using on-disk content for solution server (captures in-place edits): ${path}`);
+            logger.info(
+              `Using on-disk content for solution server (captures in-place edits): ${path}`,
+            );
           } catch (readError) {
             logger.warn(`Could not read disk content, using original content: ${path}`, readError);
           }

--- a/vscode/go/src/goVscodeProxyServer.ts
+++ b/vscode/go/src/goVscodeProxyServer.ts
@@ -74,16 +74,36 @@ export class GoVscodeProxyServer implements vscode.Disposable {
       });
 
       try {
-        const result: vscode.Location[] = await vscode.commands.executeCommand(
-          "vscode.executeDefinitionProvider",
-          vscode.Uri.parse(params.textDocument.uri),
-          new vscode.Position(params.position.line, params.position.character),
-        );
+        const vscodeUri = vscode.Uri.parse(params.textDocument.uri);
+        const result: vscode.Location | vscode.Location[] | vscode.LocationLink[] =
+          await vscode.commands.executeCommand(
+            "vscode.executeDefinitionProvider",
+            vscodeUri,
+            new vscode.Position(params.position.line, params.position.character),
+          );
 
         this.logger.info(
           `Definition result: ${Array.isArray(result) ? result.length : 1} locations`,
         );
-        return result?.map((location) => this.converter.asLocation(location)) || [];
+
+        if (Array.isArray(result)) {
+          if (result.length === 0) {
+            return [];
+          }
+          const first = result[0];
+          if (first instanceof vscode.Location) {
+            return (result as vscode.Location[]).map((location) =>
+              this.converter.asLocation(location),
+            );
+          }
+          const links = result as vscode.LocationLink[];
+          return links.map((link) => {
+            const range = link.targetSelectionRange ?? link.targetRange;
+            return this.converter.asLocation(new vscode.Location(link.targetUri, range));
+          });
+        } else {
+          return [this.converter.asLocation(result)];
+        }
       } catch (error) {
         this.logger.error(`Text document definition error`, error);
         throw error;
@@ -116,7 +136,7 @@ export class GoVscodeProxyServer implements vscode.Disposable {
     // Handle textDocument/didOpen requests
     connection.onNotification("textDocument/didOpen", async (params: any) => {
       try {
-        await vscode.workspace.openTextDocument(params.textDocument.uri);
+        await vscode.workspace.openTextDocument(vscode.Uri.parse(params.textDocument.uri));
       } catch (error) {
         this.logger.error("Failed to open text document", { error, params });
       }
@@ -149,7 +169,7 @@ export class GoVscodeProxyServer implements vscode.Disposable {
         return result?.map(converterFunc) || [];
       } catch (error) {
         this.logger.error("Failed to get document symbols", { error, params });
-        return [];
+        throw error;
       }
     });
 

--- a/vscode/go/src/goVscodeProxyServer.ts
+++ b/vscode/go/src/goVscodeProxyServer.ts
@@ -75,6 +75,7 @@ export class GoVscodeProxyServer implements vscode.Disposable {
 
       try {
         const vscodeUri = vscode.Uri.parse(params.textDocument.uri);
+        await vscode.workspace.openTextDocument(vscodeUri);
         const result: vscode.Location | vscode.Location[] | vscode.LocationLink[] =
           await vscode.commands.executeCommand(
             "vscode.executeDefinitionProvider",
@@ -126,7 +127,12 @@ export class GoVscodeProxyServer implements vscode.Disposable {
         this.logger.info(
           `References result: ${Array.isArray(result) ? result.length : 0} locations`,
         );
-        return result?.map((location) => this.converter.asLocation(location)) || [];
+        return (
+          result?.map((location) => ({
+            uri: location.uri.toString(true),
+            range: this.converter.asRange(location.range),
+          })) || []
+        );
       } catch (error) {
         this.logger.error(`Text document references error`, error);
         throw error;
@@ -149,9 +155,11 @@ export class GoVscodeProxyServer implements vscode.Disposable {
       });
 
       try {
+        const vscodeUri = vscode.Uri.parse(params.textDocument.uri);
+        await vscode.workspace.openTextDocument(vscodeUri);
         const result: vscode.DocumentSymbol[] = await vscode.commands.executeCommand(
           "vscode.executeDocumentSymbolProvider",
-          vscode.Uri.parse(params.textDocument.uri),
+          vscodeUri,
         );
 
         this.logger.info(`Document symbol result: ${result?.length || 0} symbols`);

--- a/vscode/javascript/src/extension.ts
+++ b/vscode/javascript/src/extension.ts
@@ -83,12 +83,14 @@ export async function activate(context: vscode.ExtensionContext) {
       javascriptVersion: javascriptExtVersion,
       coreVersion: coreExtVersion,
     });
-  } else {
-    logger.info("Version compatibility check passed", {
-      javascriptVersion: javascriptExtVersion,
-      coreVersion: coreExtVersion,
-    });
+    vscode.window.showErrorMessage(message);
+    return;
   }
+
+  logger.info("Version compatibility check passed", {
+    javascriptVersion: javascriptExtVersion,
+    coreVersion: coreExtVersion,
+  });
 
   // Create socket paths for communication
   const providerSocketPath = generateSafePipeName(EXTENSION_NAME); // GRPC socket for kai-analyzer-rpc

--- a/vscode/javascript/src/extension.ts
+++ b/vscode/javascript/src/extension.ts
@@ -83,14 +83,12 @@ export async function activate(context: vscode.ExtensionContext) {
       javascriptVersion: javascriptExtVersion,
       coreVersion: coreExtVersion,
     });
-    vscode.window.showErrorMessage(message);
-    return;
+  } else {
+    logger.info("Version compatibility check passed", {
+      javascriptVersion: javascriptExtVersion,
+      coreVersion: coreExtVersion,
+    });
   }
-
-  logger.info("Version compatibility check passed", {
-    javascriptVersion: javascriptExtVersion,
-    coreVersion: coreExtVersion,
-  });
 
   // Create socket paths for communication
   const providerSocketPath = generateSafePipeName(EXTENSION_NAME); // GRPC socket for kai-analyzer-rpc

--- a/vscode/javascript/src/vscodeProxyServer.ts
+++ b/vscode/javascript/src/vscodeProxyServer.ts
@@ -78,9 +78,11 @@ export class vscodeProxyServer implements vscode.Disposable {
     connection.onRequest("textDocument/documentSymbol", async (params: any) => {
       this.logger.info("Received textDocument/documentSymbol request", { params });
       try {
+        const vscodeUri = vscode.Uri.parse(params.textDocument.uri);
+        await vscode.workspace.openTextDocument(vscodeUri);
         const result: vscode.DocumentSymbol[] = await vscode.commands.executeCommand(
           "vscode.executeDocumentSymbolProvider",
-          vscode.Uri.parse(params.textDocument.uri),
+          vscodeUri,
         );
         const converterFunc = (symbol: vscode.DocumentSymbol): proto.DocumentSymbol => {
           return {
@@ -106,6 +108,7 @@ export class vscodeProxyServer implements vscode.Disposable {
 
       try {
         const vscodeUri = vscode.Uri.parse(params.textDocument.uri);
+        await vscode.workspace.openTextDocument(vscodeUri);
         const result: vscode.Location | vscode.Location[] | vscode.LocationLink[] =
           await vscode.commands.executeCommand(
             "vscode.executeDefinitionProvider",
@@ -154,7 +157,12 @@ export class vscodeProxyServer implements vscode.Disposable {
         this.logger.info(
           `References result: ${Array.isArray(result) ? result.length : 0} locations`,
         );
-        return result?.map((location) => this.converter.asLocation(location)) || [];
+        return (
+          result?.map((location) => ({
+            uri: location.uri.toString(true),
+            range: this.converter.asRange(location.range),
+          })) || []
+        );
       } catch (error) {
         this.logger.error(`Text document references error`, error);
         throw error;

--- a/vscode/javascript/src/vscodeProxyServer.ts
+++ b/vscode/javascript/src/vscodeProxyServer.ts
@@ -69,7 +69,7 @@ export class vscodeProxyServer implements vscode.Disposable {
     connection.onNotification("textDocument/didOpen", async (params: any) => {
       this.logger.info("Received textDocument/didOpen", { params });
       try {
-        await vscode.workspace.openTextDocument(params.textDocument.uri);
+        await vscode.workspace.openTextDocument(vscode.Uri.parse(params.textDocument.uri));
       } catch (error) {
         this.logger.error("Failed to open text document", { error, params });
       }


### PR DESCRIPTION
Resolves #1427 
Resolves #1429

Needs https://github.com/konveyor/analyzer-lsp/pull/1157 & https://github.com/konveyor/analyzer-lsp/pull/1159 
to work.

This PR: 
 - Updates how the extension was handling file uris on Windows to correctly report analysis incidents.
 - Allows the JS provider to initialize even when there is a version mismatch, this is the current behaviour of the Go and Java providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows file URI encoding in Go analysis so reference locations correctly match the workspace folder.

* **Improvements**
  * Enhanced Go “Go to Definition” and “Find References” through improved LSP result handling and more reliable document opening.
  * Improved JavaScript language proxy behavior with safer URI parsing for document-related requests.
  * Normalized file paths when accepting and applying diffs to ensure modified-file matching works consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->