### PR TITLE
:sparkles: implement provider-specific rule packaging

### DIFF
--- a/changes/unreleased/1440-provider-specific-rule-packaging.yaml
+++ b/changes/unreleased/1440-provider-specific-rule-packaging.yaml
@@ -1,0 +1,4 @@
+kind: enhancement
+description: >
+  Each language extension now bundles and supplies its own stable rulesets
+  instead of all rulesets being bundled in the core extension.

--- a/scripts/collect-assets.js
+++ b/scripts/collect-assets.js
@@ -150,9 +150,8 @@ const actions = [
   }),
 
   // Download and extract seed rulesets from a rulesets repo release.
-  // Supports both the layout introduced in konveyor/rulesets#342 (stable/<lang>/* and preview/*)
-  // and the legacy layout (default/generated/*). Tries the new layout first; falls back to the
-  // legacy one. Throws if neither layout produces any files.
+  // Per-language rulesets are extracted into separate directories for each language extension.
+  // Preview rulesets and legacy fallback go to the core extension's rulesets directory.
   async () => {
     const rulesetConfig = {
       downloadDirectory: join(DOWNLOAD_CACHE, "sources"),
@@ -164,39 +163,63 @@ const actions = [
       globs: ["**/*.yaml", "**/*.yml", "!**/tests/**"],
     };
 
-    try {
-      // Post-konveyor/rulesets#342: rules live in stable/<lang>/* and preview/*
-      const stableMeta = await downloadAndExtractGitHubReleaseSourceCode({
-        ...rulesetConfig,
-        context: "{{root}}/stable",
-      });
+    // Per-language extraction targets
+    const languages = [
+      { name: "java", dir: "rulesets-java" },
+      { name: "nodejs", dir: "rulesets-nodejs" },
+      { name: "dotnet", dir: "rulesets-dotnet" },
+      { name: "go", dir: "rulesets-go" },
+    ];
+
+    let usedNewLayout = false;
+
+    // Try per-language extraction (post-rulesets#342 layout: stable/<lang>/*)
+    for (const lang of languages) {
       try {
         await downloadAndExtractGitHubReleaseSourceCode({
           ...rulesetConfig,
+          targetDirectory: join(DOWNLOAD_DIR, lang.dir),
+          context: `{{root}}/stable/${lang.name}`,
+        });
+        usedNewLayout = true;
+        console.log(`Extracted ${lang.name} rulesets to ${lang.dir}`);
+      } catch (err) {
+        if (!isNoFilesMatchedError(err)) {
+          throw err;
+        }
+        console.warn(`No stable/${lang.name} rulesets found in this release, skipping`);
+      }
+    }
+
+    // Extract preview rulesets into core's rulesets directory
+    if (usedNewLayout) {
+      try {
+        const previewMeta = await downloadAndExtractGitHubReleaseSourceCode({
+          ...rulesetConfig,
           context: "{{root}}/preview",
         });
+        console.log("Extracted preview rulesets to core rulesets directory");
+        return { id: "seed rulesets", meta: previewMeta };
       } catch (err) {
         if (!isNoFilesMatchedError(err)) {
           throw err;
         }
         console.warn("No preview rulesets found in this release, skipping");
+        return { id: "seed rulesets", meta: {} };
       }
-      console.log("Extracted rulesets using post-rulesets#342 layout (stable + preview)");
-      return { id: "seed rulesets", meta: stableMeta };
-    } catch (err) {
-      if (!isNoFilesMatchedError(err)) {
-        throw err;
-      }
-      console.warn(
-        "Post-rulesets#342 layout not found — falling back to pre-rulesets#342 layout (default/generated)",
-      );
-      const meta = await downloadAndExtractGitHubReleaseSourceCode({
-        ...rulesetConfig,
-        context: "{{root}}/default/generated",
-      });
-      console.log("Extracted rulesets using pre-rulesets#342 layout (default/generated)");
-      return { id: "seed rulesets", meta };
     }
+
+    // Legacy fallback: pre-rulesets#342 layout (default/generated/*)
+    // All rulesets go into core's rulesets directory (same as before)
+    console.warn(
+      "Post-rulesets#342 layout not found — falling back to pre-rulesets#342 layout (default/generated)",
+    );
+    const meta = await downloadAndExtractGitHubReleaseSourceCode({
+      ...rulesetConfig,
+      context: "{{root}}/default/generated",
+    });
+    console.log("Extracted rulesets using pre-rulesets#342 layout (default/generated)");
+    return { id: "seed rulesets", meta };
   },
 
   // Extract jdt.ls bundles from the linux-x64_64 downloaded workflow artifact or release asset

--- a/scripts/collect-assets.js
+++ b/scripts/collect-assets.js
@@ -171,9 +171,9 @@ const actions = [
       { name: "go", dir: "rulesets-go" },
     ];
 
-    let usedNewLayout = false;
+    let hasPerLanguageRulesets = false;
 
-    // Try per-language extraction (post-rulesets#342 layout: stable/<lang>/*)
+    // Extract stable rulesets per language from stable/<lang>/*
     for (const lang of languages) {
       try {
         await downloadAndExtractGitHubReleaseSourceCode({
@@ -181,7 +181,7 @@ const actions = [
           targetDirectory: join(DOWNLOAD_DIR, lang.dir),
           context: `{{root}}/stable/${lang.name}`,
         });
-        usedNewLayout = true;
+        hasPerLanguageRulesets = true;
         console.log(`Extracted ${lang.name} rulesets to ${lang.dir}`);
       } catch (err) {
         if (!isNoFilesMatchedError(err)) {
@@ -192,7 +192,7 @@ const actions = [
     }
 
     // Extract preview rulesets into core's rulesets directory
-    if (usedNewLayout) {
+    if (hasPerLanguageRulesets) {
       try {
         const previewMeta = await downloadAndExtractGitHubReleaseSourceCode({
           ...rulesetConfig,
@@ -209,16 +209,16 @@ const actions = [
       }
     }
 
-    // Legacy fallback: pre-rulesets#342 layout (default/generated/*)
+    // Legacy fallback: older releases without stable/<lang>/ layout
     // All rulesets go into core's rulesets directory (same as before)
     console.warn(
-      "Post-rulesets#342 layout not found — falling back to pre-rulesets#342 layout (default/generated)",
+      "No per-language rulesets layout found, falling back to legacy layout (default/generated)",
     );
     const meta = await downloadAndExtractGitHubReleaseSourceCode({
       ...rulesetConfig,
       context: "{{root}}/default/generated",
     });
-    console.log("Extracted rulesets using pre-rulesets#342 layout (default/generated)");
+    console.log("Extracted rulesets using legacy layout (default/generated)");
     return { id: "seed rulesets", meta };
   },
 

--- a/scripts/copy-dist.js
+++ b/scripts/copy-dist.js
@@ -92,7 +92,7 @@ await copy({
       dest: `dist/${CORE_EXTENSION_NAME}/out/webview/`,
     },
 
-    // seed assets - rulesets
+    // seed assets - preview rulesets (stable rulesets are in language extensions)
     {
       context: "downloaded_assets/rulesets",
       src: ["**/*"],
@@ -149,6 +149,7 @@ await copy({
 
         packageJson.includedAssetPaths = {
           javaExternalProvider: "./assets/java-external-provider",
+          rulesets: "./assets/rulesets",
         };
 
         packageJson.contributes.javaExtensions = ["./assets/jdtls-bundles/bundle.jar"];
@@ -186,6 +187,13 @@ await copy({
       src: ["**/*.jar"],
       dest: `dist/${JAVA_EXTENSION_NAME}/assets/jdtls-bundles`,
     },
+
+    // seed assets - java rulesets
+    {
+      context: "downloaded_assets/rulesets-java",
+      src: ["**/*"],
+      dest: `dist/${JAVA_EXTENSION_NAME}/assets/rulesets`,
+    },
   ],
 });
 
@@ -212,6 +220,7 @@ await copy({
 
         packageJson.includedAssetPaths = {
           nodejsExternalProvider: "./assets/nodejs-external-provider",
+          rulesets: "./assets/rulesets",
         };
 
         return JSON.stringify(packageJson, null, 2);
@@ -240,6 +249,13 @@ await copy({
       src: ["*/nodejs-external-provider*"],
       dest: `dist/${JS_EXTENSION_NAME}/assets/nodejs-external-provider`,
     },
+
+    // seed assets - nodejs rulesets
+    {
+      context: "downloaded_assets/rulesets-nodejs",
+      src: ["**/*"],
+      dest: `dist/${JS_EXTENSION_NAME}/assets/rulesets`,
+    },
   ],
 });
 
@@ -267,6 +283,7 @@ await copy({
         packageJson.includedAssetPaths = {
           goExternalProvider: "./assets/go-external-provider",
           konveyorAnalyzerDep: "./assets/konveyor-analyzer-dep",
+          rulesets: "./assets/rulesets",
         };
 
         return JSON.stringify(packageJson, null, 2);
@@ -302,6 +319,13 @@ await copy({
       src: ["*/konveyor-analyzer-dep*"],
       dest: `dist/${GO_EXTENSION_NAME}/assets/konveyor-analyzer-dep`,
     },
+
+    // seed assets - go rulesets
+    {
+      context: "downloaded_assets/rulesets-go",
+      src: ["**/*"],
+      dest: `dist/${GO_EXTENSION_NAME}/assets/rulesets`,
+    },
   ],
 });
 
@@ -328,6 +352,7 @@ await copy({
 
         packageJson.includedAssetPaths = {
           csharpAnalyzerProvider: "./assets/c-sharp-analyzer-provider",
+          rulesets: "./assets/rulesets",
         };
 
         return JSON.stringify(packageJson, null, 2);
@@ -355,6 +380,13 @@ await copy({
       context: "downloaded_assets/c-sharp-analyzer-provider",
       src: ["*/c-sharp-analyzer-provider*"],
       dest: `dist/${CSHARP_EXTENSION_NAME}/assets/c-sharp-analyzer-provider`,
+    },
+
+    // seed assets - dotnet rulesets
+    {
+      context: "downloaded_assets/rulesets-dotnet",
+      src: ["**/*"],
+      dest: `dist/${CSHARP_EXTENSION_NAME}/assets/rulesets`,
     },
   ],
 });

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -6,3 +6,4 @@ export * from "./utils/diffUtils";
 export * from "./api";
 export * from "./healthCheckHelpers";
 export * from "./pipeName";
+export * from "./utils/packagePaths";

--- a/shared/src/utils/packagePaths.ts
+++ b/shared/src/utils/packagePaths.ts
@@ -1,0 +1,14 @@
+/**
+ * Extract the rulesets path from a language extension's package.json.
+ * Throws immediately when the field is missing so packaging bugs are caught early.
+ */
+export function getIncludedRulesetsPath(packageJSON: Record<string, unknown>): string {
+  const paths = packageJSON.includedAssetPaths as Record<string, string> | undefined;
+  const rulesetsPath = paths?.rulesets;
+  if (!rulesetsPath) {
+    throw new Error(
+      "includedAssetPaths.rulesets is missing from package.json — this indicates a packaging bug",
+    );
+  }
+  return rulesetsPath;
+}

--- a/vscode/core/src/api/index.ts
+++ b/vscode/core/src/api/index.ts
@@ -13,6 +13,8 @@ import {
 export class ProviderRegistry {
   private providers: Map<string, ProviderRegistration> = new Map();
   private analysisCompleteEmitter = new vscode.EventEmitter<AnalysisResults>();
+  private providerRegisteredEmitter = new vscode.EventEmitter<ProviderRegistration>();
+  readonly onDidRegisterProvider = this.providerRegisteredEmitter.event;
 
   constructor(
     private logger: Logger,
@@ -41,6 +43,7 @@ export class ProviderRegistry {
     }
 
     this.providers.set(config.name, config);
+    this.providerRegisteredEmitter.fire(config);
     this.updateContextKey();
 
     return new vscode.Disposable(() => {
@@ -88,6 +91,7 @@ export class ProviderRegistry {
       vscode.commands.executeCommand("setContext", `${this.extensionName}.hasProviders`, false);
     }
     this.analysisCompleteEmitter.dispose();
+    this.providerRegisteredEmitter.dispose();
   }
 }
 

--- a/vscode/core/src/client/__tests__/analyzerClient.test.ts
+++ b/vscode/core/src/client/__tests__/analyzerClient.test.ts
@@ -1,0 +1,130 @@
+import expect from "expect";
+
+// Test the getActiveProfileConfig logic in isolation.
+// AnalyzerClient has heavy dependencies (vscode, ChildProcess, etc.),
+// so we reproduce the exact aggregation logic in a testable wrapper.
+class TestableAnalyzerClient {
+  private assetPaths: { rulesets: string };
+  private providerRegistry: { getProviders: () => Array<{ rulesetsPaths: string[] }> };
+  private extStateData: { activeProfileId: string; profiles: any[] };
+
+  constructor(opts: {
+    rulesetsPath: string;
+    providers: Array<{ rulesetsPaths: string[] }>;
+    activeProfileId: string;
+    profiles: any[];
+  }) {
+    this.assetPaths = { rulesets: opts.rulesetsPath };
+    this.providerRegistry = { getProviders: () => opts.providers };
+    this.extStateData = {
+      activeProfileId: opts.activeProfileId,
+      profiles: opts.profiles,
+    };
+  }
+
+  getActiveProfileConfig() {
+    const { activeProfileId, profiles } = this.extStateData;
+    const profile = profiles.find((p: any) => p.id === activeProfileId);
+    if (!profile) {
+      throw new Error("No active profile configured.");
+    }
+
+    const providerRulesets = profile.useDefaultRules
+      ? this.providerRegistry.getProviders().flatMap((p) => p.rulesetsPaths)
+      : [];
+
+    const rulesets: string[] = [
+      profile.useDefaultRules ? this.assetPaths.rulesets : null,
+      ...providerRulesets,
+      ...(profile.customRules || []),
+    ].filter(Boolean) as string[];
+
+    return {
+      labelSelector: profile.labelSelector,
+      rulesets,
+      isValid: !!profile.labelSelector && rulesets.length > 0,
+    };
+  }
+}
+
+describe("getActiveProfileConfig with provider rulesets", () => {
+  const baseProfile = {
+    id: "test-profile",
+    name: "Test",
+    labelSelector: "(konveyor.io/target=quarkus)",
+    useDefaultRules: true,
+    customRules: [],
+  };
+
+  it("should include core + provider rulesets when useDefaultRules is true", () => {
+    const client = new TestableAnalyzerClient({
+      rulesetsPath: "/core/rulesets",
+      providers: [{ rulesetsPaths: ["/java/rulesets"] }, { rulesetsPaths: ["/nodejs/rulesets"] }],
+      activeProfileId: "test-profile",
+      profiles: [{ ...baseProfile, useDefaultRules: true }],
+    });
+
+    const config = client.getActiveProfileConfig();
+    expect(config.rulesets).toEqual(["/core/rulesets", "/java/rulesets", "/nodejs/rulesets"]);
+    expect(config.isValid).toBe(true);
+  });
+
+  it("should exclude core and provider rulesets when useDefaultRules is false", () => {
+    const client = new TestableAnalyzerClient({
+      rulesetsPath: "/core/rulesets",
+      providers: [{ rulesetsPaths: ["/java/rulesets"] }],
+      activeProfileId: "test-profile",
+      profiles: [
+        {
+          ...baseProfile,
+          useDefaultRules: false,
+          customRules: ["/custom/rules"],
+        },
+      ],
+    });
+
+    const config = client.getActiveProfileConfig();
+    expect(config.rulesets).toEqual(["/custom/rules"]);
+  });
+
+  it("should skip providers with empty rulesetsPaths", () => {
+    const client = new TestableAnalyzerClient({
+      rulesetsPath: "/core/rulesets",
+      providers: [{ rulesetsPaths: [] }, { rulesetsPaths: ["/java/rulesets"] }],
+      activeProfileId: "test-profile",
+      profiles: [{ ...baseProfile }],
+    });
+
+    const config = client.getActiveProfileConfig();
+    expect(config.rulesets).toEqual(["/core/rulesets", "/java/rulesets"]);
+  });
+
+  it("should include customRules after provider rulesets", () => {
+    const client = new TestableAnalyzerClient({
+      rulesetsPath: "/core/rulesets",
+      providers: [{ rulesetsPaths: ["/java/rulesets"] }],
+      activeProfileId: "test-profile",
+      profiles: [
+        {
+          ...baseProfile,
+          useDefaultRules: true,
+          customRules: ["/custom/rules"],
+        },
+      ],
+    });
+
+    const config = client.getActiveProfileConfig();
+    expect(config.rulesets).toEqual(["/core/rulesets", "/java/rulesets", "/custom/rules"]);
+  });
+
+  it("should throw when no active profile is found", () => {
+    const client = new TestableAnalyzerClient({
+      rulesetsPath: "/core/rulesets",
+      providers: [],
+      activeProfileId: "nonexistent",
+      profiles: [],
+    });
+
+    expect(() => client.getActiveProfileConfig()).toThrow("No active profile configured.");
+  });
+});

--- a/vscode/core/src/client/__tests__/analyzerClient.test.ts
+++ b/vscode/core/src/client/__tests__/analyzerClient.test.ts
@@ -1,130 +1,41 @@
 import expect from "expect";
+import { buildRulesetsList } from "../rulesets";
 
-// Test the getActiveProfileConfig logic in isolation.
-// AnalyzerClient has heavy dependencies (vscode, ChildProcess, etc.),
-// so we reproduce the exact aggregation logic in a testable wrapper.
-class TestableAnalyzerClient {
-  private assetPaths: { rulesets: string };
-  private providerRegistry: { getProviders: () => Array<{ rulesetsPaths: string[] }> };
-  private extStateData: { activeProfileId: string; profiles: any[] };
-
-  constructor(opts: {
-    rulesetsPath: string;
-    providers: Array<{ rulesetsPaths: string[] }>;
-    activeProfileId: string;
-    profiles: any[];
-  }) {
-    this.assetPaths = { rulesets: opts.rulesetsPath };
-    this.providerRegistry = { getProviders: () => opts.providers };
-    this.extStateData = {
-      activeProfileId: opts.activeProfileId,
-      profiles: opts.profiles,
-    };
-  }
-
-  getActiveProfileConfig() {
-    const { activeProfileId, profiles } = this.extStateData;
-    const profile = profiles.find((p: any) => p.id === activeProfileId);
-    if (!profile) {
-      throw new Error("No active profile configured.");
-    }
-
-    const providerRulesets = profile.useDefaultRules
-      ? this.providerRegistry.getProviders().flatMap((p) => p.rulesetsPaths)
-      : [];
-
-    const rulesets: string[] = [
-      profile.useDefaultRules ? this.assetPaths.rulesets : null,
-      ...providerRulesets,
-      ...(profile.customRules || []),
-    ].filter(Boolean) as string[];
-
-    return {
-      labelSelector: profile.labelSelector,
-      rulesets,
-      isValid: !!profile.labelSelector && rulesets.length > 0,
-    };
-  }
-}
-
-describe("getActiveProfileConfig with provider rulesets", () => {
+describe("buildRulesetsList", () => {
   const baseProfile = {
-    id: "test-profile",
-    name: "Test",
-    labelSelector: "(konveyor.io/target=quarkus)",
     useDefaultRules: true,
-    customRules: [],
+    customRules: [] as string[],
   };
 
   it("should include core + provider rulesets when useDefaultRules is true", () => {
-    const client = new TestableAnalyzerClient({
-      rulesetsPath: "/core/rulesets",
-      providers: [{ rulesetsPaths: ["/java/rulesets"] }, { rulesetsPaths: ["/nodejs/rulesets"] }],
-      activeProfileId: "test-profile",
-      profiles: [{ ...baseProfile, useDefaultRules: true }],
-    });
-
-    const config = client.getActiveProfileConfig();
-    expect(config.rulesets).toEqual(["/core/rulesets", "/java/rulesets", "/nodejs/rulesets"]);
-    expect(config.isValid).toBe(true);
+    const rulesets = buildRulesetsList(
+      { ...baseProfile, useDefaultRules: true },
+      "/core/rulesets",
+      ["/java/rulesets", "/nodejs/rulesets"],
+    );
+    expect(rulesets).toEqual(["/core/rulesets", "/java/rulesets", "/nodejs/rulesets"]);
   });
 
   it("should exclude core and provider rulesets when useDefaultRules is false", () => {
-    const client = new TestableAnalyzerClient({
-      rulesetsPath: "/core/rulesets",
-      providers: [{ rulesetsPaths: ["/java/rulesets"] }],
-      activeProfileId: "test-profile",
-      profiles: [
-        {
-          ...baseProfile,
-          useDefaultRules: false,
-          customRules: ["/custom/rules"],
-        },
-      ],
-    });
-
-    const config = client.getActiveProfileConfig();
-    expect(config.rulesets).toEqual(["/custom/rules"]);
+    const rulesets = buildRulesetsList(
+      { ...baseProfile, useDefaultRules: false, customRules: ["/custom/rules"] },
+      "/core/rulesets",
+      ["/java/rulesets"],
+    );
+    expect(rulesets).toEqual(["/custom/rules"]);
   });
 
   it("should skip providers with empty rulesetsPaths", () => {
-    const client = new TestableAnalyzerClient({
-      rulesetsPath: "/core/rulesets",
-      providers: [{ rulesetsPaths: [] }, { rulesetsPaths: ["/java/rulesets"] }],
-      activeProfileId: "test-profile",
-      profiles: [{ ...baseProfile }],
-    });
-
-    const config = client.getActiveProfileConfig();
-    expect(config.rulesets).toEqual(["/core/rulesets", "/java/rulesets"]);
+    const rulesets = buildRulesetsList({ ...baseProfile }, "/core/rulesets", ["/java/rulesets"]);
+    expect(rulesets).toEqual(["/core/rulesets", "/java/rulesets"]);
   });
 
   it("should include customRules after provider rulesets", () => {
-    const client = new TestableAnalyzerClient({
-      rulesetsPath: "/core/rulesets",
-      providers: [{ rulesetsPaths: ["/java/rulesets"] }],
-      activeProfileId: "test-profile",
-      profiles: [
-        {
-          ...baseProfile,
-          useDefaultRules: true,
-          customRules: ["/custom/rules"],
-        },
-      ],
-    });
-
-    const config = client.getActiveProfileConfig();
-    expect(config.rulesets).toEqual(["/core/rulesets", "/java/rulesets", "/custom/rules"]);
-  });
-
-  it("should throw when no active profile is found", () => {
-    const client = new TestableAnalyzerClient({
-      rulesetsPath: "/core/rulesets",
-      providers: [],
-      activeProfileId: "nonexistent",
-      profiles: [],
-    });
-
-    expect(() => client.getActiveProfileConfig()).toThrow("No active profile configured.");
+    const rulesets = buildRulesetsList(
+      { ...baseProfile, useDefaultRules: true, customRules: ["/custom/rules"] },
+      "/core/rulesets",
+      ["/java/rulesets"],
+    );
+    expect(rulesets).toEqual(["/core/rulesets", "/java/rulesets", "/custom/rules"]);
   });
 });

--- a/vscode/core/src/client/analyzerClient.ts
+++ b/vscode/core/src/client/analyzerClient.ts
@@ -763,8 +763,13 @@ export class AnalyzerClient {
       throw new Error("No active profile configured.");
     }
 
+    const providerRulesets = profile.useDefaultRules
+      ? this.providerRegistry.getProviders().flatMap((p) => p.rulesetsPaths)
+      : [];
+
     const rulesets: string[] = [
       profile.useDefaultRules ? this.assetPaths.rulesets : null,
+      ...providerRulesets,
       ...(profile.customRules || []),
     ].filter(Boolean) as string[];
 

--- a/vscode/core/src/client/analyzerClient.ts
+++ b/vscode/core/src/client/analyzerClient.ts
@@ -32,6 +32,7 @@ import { TaskManager } from "src/taskManager/types";
 import { Logger } from "winston";
 import { executeExtensionCommand } from "../commands";
 import { ProviderRegistry } from "../api";
+import { buildRulesetsList } from "./rulesets";
 
 export class AnalyzerClient {
   // Progress percentage ranges for each stage
@@ -767,11 +768,7 @@ export class AnalyzerClient {
       ? this.providerRegistry.getProviders().flatMap((p) => p.rulesetsPaths)
       : [];
 
-    const rulesets: string[] = [
-      profile.useDefaultRules ? this.assetPaths.rulesets : null,
-      ...providerRulesets,
-      ...(profile.customRules || []),
-    ].filter(Boolean) as string[];
+    const rulesets = buildRulesetsList(profile, this.assetPaths.rulesets, providerRulesets);
 
     return {
       labelSelector: profile.labelSelector,

--- a/vscode/core/src/client/rulesets.ts
+++ b/vscode/core/src/client/rulesets.ts
@@ -1,0 +1,11 @@
+export function buildRulesetsList(
+  profile: { useDefaultRules: boolean; customRules: readonly string[] },
+  coreRulesetsPath: string,
+  providerRulesets: string[],
+): string[] {
+  return [
+    profile.useDefaultRules ? coreRulesetsPath : null,
+    ...(profile.useDefaultRules ? providerRulesets : []),
+    ...(profile.customRules || []),
+  ].filter(Boolean) as string[];
+}

--- a/vscode/core/src/extension.ts
+++ b/vscode/core/src/extension.ts
@@ -502,15 +502,23 @@ class VsCodeExtension {
         ...this.providerRegistry.getProviders().flatMap((p) => p.rulesetsPaths),
       ];
 
+      let labelDiscoveryRunId = 0;
       const runLabelDiscovery = () => {
+        const runId = ++labelDiscoveryRunId;
         discoverLabels(getAllRulesetsDirs()).then(
           (discoveredLabels) => {
+            if (runId !== labelDiscoveryRunId) {
+              return;
+            }
             this.state.mutateSettings((draft) => {
               draft.availableTargets = discoveredLabels.targets;
               draft.availableSources = discoveredLabels.sources;
             });
           },
           (err) => {
+            if (runId !== labelDiscoveryRunId) {
+              return;
+            }
             this.state.logger.warn(`Failed to discover labels from rulesets: ${err}`);
           },
         );

--- a/vscode/core/src/extension.ts
+++ b/vscode/core/src/extension.ts
@@ -83,7 +83,7 @@ class VsCodeExtension {
     public readonly paths: ExtensionPaths,
     public readonly context: vscode.ExtensionContext,
     logger: winston.Logger,
-    providerRegistry: ProviderRegistry,
+    private readonly providerRegistry: ProviderRegistry,
     private readonly healthCheckRegistry: HealthCheckRegistry,
   ) {
     this.diffStatusBarItem = vscode.window.createStatusBarItem(
@@ -497,16 +497,35 @@ class VsCodeExtension {
       });
 
       // Discover available target/source labels from bundled rulesets (non-blocking)
-      discoverLabels(this.state.analyzerClient.rulesetsPath).then(
-        (discoveredLabels) => {
-          this.state.mutateSettings((draft) => {
-            draft.availableTargets = discoveredLabels.targets;
-            draft.availableSources = discoveredLabels.sources;
-          });
-        },
-        (err) => {
-          this.state.logger.warn(`Failed to discover labels from rulesets: ${err}`);
-        },
+      const getAllRulesetsDirs = () => [
+        this.state.analyzerClient.rulesetsPath,
+        ...this.providerRegistry.getProviders().flatMap((p) => p.rulesetsPaths),
+      ];
+
+      const runLabelDiscovery = () => {
+        discoverLabels(getAllRulesetsDirs()).then(
+          (discoveredLabels) => {
+            this.state.mutateSettings((draft) => {
+              draft.availableTargets = discoveredLabels.targets;
+              draft.availableSources = discoveredLabels.sources;
+            });
+          },
+          (err) => {
+            this.state.logger.warn(`Failed to discover labels from rulesets: ${err}`);
+          },
+        );
+      };
+
+      // Initial discovery with core rulesets
+      runLabelDiscovery();
+
+      // Re-discover when providers with rulesets register
+      this.context.subscriptions.push(
+        this.providerRegistry.onDidRegisterProvider((provider) => {
+          if (provider.rulesetsPaths.length > 0) {
+            runLabelDiscovery();
+          }
+        }),
       );
 
       const allProfiles = await getAllProfiles(this.context);

--- a/vscode/core/src/utilities/labels/__tests__/discoverLabels.test.ts
+++ b/vscode/core/src/utilities/labels/__tests__/discoverLabels.test.ts
@@ -16,12 +16,12 @@ describe("discoverLabels", () => {
   });
 
   it("should return empty arrays when directory does not exist", async () => {
-    const result = await discoverLabels(path.join(tempDir, "nonexistent"));
+    const result = await discoverLabels([path.join(tempDir, "nonexistent")]);
     expect(result).toEqual({ targets: [], sources: [] });
   });
 
   it("should return empty arrays when directory has no yaml files", async () => {
-    const result = await discoverLabels(tempDir);
+    const result = await discoverLabels([tempDir]);
     expect(result).toEqual({ targets: [], sources: [] });
   });
 
@@ -34,7 +34,7 @@ describe("discoverLabels", () => {
 `,
     );
 
-    const result = await discoverLabels(tempDir);
+    const result = await discoverLabels([tempDir]);
     expect(result.targets).toEqual(["quarkus"]);
     expect(result.sources).toEqual(["java-ee"]);
   });
@@ -55,7 +55,7 @@ describe("discoverLabels", () => {
 `,
     );
 
-    const result = await discoverLabels(tempDir);
+    const result = await discoverLabels([tempDir]);
     expect(result.targets).toEqual(["quarkus"]);
     expect(result.sources).toEqual(["eap", "java-ee"]);
   });
@@ -71,7 +71,7 @@ describe("discoverLabels", () => {
 `,
     );
 
-    const result = await discoverLabels(tempDir);
+    const result = await discoverLabels([tempDir]);
     expect(result.targets).toEqual(["spring-boot3+", "spring6+"]);
     expect(result.sources).toEqual(["eap7.0-", "spring-boot2"]);
   });
@@ -86,7 +86,7 @@ describe("discoverLabels", () => {
 `,
     );
 
-    const result = await discoverLabels(tempDir);
+    const result = await discoverLabels([tempDir]);
     expect(result.targets).toEqual(["azure-aks", "eap8", "quarkus"]);
   });
 
@@ -100,8 +100,52 @@ describe("discoverLabels", () => {
 `,
     );
 
-    const result = await discoverLabels(tempDir);
+    const result = await discoverLabels([tempDir]);
     expect(result.targets).toEqual(["spring-boot3+"]);
+  });
+
+  it("should merge labels from multiple directories", async () => {
+    const dir1 = path.join(tempDir, "java-rules");
+    const dir2 = path.join(tempDir, "nodejs-rules");
+    await fs.mkdir(dir1, { recursive: true });
+    await fs.mkdir(dir2, { recursive: true });
+
+    await fs.writeFile(
+      path.join(dir1, "rule.yaml"),
+      `- labels:
+    - konveyor.io/target=quarkus
+    - konveyor.io/source=java-ee
+`,
+    );
+    await fs.writeFile(
+      path.join(dir2, "rule.yaml"),
+      `- labels:
+    - konveyor.io/target=nodejs18+
+    - konveyor.io/source=nodejs16
+`,
+    );
+
+    const result = await discoverLabels([dir1, dir2]);
+    expect(result.targets).toEqual(["nodejs18+", "quarkus"]);
+    expect(result.sources).toEqual(["java-ee", "nodejs16"]);
+  });
+
+  it("should handle mix of existing and non-existent directories", async () => {
+    await fs.writeFile(
+      path.join(tempDir, "rule.yaml"),
+      `- labels:
+    - konveyor.io/target=eap8
+`,
+    );
+
+    const result = await discoverLabels([tempDir, path.join(tempDir, "nonexistent")]);
+    expect(result.targets).toEqual(["eap8"]);
+    expect(result.sources).toEqual([]);
+  });
+
+  it("should return empty arrays for empty input", async () => {
+    const result = await discoverLabels([]);
+    expect(result).toEqual({ targets: [], sources: [] });
   });
 });
 
@@ -156,7 +200,7 @@ describe("discoverLabels against real rulesets", () => {
       }
     }
 
-    const result = await discoverLabels(rulesetsDir);
+    const result = await discoverLabels([rulesetsDir]);
 
     const discoveredTargetSet = new Set(result.targets);
     const discoveredSourceSet = new Set(result.sources);

--- a/vscode/core/src/utilities/labels/__tests__/discoverLabels.test.ts
+++ b/vscode/core/src/utilities/labels/__tests__/discoverLabels.test.ts
@@ -150,21 +150,30 @@ describe("discoverLabels", () => {
 });
 
 describe("discoverLabels against real rulesets", () => {
-  const rulesetsDir = path.resolve(__dirname, "../../../../../../downloaded_assets/rulesets");
+  const assetsDir = path.resolve(__dirname, "../../../../../../downloaded_assets");
+  const rulesetsDirs = [
+    path.join(assetsDir, "rulesets"),
+    path.join(assetsDir, "rulesets-java"),
+    path.join(assetsDir, "rulesets-nodejs"),
+    path.join(assetsDir, "rulesets-dotnet"),
+    path.join(assetsDir, "rulesets-go"),
+  ];
 
-  let rulesetsExist = false;
+  const existingDirs: string[] = [];
 
   before(async () => {
-    try {
-      await fs.access(rulesetsDir);
-      rulesetsExist = true;
-    } catch {
-      rulesetsExist = false;
+    for (const dir of rulesetsDirs) {
+      try {
+        await fs.access(dir);
+        existingDirs.push(dir);
+      } catch {
+        // skip non-existent directories
+      }
     }
   });
 
   it("should discover the same labels as a naive line-by-line scan", async function (this: Mocha.Context) {
-    if (!rulesetsExist) {
+    if (existingDirs.length === 0) {
       this.skip();
     }
 
@@ -175,32 +184,32 @@ describe("discoverLabels against real rulesets", () => {
     const refTargets = new Set<string>();
     const refSources = new Set<string>();
 
-    const dirEntries = await fs.readdir(rulesetsDir, { recursive: true });
-    const yamlFiles = dirEntries
-      .filter((e) => e.endsWith(".yaml"))
-      .map((e) => path.join(rulesetsDir, e));
+    for (const dir of existingDirs) {
+      const dirEntries = await fs.readdir(dir, { recursive: true });
+      const yamlFiles = dirEntries.filter((e) => e.endsWith(".yaml")).map((e) => path.join(dir, e));
 
-    for (const file of yamlFiles) {
-      let content: string;
-      try {
-        content = await fs.readFile(file, "utf-8");
-      } catch {
-        continue; // skip directories or unreadable entries
-      }
-      const lines = content.split("\n");
-      for (const line of lines) {
-        const tm = line.match(TARGET_RE);
-        if (tm) {
-          refTargets.add(tm[1]);
+      for (const file of yamlFiles) {
+        let content: string;
+        try {
+          content = await fs.readFile(file, "utf-8");
+        } catch {
+          continue;
         }
-        const sm = line.match(SOURCE_RE);
-        if (sm) {
-          refSources.add(sm[1]);
+        const lines = content.split("\n");
+        for (const line of lines) {
+          const tm = line.match(TARGET_RE);
+          if (tm) {
+            refTargets.add(tm[1]);
+          }
+          const sm = line.match(SOURCE_RE);
+          if (sm) {
+            refSources.add(sm[1]);
+          }
         }
       }
     }
 
-    const result = await discoverLabels([rulesetsDir]);
+    const result = await discoverLabels(existingDirs);
 
     const discoveredTargetSet = new Set(result.targets);
     const discoveredSourceSet = new Set(result.sources);

--- a/vscode/core/src/utilities/labels/discoverLabels.ts
+++ b/vscode/core/src/utilities/labels/discoverLabels.ts
@@ -9,35 +9,33 @@ export interface DiscoveredLabels {
 }
 
 /**
- * Scan all YAML rule files in the given rulesets directory and extract
+ * Scan all YAML rule files in the given rulesets directories and extract
  * unique `konveyor.io/target` and `konveyor.io/source` label values.
  */
-export async function discoverLabels(rulesetsDir: string): Promise<DiscoveredLabels> {
-  let entries: string[];
-  try {
-    const dirEntries = await readdir(rulesetsDir, { recursive: true });
-    entries = dirEntries.filter((e) => e.endsWith(".yaml")).map((e) => join(rulesetsDir, e));
-  } catch {
-    return { targets: [], sources: [] };
-  }
-
-  if (entries.length === 0) {
-    return { targets: [], sources: [] };
-  }
-
+export async function discoverLabels(rulesetsDirs: string[]): Promise<DiscoveredLabels> {
   const targets = new Set<string>();
   const sources = new Set<string>();
 
-  const contents = await Promise.all(entries.map((f) => readFile(f, "utf-8").catch(() => "")));
+  for (const rulesetsDir of rulesetsDirs) {
+    let entries: string[];
+    try {
+      const dirEntries = await readdir(rulesetsDir, { recursive: true });
+      entries = dirEntries.filter((e) => e.endsWith(".yaml")).map((e) => join(rulesetsDir, e));
+    } catch {
+      continue;
+    }
 
-  for (const content of contents) {
-    for (const match of content.matchAll(LABEL_PATTERN)) {
-      const kind = match[1];
-      const value = match[2];
-      if (kind === "target") {
-        targets.add(value);
-      } else {
-        sources.add(value);
+    const contents = await Promise.all(entries.map((f) => readFile(f, "utf-8").catch(() => "")));
+
+    for (const content of contents) {
+      for (const match of content.matchAll(LABEL_PATTERN)) {
+        const kind = match[1];
+        const value = match[2];
+        if (kind === "target") {
+          targets.add(value);
+        } else {
+          sources.add(value);
+        }
       }
     }
   }

--- a/vscode/csharp/package.json
+++ b/vscode/csharp/package.json
@@ -43,7 +43,8 @@
   ],
   "contributes": {},
   "includedAssetPaths": {
-    "csharpAnalyzerProvider": "../../downloaded_assets/c-sharp-analyzer-provider"
+    "csharpAnalyzerProvider": "../../downloaded_assets/c-sharp-analyzer-provider",
+    "rulesets": "../../downloaded_assets/rulesets-dotnet"
   },
   "scripts": {
     "clean": "rimraf out",

--- a/vscode/csharp/src/extension.ts
+++ b/vscode/csharp/src/extension.ts
@@ -169,8 +169,10 @@ export async function activate(context: vscode.ExtensionContext) {
       contextLines: 10,
     },
     rulesetsPaths: [
-      // In Phase 1, rulesets are still in core extension
-      // Will be moved to C# extension in later phase if needed
+      context.asAbsolutePath(
+        context.extension.packageJSON.includedAssetPaths?.rulesets ??
+          "../../downloaded_assets/rulesets-dotnet",
+      ),
     ],
   });
 

--- a/vscode/csharp/src/extension.ts
+++ b/vscode/csharp/src/extension.ts
@@ -4,7 +4,11 @@ import * as path from "node:path";
 import * as fs from "node:fs";
 import winston from "winston";
 import { OutputChannelTransport } from "winston-transport-vscode";
-import { type KonveyorCoreApi, generateSafePipeName } from "@editor-extensions/shared";
+import {
+  type KonveyorCoreApi,
+  generateSafePipeName,
+  getIncludedRulesetsPath,
+} from "@editor-extensions/shared";
 import { CSharpExternalProviderManager } from "./csharpExternalProviderManager";
 import {
   CORE_EXTENSION_ID,
@@ -168,12 +172,7 @@ export async function activate(context: vscode.ExtensionContext) {
       ],
       contextLines: 10,
     },
-    rulesetsPaths: [
-      context.asAbsolutePath(
-        context.extension.packageJSON.includedAssetPaths?.rulesets ??
-          "../../downloaded_assets/rulesets-dotnet",
-      ),
-    ],
+    rulesetsPaths: [context.asAbsolutePath(getIncludedRulesetsPath(context.extension.packageJSON))],
   });
 
   context.subscriptions.push(providerDisposable);

--- a/vscode/go/package.json
+++ b/vscode/go/package.json
@@ -46,7 +46,8 @@
   "contributes": {},
   "includedAssetPaths": {
     "goExternalProvider": "../../downloaded_assets/go-external-provider",
-    "konveyorAnalyzerDep": "../../downloaded_assets/konveyor-analyzer-dep"
+    "konveyorAnalyzerDep": "../../downloaded_assets/konveyor-analyzer-dep",
+    "rulesets": "../../downloaded_assets/rulesets-go"
   },
   "scripts": {
     "clean": "rimraf out",

--- a/vscode/go/src/extension.ts
+++ b/vscode/go/src/extension.ts
@@ -181,8 +181,10 @@ export async function activate(context: vscode.ExtensionContext) {
       contextLines: 10,
     },
     rulesetsPaths: [
-      // In Phase 1, rulesets are still in core extension
-      // Will be moved to Go extension in later phase
+      context.asAbsolutePath(
+        context.extension.packageJSON.includedAssetPaths?.rulesets ??
+          "../../downloaded_assets/rulesets-go",
+      ),
     ],
   });
 

--- a/vscode/go/src/extension.ts
+++ b/vscode/go/src/extension.ts
@@ -2,7 +2,11 @@ import * as vscode from "vscode";
 import { exec } from "node:child_process";
 import winston from "winston";
 import { OutputChannelTransport } from "winston-transport-vscode";
-import { type KonveyorCoreApi, generateSafePipeName } from "@editor-extensions/shared";
+import {
+  type KonveyorCoreApi,
+  generateSafePipeName,
+  getIncludedRulesetsPath,
+} from "@editor-extensions/shared";
 import { GoVscodeProxyServer } from "./goVscodeProxyServer";
 import { GoExternalProviderManager } from "./goExternalProviderManager";
 import {
@@ -180,12 +184,7 @@ export async function activate(context: vscode.ExtensionContext) {
       ],
       contextLines: 10,
     },
-    rulesetsPaths: [
-      context.asAbsolutePath(
-        context.extension.packageJSON.includedAssetPaths?.rulesets ??
-          "../../downloaded_assets/rulesets-go",
-      ),
-    ],
+    rulesetsPaths: [context.asAbsolutePath(getIncludedRulesetsPath(context.extension.packageJSON))],
   });
 
   context.subscriptions.push(providerDisposable);

--- a/vscode/java/package.json
+++ b/vscode/java/package.json
@@ -53,7 +53,8 @@
     ]
   },
   "includedAssetPaths": {
-    "javaExternalProvider": "../../downloaded_assets/java-external-provider"
+    "javaExternalProvider": "../../downloaded_assets/java-external-provider",
+    "rulesets": "../../downloaded_assets/rulesets-java"
   },
   "scripts": {
     "clean": "rimraf out",

--- a/vscode/java/src/extension.ts
+++ b/vscode/java/src/extension.ts
@@ -356,8 +356,10 @@ async function initializeProviders(
       contextLines: 10,
     },
     rulesetsPaths: [
-      // In Phase 1, rulesets are still in core extension
-      // Will be moved to java extension in later phase
+      context.asAbsolutePath(
+        context.extension.packageJSON.includedAssetPaths?.rulesets ??
+          "../../downloaded_assets/rulesets-java",
+      ),
     ],
   });
 

--- a/vscode/java/src/extension.ts
+++ b/vscode/java/src/extension.ts
@@ -1,7 +1,11 @@
 import * as vscode from "vscode";
 import winston from "winston";
 import { OutputChannelTransport } from "winston-transport-vscode";
-import { KonveyorCoreApi, generateSafePipeName } from "@editor-extensions/shared";
+import {
+  KonveyorCoreApi,
+  generateSafePipeName,
+  getIncludedRulesetsPath,
+} from "@editor-extensions/shared";
 import {
   CORE_EXTENSION_ID,
   EXTENSION_DISPLAY_NAME,
@@ -355,12 +359,7 @@ async function initializeProviders(
       ],
       contextLines: 10,
     },
-    rulesetsPaths: [
-      context.asAbsolutePath(
-        context.extension.packageJSON.includedAssetPaths?.rulesets ??
-          "../../downloaded_assets/rulesets-java",
-      ),
-    ],
+    rulesetsPaths: [context.asAbsolutePath(getIncludedRulesetsPath(context.extension.packageJSON))],
   });
 
   context.subscriptions.push(providerDisposable);

--- a/vscode/javascript/package.json
+++ b/vscode/javascript/package.json
@@ -45,7 +45,8 @@
   ],
   "contributes": {},
   "includedAssetPaths": {
-    "nodejsExternalProvider": "../../downloaded_assets/nodejs-external-provider"
+    "nodejsExternalProvider": "../../downloaded_assets/nodejs-external-provider",
+    "rulesets": "../../downloaded_assets/rulesets-nodejs"
   },
   "scripts": {
     "clean": "rimraf out",

--- a/vscode/javascript/src/extension.ts
+++ b/vscode/javascript/src/extension.ts
@@ -177,8 +177,10 @@ export async function activate(context: vscode.ExtensionContext) {
       contextLines: 10,
     },
     rulesetsPaths: [
-      // In Phase 1, rulesets are still in core extension
-      // Will be moved to JavaScript extension in later phase
+      context.asAbsolutePath(
+        context.extension.packageJSON.includedAssetPaths?.rulesets ??
+          "../../downloaded_assets/rulesets-nodejs",
+      ),
     ],
   });
 

--- a/vscode/javascript/src/extension.ts
+++ b/vscode/javascript/src/extension.ts
@@ -1,7 +1,11 @@
 import * as vscode from "vscode";
 import winston from "winston";
 import { OutputChannelTransport } from "winston-transport-vscode";
-import { KonveyorCoreApi, generateSafePipeName } from "@editor-extensions/shared";
+import {
+  KonveyorCoreApi,
+  generateSafePipeName,
+  getIncludedRulesetsPath,
+} from "@editor-extensions/shared";
 import {
   CORE_EXTENSION_ID,
   EXTENSION_DISPLAY_NAME,
@@ -176,12 +180,7 @@ export async function activate(context: vscode.ExtensionContext) {
       ],
       contextLines: 10,
     },
-    rulesetsPaths: [
-      context.asAbsolutePath(
-        context.extension.packageJSON.includedAssetPaths?.rulesets ??
-          "../../downloaded_assets/rulesets-nodejs",
-      ),
-    ],
+    rulesetsPaths: [context.asAbsolutePath(getIncludedRulesetsPath(context.extension.packageJSON))],
   });
 
   context.subscriptions.push(providerDisposable);


### PR DESCRIPTION
Move from bundling all rulesets in core to each language extension supplying its own stable rulesets. Per-language extraction in collect-assets.js, per-language packaging in copy-dist.js, provider rulesets aggregation in analyzerClient, and re-discovery of labels on provider registration.

Refs: #1426

Assisted-by: Claude Code (claude-opus-4-6)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an event that notifies when a provider is registered.
* **Improvements**
  * Stable rulesets are now bundled by each language extension; preview rulesets are also included in the packaged output.
  * Analyzer configuration can aggregate rulesets from all registered providers (when default rules are enabled).
  * Label discovery now scans multiple ruleset directories and refreshes when new providers contribute rulesets.
* **Tests**
  * Added/updated coverage for active profile ruleset aggregation and multi-directory label discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->