### PR TITLE
:bug: honor NO_PROXY when selecting proxy dispatcher

### DIFF
--- a/changes/unreleased/1415-honor-no-proxy.yaml
+++ b/changes/unreleased/1415-honor-no-proxy.yaml
@@ -1,0 +1,6 @@
+kind: bugfix
+description: >
+  Honor the NO_PROXY environment variable when deciding whether to route
+  Hub and GenAI provider connections through HTTP_PROXY/HTTPS_PROXY.
+  Targets matching NO_PROXY (including loopback addresses such as
+  127.0.0.1) now bypass the proxy as expected.

--- a/vscode/core/src/hub/HubConnectionManager.ts
+++ b/vscode/core/src/hub/HubConnectionManager.ts
@@ -359,7 +359,13 @@ export class HubConnectionManager {
     // Create connection-scoped fetch for insecure mode
     if (this.config.auth.insecure) {
       this.logger.warn("SSL certificate verification is disabled for Hub connections");
-      const dispatcher = await getDispatcherWithCertBundle(undefined, true);
+      const dispatcher = await getDispatcherWithCertBundle(
+        undefined,
+        true,
+        false,
+        this.logger,
+        this.config.url,
+      );
       this.scopedFetch = getFetchWithDispatcher(dispatcher);
     } else {
       this.scopedFetch = null;

--- a/vscode/core/src/modelProvider/modelCreator.ts
+++ b/vscode/core/src/modelProvider/modelCreator.ts
@@ -33,7 +33,7 @@ class AzureChatOpenAICreator implements ModelCreator {
   constructor(private readonly logger: Logger) {}
 
   async create(args: Record<string, any>, env: Record<string, string>): Promise<BaseChatModel> {
-    const fetchFn = await setupProviderTLS(env, this.logger);
+    const fetchFn = await setupProviderTLS(env, this.logger, extractProviderTargetUrl(args));
     return new AzureChatOpenAI({
       openAIApiKey: env.AZURE_OPENAI_API_KEY,
       ...args,
@@ -71,7 +71,13 @@ class ChatBedrockCreator implements ModelCreator {
   constructor(private readonly logger: Logger) {}
 
   async create(args: Record<string, any>, env: Record<string, string>): Promise<BaseChatModel> {
-    await setupProviderTLS(env, this.logger);
+    const bedrockEndpoint =
+      extractProviderTargetUrl(args) ||
+      (env.AWS_DEFAULT_REGION
+        ? `https://bedrock-runtime.${env.AWS_DEFAULT_REGION}.amazonaws.com`
+        : undefined);
+
+    await setupProviderTLS(env, this.logger, bedrockEndpoint);
 
     const config: ChatBedrockConverseInput = {
       ...args,
@@ -86,7 +92,7 @@ class ChatBedrockCreator implements ModelCreator {
 
     const httpProtocol = getConfigHttpProtocol();
     const httpVersion = httpProtocol === "http2" ? "2.0" : "1.1";
-    const requestHandler = await getNodeHttpHandler(env, this.logger, httpVersion);
+    const requestHandler = await getNodeHttpHandler(env, this.logger, httpVersion, bedrockEndpoint);
     const runtimeClient = new BedrockRuntimeClient({
       region: env.AWS_DEFAULT_REGION,
       credentials: config.credentials,
@@ -113,7 +119,7 @@ class ChatDeepSeekCreator implements ModelCreator {
   constructor(private readonly logger: Logger) {}
 
   async create(args: Record<string, any>, env: Record<string, string>): Promise<BaseChatModel> {
-    const fetchFn = await setupProviderTLS(env, this.logger);
+    const fetchFn = await setupProviderTLS(env, this.logger, extractProviderTargetUrl(args));
     return new ChatDeepSeek({
       apiKey: env.DEEPSEEK_API_KEY,
       ...args,
@@ -143,7 +149,7 @@ class ChatGoogleGenerativeAICreator implements ModelCreator {
   constructor(private readonly logger: Logger) {}
 
   async create(args: Record<string, any>, env: Record<string, string>): Promise<BaseChatModel> {
-    await setupProviderTLS(env, this.logger);
+    await setupProviderTLS(env, this.logger, extractProviderTargetUrl(args));
     return new ChatGoogleGenerativeAI({
       apiKey: env.GOOGLE_API_KEY,
       ...args,
@@ -168,7 +174,7 @@ class ChatOllamaCreator implements ModelCreator {
   constructor(private readonly logger: Logger) {}
 
   async create(args: Record<string, any>, env: Record<string, string>): Promise<BaseChatModel> {
-    const fetchFn = await setupProviderTLS(env, this.logger);
+    const fetchFn = await setupProviderTLS(env, this.logger, extractProviderTargetUrl(args));
     return new ChatOllama({
       ...args,
       ...(fetchFn ? { fetch: fetchFn } : {}),
@@ -191,7 +197,7 @@ class ChatOpenAICreator implements ModelCreator {
   constructor(private readonly logger: Logger) {}
 
   async create(args: Record<string, any>, env: Record<string, string>): Promise<BaseChatModel> {
-    const fetchFn = await setupProviderTLS(env, this.logger);
+    const fetchFn = await setupProviderTLS(env, this.logger, extractProviderTargetUrl(args));
     return new ChatOpenAI({
       apiKey: env.OPENAI_API_KEY,
       ...args,
@@ -256,9 +262,33 @@ function getCaBundleAndInsecure(env: Record<string, string>): {
  * dispatcher entirely. We must also override `globalThis.fetch` with our
  * bundled undici's fetch to ensure custom CA certs are used.
  */
+/**
+ * Pulls a likely target URL out of a model provider's `args` so the TLS
+ * dispatcher can evaluate `NO_PROXY` against it. Returns `undefined` if the
+ * provider's endpoint isn't expressed in the args (cloud SDKs that resolve
+ * their endpoint internally) — in which case proxy behavior falls back to
+ * the historical "always use the proxy if one is set" path.
+ */
+function extractProviderTargetUrl(args: Record<string, any> | undefined): string | undefined {
+  if (!args) {
+    return undefined;
+  }
+  return (
+    args.configuration?.baseURL ||
+    args.configuration?.basePath ||
+    args.baseUrl ||
+    args.baseURL ||
+    args.endpoint ||
+    args.endpointUrl ||
+    args.azureOpenAIEndpoint ||
+    undefined
+  );
+}
+
 async function setupProviderTLS(
   env: Record<string, string>,
   logger: Logger,
+  targetUrl?: string,
 ): Promise<FetchFn | undefined> {
   const httpProtocol = getConfigHttpProtocol();
   const allowH2 = httpProtocol === "http2";
@@ -278,6 +308,7 @@ async function setupProviderTLS(
     needsCustomDispatcher,
     hasProxy: !!proxyUrl,
     proxyUrl: proxyUrl ? sanitizeUrl(proxyUrl) : "none",
+    targetUrl: targetUrl ? sanitizeUrl(targetUrl) : "none",
     envKeys: Object.keys(env),
   });
 
@@ -288,7 +319,13 @@ async function setupProviderTLS(
   }
 
   try {
-    const dispatcher = await getDispatcherWithCertBundle(caBundle, insecure, allowH2, logger);
+    const dispatcher = await getDispatcherWithCertBundle(
+      caBundle,
+      insecure,
+      allowH2,
+      logger,
+      targetUrl,
+    );
     const customFetch = getFetchWithDispatcher(dispatcher);
     setGlobalDispatcher(dispatcher as any);
     globalThis.fetch = customFetch as typeof globalThis.fetch;

--- a/vscode/core/src/utilities/__tests__/tls.test.ts
+++ b/vscode/core/src/utilities/__tests__/tls.test.ts
@@ -1,0 +1,250 @@
+import expect from "expect";
+import winston from "winston";
+
+import { getDispatcherWithCertBundle, getNodeHttpHandler, shouldBypassProxy } from "../tls";
+
+/**
+ * Regression tests for issue #1415:
+ *
+ * When `HTTP_PROXY` / `HTTPS_PROXY` are set in the environment and `NO_PROXY`
+ * lists the target host (e.g. `127.0.0.1`), the extension was still routing
+ * the connection through the proxy because `tls.ts` did not consult
+ * `NO_PROXY`.
+ *
+ * These tests pin the desired behavior at two layers:
+ *   1. `shouldBypassProxy(targetUrl, noProxy)` — pure helper, covers NO_PROXY
+ *      matching semantics.
+ *   2. `getDispatcherWithCertBundle` / `getNodeHttpHandler` — must bypass the
+ *      proxy-agent path when the target URL matches NO_PROXY.
+ */
+
+const PROXY_ENV_VARS = [
+  "HTTPS_PROXY",
+  "https_proxy",
+  "HTTP_PROXY",
+  "http_proxy",
+  "NO_PROXY",
+  "no_proxy",
+];
+
+function snapshotProxyEnv(): Record<string, string | undefined> {
+  const snapshot: Record<string, string | undefined> = {};
+  for (const key of PROXY_ENV_VARS) {
+    snapshot[key] = process.env[key];
+  }
+  return snapshot;
+}
+
+function restoreProxyEnv(snapshot: Record<string, string | undefined>): void {
+  for (const key of PROXY_ENV_VARS) {
+    const value = snapshot[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function clearProxyEnv(): void {
+  for (const key of PROXY_ENV_VARS) {
+    delete process.env[key];
+  }
+}
+
+describe("tls — NO_PROXY handling (issue #1415)", () => {
+  describe("shouldBypassProxy", () => {
+    it("returns false when noProxy is undefined", () => {
+      expect(shouldBypassProxy("https://example.com", undefined)).toBe(false);
+    });
+
+    it("returns false when noProxy is empty string", () => {
+      expect(shouldBypassProxy("https://example.com", "")).toBe(false);
+    });
+
+    it("returns false when targetUrl is undefined", () => {
+      expect(shouldBypassProxy(undefined, "*")).toBe(false);
+    });
+
+    it("returns true when noProxy is wildcard '*'", () => {
+      expect(shouldBypassProxy("https://anything.example.com/path", "*")).toBe(true);
+      expect(shouldBypassProxy("http://127.0.0.1:8080", "*")).toBe(true);
+    });
+
+    it("returns true for exact IP match (bug #1415 repro)", () => {
+      expect(shouldBypassProxy("http://127.0.0.1:8080/v1", "127.0.0.1")).toBe(true);
+    });
+
+    it("returns true for exact hostname match", () => {
+      expect(shouldBypassProxy("http://localhost:8080", "localhost")).toBe(true);
+    });
+
+    it("matches an entry in a comma-separated list", () => {
+      expect(shouldBypassProxy("http://foo.example.com", "a.com,foo.example.com,bar.com")).toBe(
+        true,
+      );
+    });
+
+    it("tolerates whitespace around comma-separated entries", () => {
+      expect(shouldBypassProxy("http://localhost", "  localhost , 127.0.0.1  ")).toBe(true);
+    });
+
+    it("treats leading-dot entries as domain suffix matches for subdomains", () => {
+      expect(shouldBypassProxy("https://api.example.com", ".example.com")).toBe(true);
+    });
+
+    it("does not match the parent domain when entry has a leading dot", () => {
+      expect(shouldBypassProxy("https://example.com", ".example.com")).toBe(false);
+    });
+
+    it("treats bare-host entries as suffix matches (curl/requests style)", () => {
+      expect(shouldBypassProxy("https://api.example.com", "example.com")).toBe(true);
+    });
+
+    it("does not falsely match unrelated hosts", () => {
+      expect(shouldBypassProxy("https://api.openai.com", "127.0.0.1,localhost")).toBe(false);
+    });
+
+    it("is case-insensitive on host comparison", () => {
+      expect(shouldBypassProxy("https://API.Example.COM", "example.com")).toBe(true);
+    });
+
+    it("honors port-qualified entries", () => {
+      expect(shouldBypassProxy("http://localhost:8080", "localhost:8080")).toBe(true);
+    });
+
+    it("does not match when the port-qualified entry's port differs", () => {
+      expect(shouldBypassProxy("http://localhost:9090", "localhost:8080")).toBe(false);
+    });
+
+    it("returns false (no throw) when targetUrl is not a parseable URL", () => {
+      expect(shouldBypassProxy("not a url", "*")).toBe(false);
+      expect(shouldBypassProxy("", "*")).toBe(false);
+    });
+
+    it("does not confuse partial-string overlaps (e.g. 'example.com' must not match 'badexample.com')", () => {
+      expect(shouldBypassProxy("https://badexample.com", "example.com")).toBe(false);
+    });
+  });
+
+  describe("getDispatcherWithCertBundle", () => {
+    const logger = winston.createLogger({ silent: true });
+    let envSnapshot: Record<string, string | undefined>;
+
+    beforeEach(() => {
+      envSnapshot = snapshotProxyEnv();
+      clearProxyEnv();
+    });
+
+    afterEach(() => {
+      restoreProxyEnv(envSnapshot);
+    });
+
+    it("returns a non-ProxyAgent dispatcher when NO_PROXY matches the target host (bug #1415)", async () => {
+      process.env.HTTPS_PROXY = "http://corporate-proxy.example.com:8080";
+      process.env.NO_PROXY = "127.0.0.1";
+
+      const dispatcher = await getDispatcherWithCertBundle(
+        undefined,
+        false,
+        false,
+        logger,
+        "http://127.0.0.1:8080/v1",
+      );
+
+      expect(dispatcher.constructor.name).not.toBe("ProxyAgent");
+    });
+
+    it("still returns a ProxyAgent when HTTPS_PROXY is set and NO_PROXY is unset", async () => {
+      process.env.HTTPS_PROXY = "http://corporate-proxy.example.com:8080";
+
+      const dispatcher = await getDispatcherWithCertBundle(
+        undefined,
+        false,
+        false,
+        logger,
+        "https://api.openai.com",
+      );
+
+      expect(dispatcher.constructor.name).toBe("ProxyAgent");
+    });
+
+    it("still uses the proxy when NO_PROXY exists but does not match the target host", async () => {
+      process.env.HTTPS_PROXY = "http://corporate-proxy.example.com:8080";
+      process.env.NO_PROXY = "api.openai.com";
+
+      const dispatcher = await getDispatcherWithCertBundle(
+        undefined,
+        false,
+        false,
+        logger,
+        "https://other.example.com",
+      );
+
+      expect(dispatcher.constructor.name).toBe("ProxyAgent");
+    });
+
+    it("returns a plain Agent when no proxy env vars are set, regardless of targetUrl", async () => {
+      const dispatcher = await getDispatcherWithCertBundle(
+        undefined,
+        false,
+        false,
+        logger,
+        "http://127.0.0.1:8080",
+      );
+
+      expect(dispatcher.constructor.name).not.toBe("ProxyAgent");
+    });
+
+    it("preserves back-compat: callers that omit targetUrl still get a ProxyAgent when proxy env vars are set", async () => {
+      process.env.HTTPS_PROXY = "http://corporate-proxy.example.com:8080";
+
+      const dispatcher = await getDispatcherWithCertBundle(undefined, false, false, logger);
+
+      expect(dispatcher.constructor.name).toBe("ProxyAgent");
+    });
+  });
+
+  describe("getNodeHttpHandler", () => {
+    const logger = winston.createLogger({ silent: true });
+    let envSnapshot: Record<string, string | undefined>;
+
+    beforeEach(() => {
+      envSnapshot = snapshotProxyEnv();
+      clearProxyEnv();
+    });
+
+    afterEach(() => {
+      restoreProxyEnv(envSnapshot);
+    });
+
+    it("does not wrap requests in an HttpsProxyAgent when NO_PROXY matches the target host (bug #1415)", async () => {
+      const env = {
+        HTTPS_PROXY: "http://corporate-proxy.example.com:8080",
+        NO_PROXY: "127.0.0.1",
+      };
+
+      const handler = await getNodeHttpHandler(env, logger, "1.1", "http://127.0.0.1:8080");
+      const config = await (handler as any).configProvider;
+
+      expect(config.httpsAgent.constructor.name).not.toBe("HttpsProxyAgent");
+    });
+
+    it("still wraps in HttpsProxyAgent when NO_PROXY does not match the target host", async () => {
+      const env = {
+        HTTPS_PROXY: "http://corporate-proxy.example.com:8080",
+        NO_PROXY: "127.0.0.1",
+      };
+
+      const handler = await getNodeHttpHandler(
+        env,
+        logger,
+        "1.1",
+        "https://bedrock-runtime.us-east-1.amazonaws.com",
+      );
+      const config = await (handler as any).configProvider;
+
+      expect(config.httpsAgent.constructor.name).toBe("HttpsProxyAgent");
+    });
+  });
+});

--- a/vscode/core/src/utilities/tls.ts
+++ b/vscode/core/src/utilities/tls.ts
@@ -8,11 +8,80 @@ import { HttpsProxyAgent } from "https-proxy-agent";
 import type { Logger } from "winston";
 import { sanitizeUrl } from "./networkDiagnostics";
 
+/**
+ * Returns true if `targetUrl` should bypass any configured HTTP(S) proxy
+ * according to the `NO_PROXY` value. Implements the comma-separated,
+ * case-insensitive, suffix-style matching used by curl / requests /
+ * proxy-from-env so users' shell-level expectations are honored.
+ */
+export function shouldBypassProxy(
+  targetUrl: string | undefined,
+  noProxy: string | undefined,
+): boolean {
+  if (!targetUrl || !noProxy) {
+    return false;
+  }
+
+  let host: string;
+  let port: string;
+  try {
+    const parsed = new URL(targetUrl);
+    host = parsed.hostname.toLowerCase();
+    port = parsed.port;
+  } catch {
+    return false;
+  }
+  if (!host) {
+    return false;
+  }
+
+  const entries = noProxy
+    .split(/[,\s]+/)
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+
+  for (const entry of entries) {
+    if (entry === "*") {
+      return true;
+    }
+
+    const colonIdx = entry.lastIndexOf(":");
+    let entryHost = entry;
+    let entryPort = "";
+    if (colonIdx >= 0 && !entry.startsWith("[")) {
+      entryHost = entry.slice(0, colonIdx);
+      entryPort = entry.slice(colonIdx + 1);
+    }
+
+    if (entryPort && entryPort !== port) {
+      continue;
+    }
+
+    if (entryHost.startsWith(".")) {
+      const suffix = entryHost;
+      if (host.endsWith(suffix)) {
+        return true;
+      }
+      continue;
+    }
+
+    if (host === entryHost) {
+      return true;
+    }
+    if (host.endsWith("." + entryHost)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export async function getDispatcherWithCertBundle(
   bundlePath: string | undefined,
   insecure: boolean = false,
   allowH2: boolean = false,
   logger?: Logger,
+  targetUrl?: string,
 ): Promise<UndiciTypesDispatcher> {
   let allCerts: string | undefined;
   if (bundlePath) {
@@ -34,6 +103,9 @@ export async function getDispatcherWithCertBundle(
     process.env.HTTP_PROXY ||
     process.env.http_proxy;
 
+  const noProxy = process.env.NO_PROXY || process.env.no_proxy;
+  const bypassProxy = shouldBypassProxy(targetUrl, noProxy);
+
   if (logger) {
     logger.debug("TLS dispatcher config", {
       hasCustomCA: !!bundlePath,
@@ -42,10 +114,13 @@ export async function getDispatcherWithCertBundle(
       allowH2,
       hasProxy: !!proxyUrl,
       proxyUrl: proxyUrl ? sanitizeUrl(proxyUrl) : "none",
+      hasNoProxy: !!noProxy,
+      targetUrl: targetUrl ? sanitizeUrl(targetUrl) : "none",
+      bypassProxy,
     });
   }
 
-  if (proxyUrl) {
+  if (proxyUrl && !bypassProxy) {
     if (logger) {
       logger.info(`Using proxy for Hub/provider connections: ${sanitizeUrl(proxyUrl)}`);
     }
@@ -57,6 +132,10 @@ export async function getDispatcherWithCertBundle(
         rejectUnauthorized: !insecure,
       },
     }) as unknown as UndiciTypesDispatcher;
+  }
+
+  if (proxyUrl && bypassProxy && logger) {
+    logger.info(`Bypassing proxy for ${sanitizeUrl(targetUrl!)} (matches NO_PROXY=${noProxy})`);
   }
 
   return new UndiciAgent({
@@ -86,6 +165,7 @@ export async function getNodeHttpHandler(
   env: Record<string, string>,
   logger: Logger,
   httpVersion: "1.1" | "2.0" = "1.1",
+  targetUrl?: string,
 ): Promise<NodeHttpHandler | NodeHttp2Handler> {
   const caBundle = env["CA_BUNDLE"] || env["AWS_CA_BUNDLE"];
 
@@ -120,6 +200,10 @@ export async function getNodeHttpHandler(
     process.env.HTTP_PROXY ||
     process.env.http_proxy;
 
+  const noProxy =
+    env["NO_PROXY"] || env["no_proxy"] || process.env.NO_PROXY || process.env.no_proxy;
+  const bypassProxy = shouldBypassProxy(targetUrl, noProxy);
+
   interface HttpsAgentOptionsWithALPN extends AgentOptions {
     ALPNProtocols?: string[];
   }
@@ -141,8 +225,12 @@ export async function getNodeHttpHandler(
     sessionTimeout: 30000,
   };
 
-  if (proxyUrl) {
-    logger.info(`Using proxy ${proxyUrl} for AWS Bedrock`);
+  if (proxyUrl && bypassProxy) {
+    logger.info(`Bypassing proxy for ${sanitizeUrl(targetUrl!)} (matches NO_PROXY=${noProxy})`);
+  }
+
+  if (proxyUrl && !bypassProxy) {
+    logger.info(`Using proxy ${sanitizeUrl(proxyUrl)} for AWS Bedrock`);
 
     if (httpVersion === "2.0") {
       logger.warn(


### PR DESCRIPTION
Closes #1415.

When `HTTP_PROXY` / `HTTPS_PROXY` are set in the shell that launches VS Code, the extension was routing every Hub/provider connection through that proxy — even when `NO_PROXY` listed the target host. So a user with a corporate proxy in their environment and a local model on `http://127.0.0.1:8080/v1` would see:

```
Using proxy for Hub/provider connections: http://172.19.44.13:5555/
```

even though their `NO_PROXY=127.0.0.1` should have bypassed it. The only workaround was unsetting `HTTP_PROXY`/`HTTPS_PROXY` before launching VS Code.

### Root cause

`getDispatcherWithCertBundle` and `getNodeHttpHandler` in `vscode/core/src/utilities/tls.ts` read `HTTP_PROXY`/`HTTPS_PROXY` and unconditionally constructed a `ProxyAgent` / `HttpsProxyAgent`. Neither function accepted a target URL, so `NO_PROXY` couldn't be evaluated.

### Fix

- New `shouldBypassProxy(targetUrl, noProxy)` helper with curl/requests-compatible semantics: `*` wildcard, exact host, leading-dot suffix (`.example.com`), bare-host suffix, port-qualified entries (`localhost:8080`), case-insensitive, comma- or whitespace-separated.
- Both dispatcher factories now take an optional `targetUrl` and skip the proxy branch when `shouldBypassProxy` returns true. Old callers that don't pass a URL get the existing behavior — no surprise regressions.
- Wired the target URL through every call site:
  - `HubConnectionManager` — passes `this.config.url`
  - `modelCreator` — new `extractProviderTargetUrl(args)` helper pulls baseURL/baseUrl/endpoint/azureOpenAIEndpoint from the model args. For `ChatBedrock`, falls back to synthesizing `https://bedrock-runtime.{region}.amazonaws.com` from `AWS_DEFAULT_REGION` when no explicit endpoint is configured.
- Added a `"Bypassing proxy for X (matches NO_PROXY=Y)"` info log so the decision is debuggable from logs the way the original symptom was.

Also a small drive-by: the `Using proxy ... for AWS Bedrock` log line was leaking proxy basic-auth creds; now passed through `sanitizeUrl`.

### Tests

Built TDD-style — tests written first, watched them fail, then implemented.

- 17 unit cases for `shouldBypassProxy` covering each matching rule and a few false-positive guards (`badexample.com` mustn't match `example.com`, unparseable URLs return false instead of throwing, etc.)
- 5 integration cases for `getDispatcherWithCertBundle` and 2 for `getNodeHttpHandler` that set proxy env vars and assert the right dispatcher subclass is constructed — including the literal #1415 repro.
- All 132 tests pass (`npm test:unit-tests`).

### Test plan

- [x] Unit + integration tests in `vscode/core/src/utilities/__tests__/tls.test.ts`
- [ ] Manual: launch VS Code with `HTTPS_PROXY=http://fake-proxy:8080 NO_PROXY=127.0.0.1`, point a `ChatOpenAI` provider at `http://127.0.0.1:8080/v1`, confirm the `Using proxy for Hub/provider connections` log line no longer fires for that provider (and that the new `Bypassing proxy` line does)

### Known limitations

- `shouldBypassProxy` doesn't support CIDR ranges (`192.168.0.0/16`) or `*.example.com` glob syntax. Consistent with curl/requests/proxy-from-env; can be added later if there's demand.
- `ChatBedrock` endpoint synthesis assumes standard regional partition. FIPS / GovCloud / China-partition users will need to set `args.endpointUrl` explicitly (and probably already do).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Proxy handling now honors the NO_PROXY environment variable across Hub and model-provider connections; targets matching NO_PROXY (including localhost/127.0.0.1) will bypass proxies for more reliable local and self‑hosted connectivity.

* **Tests**
  * Added regression tests covering NO_PROXY matching semantics and proxy bypass behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->