### PR TITLE
:bug: migrate credential auth from /hub/auth/login to /hub/auth/tokens

### DIFF
--- a/tests/e2e/tests/ccm/hub-configuration.test.ts
+++ b/tests/e2e/tests/ccm/hub-configuration.test.ts
@@ -31,7 +31,9 @@ test.describe(
       const hubConfigPage = await HubConfigurationPage.open(vscodeApp);
       await hubConfigPage.fillForm(hubConfig);
 
-      await vscodeApp.assertNotification('Successfully connected to Hub solution server');
+      await vscodeApp.assertNotification('Successfully connected to Hub solution server', {
+        timeout: 30_000,
+      });
       await vscodeApp.executeQuickCommand('Developer: Reload Window');
       await hubConfigPage.openHubConfiguration();
       const view = await vscodeApp.getView(KAIViews.hubConfiguration);

--- a/vscode/core/src/hub/HubConnectionManager.ts
+++ b/vscode/core/src/hub/HubConnectionManager.ts
@@ -19,13 +19,6 @@ export interface TokenResponse {
 }
 
 // Hub login endpoint response format
-export interface HubLoginResponse {
-  user?: string;
-  token: string;
-  refresh?: string; // Refresh token (field name is "refresh")
-  expiry?: number; // Seconds until expiry (NOT Unix timestamp)
-}
-
 // Callback type for workflow disposal (called after successful connection)
 export type WorkflowDisposalCallback = (tokenRefreshOnly?: boolean) => void;
 
@@ -445,84 +438,70 @@ export class HubConnectionManager {
   }
 
   /**
-   * Exchange credentials for tokens via Hub login endpoint.
-   * Uses /hub/auth/login instead of direct Keycloak to get tokens that work with the LLM proxy.
+   * Exchange credentials for a Hub PAT via /hub/auth/tokens (Basic Auth).
+   *
+   * Since konveyor/operator#567 removed Keycloak, tackle-hub is the OIDC
+   * provider and the old /hub/auth/login endpoint no longer exists.
    */
   private async exchangeForTokens(): Promise<void> {
     if (!this.username || !this.password) {
       throw new HubConnectionManagerError("No username or password available for token exchange");
     }
 
-    const loginUrl = `${this.config.url}/hub/auth/login`;
+    const tokenUrl = `${this.config.url}/hub/auth/tokens`;
+    const basicAuth = Buffer.from(`${this.username}:${this.password}`).toString("base64");
 
-    this.logger.debug(`Attempting token exchange with ${loginUrl}`);
+    this.logger.debug(`Attempting token exchange with ${tokenUrl}`);
 
-    const loginResponse = await this.fetchWithTimeout<HubLoginResponse>(loginUrl, {
+    const tokenResponse = await this.fetchWithTimeout<{
+      token: string;
+      expiration?: string;
+      lifespan?: number;
+    }>(tokenUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json",
+        Authorization: `Basic ${basicAuth}`,
       },
-      body: JSON.stringify({
-        user: this.username,
-        password: this.password,
-      }),
+      body: "{}",
     });
 
-    this.logger.info("Token exchange successful via Hub login", {
-      hasToken: !!loginResponse.token,
-      tokenType: typeof loginResponse.token,
-      tokenLength: loginResponse.token?.length ?? 0,
-      responseKeys: Object.keys(loginResponse),
+    this.logger.info("Token exchange successful via Hub token endpoint", {
+      hasToken: !!tokenResponse.token,
+      tokenLength: tokenResponse.token?.length ?? 0,
     });
-    this.bearerToken = loginResponse.token;
-    this.refreshToken = loginResponse.refresh ?? null; // Store refresh token if provided
+    this.bearerToken = tokenResponse.token;
+    this.refreshToken = null; // PAT-based auth has no refresh token
 
-    // Get expiration from response or decode from JWT
-    if (loginResponse.expiry) {
-      // expiry is in SECONDS (not Unix timestamp), convert to milliseconds
-      this.tokenExpiresAt = Date.now() + loginResponse.expiry * 1000 - TOKEN_EXPIRY_BUFFER_MS;
+    // Determine token expiry from response
+    if (tokenResponse.expiration) {
+      const expiresAt = Date.parse(tokenResponse.expiration);
+      if (Number.isFinite(expiresAt)) {
+        this.tokenExpiresAt = expiresAt - TOKEN_EXPIRY_BUFFER_MS;
+      } else {
+        this.tokenExpiresAt = null;
+      }
+    } else if (
+      typeof tokenResponse.lifespan === "number" &&
+      Number.isFinite(tokenResponse.lifespan)
+    ) {
+      // lifespan is in hours
+      this.tokenExpiresAt =
+        Date.now() + tokenResponse.lifespan * 60 * 60 * 1000 - TOKEN_EXPIRY_BUFFER_MS;
     } else {
-      this.tokenExpiresAt = this.getExpirationFromJWT(loginResponse.token);
+      // Long-lived PAT — no expiry
+      this.tokenExpiresAt = null;
     }
   }
 
   /**
-   * Refresh tokens using the refresh token via /hub/auth/refresh endpoint.
-   * This is more efficient than re-authenticating with credentials.
+   * Refresh credentials token by minting a new PAT.
+   * The old /hub/auth/refresh endpoint no longer exists.
    */
   private async refreshWithRefreshToken(): Promise<void> {
-    if (!this.refreshToken) {
-      throw new HubConnectionManagerError("No refresh token available");
-    }
-
-    const refreshUrl = `${this.config.url}/hub/auth/refresh`;
-
-    this.logger.debug(`Attempting token refresh with ${refreshUrl}`);
-
-    const refreshResponse = await this.fetchWithTimeout<HubLoginResponse>(refreshUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-      body: JSON.stringify({
-        refresh: this.refreshToken,
-      }),
-    });
-
-    this.logger.info("Token refresh successful via Hub refresh endpoint");
-
-    // Update tokens
-    this.bearerToken = refreshResponse.token;
-    this.refreshToken = refreshResponse.refresh ?? this.refreshToken; // Use new refresh token if provided
-
-    // Get expiration from response or decode from JWT
-    if (refreshResponse.expiry) {
-      this.tokenExpiresAt = Date.now() + refreshResponse.expiry * 1000 - TOKEN_EXPIRY_BUFFER_MS;
-    } else {
-      this.tokenExpiresAt = this.getExpirationFromJWT(refreshResponse.token);
-    }
+    // Hub PATs don't support refresh — just mint a new one
+    await this.exchangeForTokens();
   }
 
   /**

--- a/vscode/core/src/hub/HubConnectionManager.ts
+++ b/vscode/core/src/hub/HubConnectionManager.ts
@@ -193,13 +193,21 @@ export class HubConnectionManager {
   }
 
   /**
-   * Check if authentication is valid
+   * Check if authentication is valid.
+   * A null tokenExpiresAt means the token is a long-lived PAT with no expiry.
    */
   public hasValidAuth(): boolean {
     if (!this.config.auth.enabled) {
       return true;
     }
-    return !!this.bearerToken && (this.tokenExpiresAt ? this.tokenExpiresAt > Date.now() : false);
+    if (!this.bearerToken) {
+      return false;
+    }
+    // null expiry = long-lived PAT, always valid while token exists
+    if (this.tokenExpiresAt === null) {
+      return true;
+    }
+    return this.tokenExpiresAt > Date.now();
   }
 
   /**
@@ -675,13 +683,14 @@ export class HubConnectionManager {
   }
 
   /**
-   * Start automatic token refresh timer
+   * Start automatic token refresh timer.
+   * For long-lived PATs (tokenExpiresAt === null), no timer is needed.
    */
   private async startTokenRefreshTimer(): Promise<void> {
     this.clearTokenRefreshTimer();
 
-    if (!this.tokenExpiresAt) {
-      this.logger.warn("No token expiration time available, cannot start refresh timer");
+    if (this.tokenExpiresAt === null) {
+      this.logger.info("Token has no expiration (long-lived PAT), skipping refresh timer");
       return;
     }
 


### PR DESCRIPTION
## Summary

Since konveyor/operator#567 removed Keycloak and made tackle-hub the OIDC provider, the `/hub/auth/login` and `/hub/auth/refresh` endpoints no longer exist. This broke credential-based authentication in the extension (E2E `@requires-minikube` tests timeout waiting for the "Successfully connected" notification).

## Changes

- **`exchangeForTokens()`** — now mints a PAT via `POST /hub/auth/tokens` with Basic Auth (matching the approach used by the E2E `AuthenticationManager` from #1436)
- **`refreshWithRefreshToken()`** — simplified to re-mint a PAT (the old `/hub/auth/refresh` endpoint is gone)
- **Removed** the unused `HubLoginResponse` interface

## Context

- Companion to #1436 which fixed the CI infrastructure setup for the same Hub auth change
- Unblocks `@requires-minikube` E2E tests that use credential auth
- The OIDC auth code flow (used in #1419) is unaffected — it already uses `/hub/auth/tokens` for PAT exchange

## Testing

- Typecheck passes (only pre-existing error from #1436 adding OIDC fields to ExtensionData without updating initializer)
- Lint passes (0 errors)
- E2E infra tests should now get past the credential auth step and show success notifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated Hub authentication to a token (PAT)-style flow and improved token expiry handling so long-lived tokens are recognized and refreshing is skipped when appropriate.
* **Tests**
  * Increased reliability of Hub connection verification by extending the notification assertion timeout in end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->