### PR TITLE
:bug: emit connectionLost event when MCP connection goes stale (#1433)

### DIFF
--- a/agentic/src/clients/solutionServerClient.ts
+++ b/agentic/src/clients/solutionServerClient.ts
@@ -378,6 +378,9 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
         // Mark as disconnected
         this.isConnected = false;
 
+        // Notify listeners that the connection has been lost
+        this.emitConnectionLost();
+
         // Close the stale MCP client to prevent resource leaks
         await this.closeStaleClient();
 
@@ -828,6 +831,9 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
 
         // Mark as disconnected so future calls will know
         this.isConnected = false;
+
+        // Notify listeners that the connection has been lost
+        this.emitConnectionLost();
 
         // Close the stale MCP client to prevent resource leaks
         await this.closeStaleClient();

--- a/agentic/src/eventEmitter.ts
+++ b/agentic/src/eventEmitter.ts
@@ -10,6 +10,7 @@ export class KaiWorkflowEventEmitter {
   }
 
   on(event: "workflowMessage", listener: (chunk: KaiWorkflowMessage) => void): this;
+  on(event: "connectionLost", listener: () => void): this;
   on(event: string, listener: (...args: any[]) => void): this {
     this.eventEmitter.on(event, listener);
     return this;
@@ -17,6 +18,10 @@ export class KaiWorkflowEventEmitter {
 
   protected emitWorkflowMessage(msg: KaiWorkflowMessage): boolean {
     return this.eventEmitter.emit("workflowMessage", msg);
+  }
+
+  protected emitConnectionLost(): boolean {
+    return this.eventEmitter.emit("connectionLost");
   }
 
   public removeAllListeners() {

--- a/changes/unreleased/1435-fix-stale-solution-server-status.yaml
+++ b/changes/unreleased/1435-fix-stale-solution-server-status.yaml
@@ -1,0 +1,5 @@
+kind: bugfix
+description: >
+  Fix solution server status chip staying green after MCP connection goes stale.
+  The webview now immediately reflects connection loss via a new connectionLost
+  event emitted by SolutionServerClient.

--- a/vscode/core/src/extension.ts
+++ b/vscode/core/src/extension.ts
@@ -618,6 +618,20 @@ class VsCodeExtension {
         }
       });
 
+      // Set up connection state change callback to immediately update the webview
+      // when the solution server connection is lost (stale MCP connection detected)
+      this.state.hubConnectionManager.setConnectionStateChangeCallback(() => {
+        this.state.logger.info(
+          "Connection state change detected, updating webview state immediately",
+        );
+        this.state.mutateServerState((draft) => {
+          draft.solutionServerConnected =
+            this.state.hubConnectionManager.isSolutionServerConnected();
+          draft.profileSyncConnected = this.state.hubConnectionManager.isProfileSyncConnected();
+          draft.llmProxyAvailable = this.state.hubConnectionManager.isLLMProxyConnected();
+        });
+      });
+
       // Initialize hub connection manager with loaded config
       // This handles connecting to the solution server if enabled
       let hubInitError: Error | undefined;

--- a/vscode/core/src/hub/HubConnectionManager.ts
+++ b/vscode/core/src/hub/HubConnectionManager.ts
@@ -35,6 +35,9 @@ export type WorkflowDisposalCallback = (tokenRefreshOnly?: boolean) => void;
 // Callback type for profile sync (to trigger automatic sync)
 export type ProfileSyncCallback = () => Promise<void>;
 
+// Callback type for connection state changes (e.g., solution server disconnects)
+export type ConnectionStateChangeCallback = () => void;
+
 const TOKEN_EXPIRY_BUFFER_MS = 30000; // 30 second buffer
 // Node's setTimeout stores its delay in a 32-bit signed int. A larger delay
 // overflows, gets clamped to 1ms, and fires immediately — which for the token
@@ -79,6 +82,7 @@ export class HubConnectionManager {
   private solutionServerClient: SolutionServerClient | null = null;
   private profileSyncClient: ProfileSyncClient | null = null;
   private onWorkflowDisposal?: WorkflowDisposalCallback;
+  private onConnectionStateChange?: ConnectionStateChangeCallback;
 
   // Authentication state
   private bearerToken: string | null = null;
@@ -133,6 +137,15 @@ export class HubConnectionManager {
    */
   public setWorkflowDisposalCallback(callback: WorkflowDisposalCallback): void {
     this.onWorkflowDisposal = callback;
+  }
+
+  /**
+   * Set connection state change callback.
+   * Called when the solution server connection is lost (e.g., stale MCP connection detected).
+   * This allows the extension to update the webview state immediately.
+   */
+  public setConnectionStateChangeCallback(callback: ConnectionStateChangeCallback): void {
+    this.onConnectionStateChange = callback;
   }
 
   /**
@@ -466,6 +479,15 @@ export class HubConnectionManager {
           this.scopedFetch ?? undefined,
         );
         await this.solutionServerClient.connect();
+
+        // Subscribe to connectionLost events to propagate state changes to the webview
+        this.solutionServerClient.on("connectionLost", () => {
+          this.logger.info(
+            "Solution server connection lost detected via connectionLost event",
+          );
+          this.onConnectionStateChange?.();
+        });
+
         this.logger.info("Successfully connected to Hub solution server");
         vscode.window.showInformationMessage("Successfully connected to Hub solution server");
       } catch (error) {
@@ -576,6 +598,8 @@ export class HubConnectionManager {
 
     if (this.solutionServerClient) {
       try {
+        // Remove event listeners before disconnecting to prevent stale callbacks
+        this.solutionServerClient.removeAllListeners();
         await this.solutionServerClient.disconnect();
       } catch (error) {
         this.logger.error("Error disconnecting solution server client", error);


### PR DESCRIPTION
## Problem

The solution server status chip in the webview stays green (connected) even after the MCP connection goes stale. The `SolutionServerClient` already sets `this.isConnected = false` when it detects connection errors in `getServerCapabilities()` and `getBestHint()`, but nothing notified the webview/HubConnectionManager of this change. The webview store kept showing "connected" until the next polling cycle (which could be up to 60 seconds with backoff).

## Solution

This PR adds an event-driven notification mechanism so the webview immediately reflects connection loss:

### Changes

1. **`agentic/src/eventEmitter.ts`** — Extended `KaiWorkflowEventEmitter` with a `connectionLost` event type and a protected `emitConnectionLost()` method.

2. **`agentic/src/clients/solutionServerClient.ts`** — After setting `this.isConnected = false` in the connection error paths of both `getServerCapabilities()` and `getBestHint()`, the client now calls `this.emitConnectionLost()` to notify listeners.

3. **`vscode/core/src/hub/HubConnectionManager.ts`** — Added a `ConnectionStateChangeCallback` type and `setConnectionStateChangeCallback()` method. After creating and connecting the `SolutionServerClient`, subscribes to its `connectionLost` event and invokes the callback. Also properly removes event listeners on disconnect to prevent stale callbacks.

4. **`vscode/core/src/extension.ts`** — Sets up the connection state change callback (right after the existing `setWorkflowDisposalCallback`) that calls `mutateServerState()` to immediately broadcast the updated connection state to the webview.

### How it works

```
MCP connection error detected
  → SolutionServerClient sets isConnected = false
  → SolutionServerClient emits "connectionLost" event
  → HubConnectionManager receives event, calls onConnectionStateChange callback
  → Extension's callback calls mutateServerState()
  → Webview receives SERVER_STATE_UPDATE with solutionServerConnected: false
  → Status chip turns red immediately
```

The existing polling mechanism continues to work as a secondary check and recovery detection (turning the chip back green when connectivity is restored).

Fixes #1433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-time connection loss detection that notifies the extension and updates UI connectivity state immediately.
  * Introduced a dedicated “connectionLost” workflow event and wired it through hub connectivity handling.

* **Bug Fixes**
  * Fixed the solution server status indicator so it no longer remains green after the MCP connection becomes stale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->