### PR TITLE
:bug: fix agent-mode recursion limit and windows demo-mode cache

### DIFF
--- a/agentic/src/nodes/analysisIssueFix.ts
+++ b/agentic/src/nodes/analysisIssueFix.ts
@@ -1,5 +1,5 @@
 import { Logger } from "winston";
-import { basename, relative } from "path";
+import { basename } from "path";
 import {
   type AIMessage,
   type AIMessageChunk,
@@ -9,7 +9,7 @@ import {
 import { promises as fsPromises } from "fs";
 import { type DynamicStructuredTool } from "@langchain/core/tools";
 
-import { getCacheKey } from "../utils";
+import { getCacheKey, toPosixRelative } from "../utils";
 import {
   type SummarizeAdditionalInfoInputState,
   type AnalysisIssueFixInputState,
@@ -184,12 +184,11 @@ As you make changes that impact dependencies or imports, be sure you explain wha
     if (state.currentIdx === state.inputIncidentsByUris.length) {
       const accumulated = [...state.outputAllResponses, ...nextState.outputAllResponses].reduce(
         (acc, val) => {
+          const rel = toPosixRelative(this.workspaceDir, val.outputUpdatedFileUri ?? "");
           return {
-            reasoning: `${acc.reasoning}\n\n\n#### Changes made in ${relative(this.workspaceDir, val.outputUpdatedFileUri ?? "")}\n\n${val.outputReasoning}`,
-            additionalInfo: `${acc.additionalInfo}\n\n\n#### Additional changes from ${relative(this.workspaceDir, val.outputUpdatedFileUri ?? "")}\n\n${val.outputAdditionalInfo}`,
-            uris: val.outputUpdatedFileUri
-              ? acc.uris.concat([relative(this.workspaceDir, val.outputUpdatedFileUri)])
-              : acc.uris,
+            reasoning: `${acc.reasoning}\n\n\n#### Changes made in ${rel}\n\n${val.outputReasoning}`,
+            additionalInfo: `${acc.additionalInfo}\n\n\n#### Additional changes from ${rel}\n\n${val.outputAdditionalInfo}`,
+            uris: val.outputUpdatedFileUri ? acc.uris.concat([rel]) : acc.uris,
           };
         },
         {

--- a/agentic/src/nodes/diagnosticsIssueFix.ts
+++ b/agentic/src/nodes/diagnosticsIssueFix.ts
@@ -1,4 +1,3 @@
-import * as pathlib from "path";
 import { Logger } from "winston";
 import {
   type AIMessageChunk,
@@ -10,7 +9,7 @@ import {
 } from "@langchain/core/messages";
 import { type DynamicStructuredTool } from "@langchain/core/tools";
 
-import { getCacheKey } from "../utils";
+import { getCacheKey, toPosixRelative } from "../utils";
 import {
   type KaiModelProvider,
   type KaiUserInteractionMessage,
@@ -220,7 +219,7 @@ export class DiagnosticsIssueFix extends BaseNode {
             nextState.inputInstructionsForGeneralFix = instructions;
             nextState.inputUrisForGeneralFix =
               state.currentTask && state.currentTask.uri
-                ? [pathlib.relative(this.workspaceDir, state.currentTask.uri)]
+                ? [toPosixRelative(this.workspaceDir, state.currentTask.uri)]
                 : undefined;
             nextState.currentAgent = name;
             break;

--- a/agentic/src/tools/filesystem.ts
+++ b/agentic/src/tools/filesystem.ts
@@ -6,6 +6,7 @@ import { DynamicStructuredTool } from "@langchain/core/tools";
 
 import { InMemoryCacheWithRevisions } from "../cache";
 import { KaiWorkflowEventEmitter } from "../eventEmitter";
+import { toPosixRelative } from "../utils";
 import {
   KaiUserInteractionMessage,
   KaiWorkflowMessageType,
@@ -91,7 +92,7 @@ export class FileSystemTools extends KaiWorkflowEventEmitter {
           const dirEntries = await fs.readdir(dir, { withFileTypes: true });
           for (const entry of dirEntries) {
             const absPath = pathlib.join(dir, entry.name);
-            const relPath = pathlib.relative(workspaceDir, absPath);
+            const relPath = toPosixRelative(workspaceDir, absPath);
             if (entry.isDirectory()) {
               await recurse(absPath);
             } else if (

--- a/agentic/src/utils.ts
+++ b/agentic/src/utils.ts
@@ -14,6 +14,15 @@ export function fileUriToPath(path: string): string {
     : cleanPath;
 }
 
+// `pathModule` is injectable so callers can pass posix/win32 for cross-OS tests.
+export function toPosixRelative(
+  workspaceDir: string,
+  target: string,
+  pathModule: Pick<typeof pathlib, "relative" | "sep"> = pathlib,
+): string {
+  return pathModule.relative(workspaceDir, target).split(pathModule.sep).join("/");
+}
+
 // used as a name for the subdirectory in the cache to store the results of current run
 export function getCacheKey(state: typeof BaseInputMetaState.State, suffix: string = ""): string {
   return pathlib.join(state.cacheSubDir, state.iterationCount.toString(), suffix);

--- a/agentic/src/workflows/interactiveWorkflow.ts
+++ b/agentic/src/workflows/interactiveWorkflow.ts
@@ -1,4 +1,3 @@
-import * as pathlib from "path";
 import { Logger } from "winston";
 import { createHash } from "crypto";
 import { EnhancedIncident } from "@editor-extensions/shared";
@@ -22,7 +21,7 @@ import {
   SummarizeHistoryOutputState,
   AnalysisIssueFixOutputState,
 } from "../schemas/analysisIssueFix";
-import { fileUriToPath } from "../utils";
+import { fileUriToPath, toPosixRelative } from "../utils";
 import { FileSystemTools } from "../tools/filesystem";
 import { KaiWorkflowEventEmitter } from "../eventEmitter";
 import { AnalysisIssueFix } from "../nodes/analysisIssueFix";
@@ -283,12 +282,12 @@ export class KaiInteractiveWorkflow
 
     // first run the analysis fix workflow
     const analysisFixOutputState = (await this.analysisFixWorkflow.invoke(graphInput, {
-      recursionLimit: incidentsByUris.length * 2 + 10,
+      recursionLimit: Math.max(50, incidentsByUris.length * 4 + 20),
     })) as typeof AnalysisWorkflowOutputState.State;
 
     let shouldAddressAdditionalInfo = false;
     // if there is any additional information spit by analysis workflow, capture that
-    const additionalInformation: string = analysisFixOutputState.summarizedAdditionalInfo;
+    const additionalInformation = analysisFixOutputState.summarizedAdditionalInfo ?? "";
     if (
       input.enableAgentMode &&
       additionalInformation.length > 0 &&
@@ -472,13 +471,15 @@ export class KaiInteractiveWorkflow
       } else if (state.inputAllAdditionalInfo) {
         this.logger.debug(`Going to summarize additional information only`);
         return "summarize_additional_information";
-      } else {
-        // Additional information is enabled but not accumulated yet
-        // This means we need to go back to router to continue processing
+      } else if (state.currentIdx < state.inputIncidentsByUris.length) {
         this.logger.debug(
           `Additional info enabled but not accumulated, going to fix_analysis_issue_router`,
         );
         return "fix_analysis_issue_router";
+      } else {
+        // All incidents processed but nothing accumulated; ending so we don't self-loop.
+        this.logger.warn("Agent mode produced no additional information; ending analysis workflow");
+        return END;
       }
     }
     return END;
@@ -551,12 +552,13 @@ export class KaiInteractiveWorkflow
   private createIncidentsHash(
     incidentsByUris: Array<{ uri: string; incidents: EnhancedIncident[] }>,
   ): string {
+    // Hash content must be byte-identical across OSes or Windows misses Linux-built caches (#1425).
     const dataString = incidentsByUris
       .map(({ uri, incidents }) => {
         const incidentsData = incidents
           .map((incident) => ({
             lineNumber: incident.lineNumber,
-            uri: pathlib.relative(this.workspaceDir, fileUriToPath(incident.uri)),
+            uri: toPosixRelative(this.workspaceDir, fileUriToPath(incident.uri)),
             message: incident.message,
             violationId: incident.violationId,
             ruleset_name: incident.ruleset_name,
@@ -569,7 +571,7 @@ export class KaiInteractiveWorkflow
           });
 
         return {
-          uri: pathlib.relative(this.workspaceDir, fileUriToPath(uri)),
+          uri: toPosixRelative(this.workspaceDir, fileUriToPath(uri)),
           incidents: incidentsData,
         };
       })

--- a/agentic/tests/interactiveWorkflow.test.ts
+++ b/agentic/tests/interactiveWorkflow.test.ts
@@ -1,0 +1,89 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as pathlib from "path";
+
+import { AIMessage } from "@langchain/core/messages";
+import * as winston from "winston";
+
+import { FileBasedResponseCache, InMemoryCacheWithRevisions, KaiWorkflowMessageType } from "../src";
+import { KaiInteractiveWorkflow } from "../src/workflows/interactiveWorkflow";
+import { FakeChatModelWithToolCalls, FakeModelProvider } from "./base";
+
+describe("KaiInteractiveWorkflow.run (issue #1418)", () => {
+  let workspaceDir: string;
+  let fileA: string;
+  let fileB: string;
+
+  beforeEach(async () => {
+    workspaceDir = await fs.promises.mkdtemp(pathlib.join(os.tmpdir(), "kai-test-"));
+    fileA = pathlib.join(workspaceDir, "A.java");
+    fileB = pathlib.join(workspaceDir, "B.java");
+    await fs.promises.writeFile(fileA, "public class A {}");
+    await fs.promises.writeFile(fileB, "public class B {}");
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("completes when the LLM yields no Updated File for two incidents in agent mode", async () => {
+    const responses = [
+      new AIMessage({ content: "# Reasoning\nNo changes required for this file." }),
+    ];
+    const model = new FakeChatModelWithToolCalls({ responses });
+    const provider = new FakeModelProvider(model, [], false, false);
+    const fsCache = new InMemoryCacheWithRevisions<string, string>(true);
+    const toolCache = new FileBasedResponseCache<Record<string, any>, string>(
+      false,
+      (x) => JSON.stringify(x),
+      (x) => x as string,
+    );
+    const logger = winston.createLogger({
+      level: "error",
+      format: winston.format.json(),
+      transports: [new winston.transports.Console({ silent: true })],
+    });
+    const workflow = new KaiInteractiveWorkflow(logger);
+
+    await workflow.init({
+      modelProvider: provider,
+      workspaceDir,
+      fsCache,
+      toolCache,
+    });
+
+    const incidents = [
+      {
+        uri: fileA,
+        violationId: "v1",
+        message: "issue A",
+        ruleset_name: "rs",
+        violation_name: "vn",
+        violation_category: "mandatory" as const,
+      },
+      {
+        uri: fileB,
+        violationId: "v2",
+        message: "issue B",
+        ruleset_name: "rs",
+        violation_name: "vn",
+        violation_category: "mandatory" as const,
+      },
+    ];
+
+    // The follow-up workflow blocks on an IDE "tasks" prompt; stop() so the test ends.
+    workflow.on("workflowMessage", (msg) => {
+      if (msg.type === KaiWorkflowMessageType.UserInteraction && msg.data.type === "tasks") {
+        workflow.stop();
+      }
+    });
+
+    const result = await workflow.run({
+      incidents,
+      enableAgentMode: true,
+      programmingLanguage: "java",
+      migrationHint: "JavaEE to Quarkus",
+    });
+    expect(result).toBeDefined();
+  }, 20_000);
+});

--- a/agentic/tests/interactiveWorkflow.test.ts
+++ b/agentic/tests/interactiveWorkflow.test.ts
@@ -36,7 +36,7 @@ describe("KaiInteractiveWorkflow.run (issue #1418)", () => {
     const toolCache = new FileBasedResponseCache<Record<string, any>, string>(
       false,
       (x) => JSON.stringify(x),
-      (x) => x as string,
+      (x) => JSON.parse(x) as string,
     );
     const logger = winston.createLogger({
       level: "error",

--- a/agentic/tests/routerEdge.test.ts
+++ b/agentic/tests/routerEdge.test.ts
@@ -1,0 +1,66 @@
+import { END } from "@langchain/langgraph";
+import * as winston from "winston";
+
+import { KaiInteractiveWorkflow } from "../src/workflows/interactiveWorkflow";
+import { type AnalysisIssueFixOrchestratorState } from "../src/schemas/analysisIssueFix";
+
+function makeWorkflow(): KaiInteractiveWorkflow {
+  const logger = winston.createLogger({
+    level: "error",
+    format: winston.format.json(),
+    transports: [new winston.transports.Console({ silent: true })],
+  });
+  return new KaiInteractiveWorkflow(logger);
+}
+
+function baseState(): typeof AnalysisIssueFixOrchestratorState.State {
+  return {
+    inputIncidentsByUris: [
+      { uri: "/work/A.java", incidents: [] },
+      { uri: "/work/B.java", incidents: [] },
+    ],
+    currentIdx: 2,
+    enableAdditionalInformation: true,
+    migrationHint: "",
+    programmingLanguage: "java",
+    cacheSubDir: "",
+    iterationCount: 0,
+    inputFileContent: undefined,
+    inputFileUri: undefined,
+    inputIncidents: [],
+    inputAllAdditionalInfo: undefined,
+    inputAllReasoning: undefined,
+    inputAllModifiedFiles: [],
+    outputAdditionalInfo: undefined,
+    outputReasoning: undefined,
+    outputUpdatedFile: undefined,
+    outputUpdatedFileUri: undefined,
+    outputHints: [],
+    outputAllResponses: [],
+  };
+}
+
+describe("analysisIssueFixRouterEdge (issue #1418)", () => {
+  it("returns END when all incidents are processed and nothing was accumulated", async () => {
+    const wf = makeWorkflow();
+    expect(await wf.analysisIssueFixRouterEdge(baseState())).toBe(END);
+  });
+
+  it("loops back to the router when incidents remain", async () => {
+    const wf = makeWorkflow();
+    const state = baseState();
+    state.currentIdx = 1;
+    expect(await wf.analysisIssueFixRouterEdge(state)).toBe("fix_analysis_issue_router");
+  });
+
+  it("routes to summarize when additional information was accumulated", async () => {
+    const wf = makeWorkflow();
+    const state = baseState();
+    state.inputAllAdditionalInfo = "info";
+    state.inputAllReasoning = "reasoning";
+    expect(await wf.analysisIssueFixRouterEdge(state)).toEqual([
+      "summarize_additional_information",
+      "summarize_history",
+    ]);
+  });
+});

--- a/agentic/tests/tools.test.ts
+++ b/agentic/tests/tools.test.ts
@@ -20,33 +20,33 @@ describe("searchFilesTool", () => {
     //TODO (pgaikwad) - do this better
     const tool = fsToolsFactory.all()[0];
 
+    // searchFiles normalizes paths to POSIX separators so output is OS-stable (#1425).
+    const appProps = "src/main/resources/application.properties";
+
     const tc1 = await tool.invoke({
       pattern: "application\\.properties",
     });
-    expect(tc1).toBe(pathlib.join("src", "main", "resources", "application.properties"));
+    expect(tc1).toBe(appProps);
 
     const tc2 = await tool.invoke({
       pattern: "application.properties",
     });
-    expect(tc2).toBe(pathlib.join("src", "main", "resources", "application.properties"));
+    expect(tc2).toBe(appProps);
 
     const tc3 = await tool.invoke({
       pattern: ".*application.*",
     });
-    expect(tc3).toBe(pathlib.join("src", "main", "resources", "application.properties"));
+    expect(tc3).toBe(appProps);
 
     const tc4 = await tool.invoke({
       pattern: ".*.java",
     });
-    const e1 = pathlib.join("src", "main", "java", "io", "example", "lib", "A.java");
-    const e2 = pathlib.join("src", "main", "java", "io", "example", "utils", "B.java");
-    expect(tc4).toBe(`${e1}\n${e2}`);
+    expect(tc4).toBe("src/main/java/io/example/lib/A.java\nsrc/main/java/io/example/utils/B.java");
 
     // ISSUE-806: when a model passes a relative path as pattern, it should match
     const tc5 = await tool.invoke({
-      pattern: pathlib.join("src", "main", "java", "io", "example", "lib", "A.java"),
+      pattern: "src/main/java/io/example/lib/A.java",
     });
-    const tc5_expected = pathlib.join("src", "main", "java", "io", "example", "lib", "A.java");
-    expect(tc5).toBe(tc5_expected);
+    expect(tc5).toBe("src/main/java/io/example/lib/A.java");
   });
 });

--- a/agentic/tests/utils.test.ts
+++ b/agentic/tests/utils.test.ts
@@ -1,4 +1,6 @@
-import { fileUriToPath } from "../src/utils";
+import { posix, win32 } from "path";
+
+import { fileUriToPath, toPosixRelative } from "../src/utils";
 
 describe("fileUriToPath", () => {
   (process.platform !== "win32" ? it : it.skip)(
@@ -18,5 +20,23 @@ describe("fileUriToPath", () => {
 
     expect(fileUriToPath(tc1)).toBe("C:\\root\\coolstore\\src\\main\\webapp\\WEB-INF\\web.xml");
     expect(fileUriToPath(tc2)).toBe("C:\\root\\coolstore\\src\\main\\webapp\\WEB-INF\\web.xml");
+  });
+});
+
+describe("toPosixRelative (issue #1425)", () => {
+  it("produces forward-slash output on POSIX", () => {
+    expect(
+      toPosixRelative("/work/coolstore", "/work/coolstore/src/main/java/Foo.java", posix),
+    ).toBe("src/main/java/Foo.java");
+  });
+
+  it("produces forward-slash output on Windows", () => {
+    expect(
+      toPosixRelative(
+        "C:\\work\\coolstore",
+        "C:\\work\\coolstore\\src\\main\\java\\Foo.java",
+        win32,
+      ),
+    ).toBe("src/main/java/Foo.java");
   });
 });

--- a/changes/unreleased/1418-agent-mode-recursion-limit.yaml
+++ b/changes/unreleased/1418-agent-mode-recursion-limit.yaml
@@ -1,0 +1,5 @@
+kind: bugfix
+description: >
+  Agent-mode workflow no longer hits the LangGraph recursion limit on small
+  incident sets. Raises the analysis-fix recursion floor and breaks a router
+  self-loop that ran when no additional information accumulated.

--- a/changes/unreleased/1425-windows-demo-mode-cache.yaml
+++ b/changes/unreleased/1425-windows-demo-mode-cache.yaml
@@ -1,0 +1,5 @@
+kind: bugfix
+description: >
+  Demo-mode LLM response cache now resolves on Windows. Workspace-relative
+  paths used in cache keys and prompt content are normalized to POSIX
+  separators so a cache built on Linux is found on Windows.

--- a/changes/unreleased/1425-windows-demo-mode-cache.yaml
+++ b/changes/unreleased/1425-windows-demo-mode-cache.yaml
@@ -2,4 +2,5 @@ kind: bugfix
 description: >
   Demo-mode LLM response cache now resolves on Windows. Workspace-relative
   paths used in cache keys and prompt content are normalized to POSIX
-  separators so a cache built on Linux is found on Windows.
+  separators, and line endings are normalized when deriving cache keys, so a
+  cache recorded on Linux/macOS (LF) is found on a Windows checkout (CRLF).

--- a/vscode/core/src/modelProvider/__tests__/cache.test.ts
+++ b/vscode/core/src/modelProvider/__tests__/cache.test.ts
@@ -5,7 +5,7 @@ import * as winston from "winston";
 import { type CacheFilePaths } from "@editor-extensions/agentic";
 import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
 
-import { getCacheForModelProvider } from "../utils";
+import { getCacheForModelProvider, hashFilteredAndSorted } from "../utils";
 
 describe("test FSCacheAndTracer", () => {
   const cacheDir = pathlib.join(__dirname, "_cache");
@@ -56,6 +56,34 @@ describe("test FSCacheAndTracer", () => {
     });
     expect(actualOutput).toBeDefined();
     expect(actualOutput?.content).toBe("world!");
+  });
+
+  it("should produce the same cache key regardless of line endings (#1425)", () => {
+    // A demo cache recorded on Linux/macOS embeds LF file content; a Windows
+    // checkout (autocrlf) reads CRLF. The key must match so Windows hits it.
+    const lf = "package com.redhat.coolstore;\nimport javax.jms.Topic;\npublic class A {}\n";
+    const crlf = lf.replace(/\n/g, "\r\n");
+    const cr = lf.replace(/\n/g, "\r");
+
+    const lfHash = hashFilteredAndSorted([new HumanMessage(lf)]);
+    expect(hashFilteredAndSorted([new HumanMessage(crlf)])).toBe(lfHash);
+    expect(hashFilteredAndSorted([new HumanMessage(cr)])).toBe(lfHash);
+  });
+
+  it("should hit a cache entry written with LF when looked up with CRLF (#1425)", async () => {
+    const fsCache = getCacheForModelProvider(
+      true,
+      winston.createLogger({ silent: true }),
+      cacheDir,
+    );
+    const cacheSubDir = "lineEndings";
+    const lf = "line one\nline two\n";
+    const crlf = lf.replace(/\n/g, "\r\n");
+
+    await fsCache.set([new HumanMessage(lf)], new AIMessage("fixed!"), { cacheSubDir });
+    const hit = await fsCache.get([new HumanMessage(crlf)], { cacheSubDir });
+    expect(hit).toBeDefined();
+    expect(hit?.content).toBe("fixed!");
   });
 
   it("should serialize and deserialize cache data properly when caching list of mixed set of messages", async () => {

--- a/vscode/core/src/modelProvider/utils.ts
+++ b/vscode/core/src/modelProvider/utils.ts
@@ -81,9 +81,37 @@ export function serializeLLMMessages(data: BaseLanguageModelInput | BaseMessage)
 
 export function hashFilteredAndSorted(input: BaseLanguageModelInput | BaseMessage): string {
   return createHash("sha256")
-    .update(JSON.stringify(serializeLLMMessages(input).map(filterFields).map(sortKeys)))
+    .update(
+      JSON.stringify(
+        serializeLLMMessages(input).map(filterFields).map(sortKeys).map(normalizeLineEndings),
+      ),
+    )
     .digest("hex")
     .slice(0, 16);
+}
+
+// Collapse CRLF/CR to LF in every string before hashing so a prompt that embeds
+// file content (e.g. AnalysisIssueFix) produces the same cache key regardless of
+// the OS line endings the file was checked out with. Without this, a Windows
+// checkout (CRLF) misses a demo cache recorded on Linux/macOS (LF) (#1425).
+// Only the cache key is normalized; the stored payload is left byte-for-byte.
+export function normalizeLineEndings<T>(obj: T): T {
+  if (typeof obj === "string") {
+    return obj.replace(/\r\n?/g, "\n") as T;
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(normalizeLineEndings) as T;
+  }
+  if (typeof obj !== "object" || obj === null) {
+    return obj;
+  }
+  const newObj: { [key: string]: any } = {};
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      newObj[key] = normalizeLineEndings((obj as any)[key]);
+    }
+  }
+  return newObj as T;
 }
 
 // Sort keys to ensure consistent hash


### PR DESCRIPTION
## Summary

Three bugs combined to surface as the `Recursion limit of 14 reached` error in agent mode (#1418), and the same scenario also explains the Windows demo-mode cache miss (#1425):

1. **Undersized recursion limit.** The analysis-fix workflow used `recursionLimit: incidentsByUris.length * 2 + 10`. For the `agent_flow_coolstore` scenario (N=2 incident URIs) that is exactly **14** — the number in the error. Raised to `Math.max(50, N * 4 + 20)`.

2. **Router self-loop with no progress guard.** In `analysisIssueFixRouterEdge`, when agent mode was on and additional info never accumulated (LLM produced no Updated File / empty response), the edge looped back to `fix_analysis_issue_router` even after every incident had been processed. The router itself made no progress, so the workflow spun until the recursion limit tripped. Added an explicit `currentIdx < length` check; when all incidents are processed and nothing accumulated, return `END` and warn.

3. **OS-dependent cache key hashes.** `createIncidentsHash` (and several prompt-content sites) used `pathlib.relative(...)`, which returns `\`-separated paths on Windows. The shipped `llm_cache.zip` was built on Linux, so on Windows every cache lookup missed → no cached LLM response → empty response → bug #2 → recursion limit. New helper `toPosixRelative` (in `agentic/src/utils.ts`) normalizes to `/` regardless of host OS; applied to every workspace-relative path that flows into a cache key or LLM prompt.

A fourth fix fell out of the integration test: when the new END branch skips `summarize_additional_information`, `analysisFixOutputState.summarizedAdditionalInfo` is `undefined` and the call site at `interactiveWorkflow.ts:294` crashed. Added a `?? ""` default.

## Regression tests

Three new tests, each verified red-without-fix → green-with-fix by temporarily reverting the corresponding production code:

- `agentic/tests/routerEdge.test.ts` — direct unit test of `analysisIssueFixRouterEdge` for the terminal-no-progress state.
- `agentic/tests/utils.test.ts` — `toPosixRelative` tested with both `path/posix` and `path/win32` so the Windows path-separator behavior is exercised on Linux CI.
- `agentic/tests/interactiveWorkflow.test.ts` — end-to-end run of `KaiInteractiveWorkflow` with a `FakeModelProvider` that emits no Updated File; pre-fix throws `GraphRecursionError: Recursion limit of 14 reached` (the exact issue error), post-fix completes.

## Test plan

- [x] `npm run build --workspace=@editor-extensions/agentic`
- [x] `npm run build --workspace=konveyor-core`
- [x] `npm run lint --workspace=@editor-extensions/agentic` (0 errors)
- [x] `npm test --workspace=@editor-extensions/agentic` — 25 passed, 1 platform-skip
- [x] `node scripts/changelog.js validate`
- [ ] Linux: run `tests/e2e/tests/agent_flow_coolstore.test.ts` (pre-existing Playwright job)
- [ ] Windows: same Playwright test against demo-mode cache (no Windows runner currently — see follow-up)

## Follow-ups / out of scope

- `basename(state.inputFileUri)` in `analysisIssueFix.ts` is also OS-dependent for `C:\foo`-style paths and feeds the LLM cache key. Pre-existing; worth a separate issue.
- A schema-level default on `summarizedAdditionalInfo` would be cleaner than the `?? ""` band-aid but touches more of the state surface.

Fixes #1418
Fixes #1425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Raised the analysis workflow recursion floor to avoid reaching recursion limits on small incident sets and removed a router self-loop when no additional info accumulates.
  * Normalized workspace-relative paths to POSIX form and line endings when generating cache keys to ensure OS-consistent cache behavior.
* **Refactor**
  * Centralized POSIX-relative path handling via a new shared utility used across tools and workflow logic.
* **Tests**
  * Added/updated Jest coverage for interactive workflow execution, routing edge cases, POSIX path normalization, file-search path output, and cache invariance across line endings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->