### PR TITLE
:bug: Fix E2E tests using wrong ref during patch releases

### DIFF
--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -230,6 +230,7 @@ jobs:
     with:
       vsix_artifact_name: "vsix-artifacts"
       trigger_context: ${{ github.event_name == 'pull_request' && 'pr' || 'manual' }}
+      ref: ${{ github.sha }}
       use_release: ${{ startsWith(github.base_ref, 'release-') || startsWith(github.ref_name, 'release-') }}
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,6 +9,11 @@ on:
       trigger_context:
         required: true
         type: string # 'pr', 'release', 'manual'
+      ref:
+        description: "Git ref to checkout for tests (must match the ref used to build the VSIX)"
+        required: false
+        type: string
+        default: ""
       use_release:
         required: false
         type: boolean
@@ -31,6 +36,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -101,6 +108,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup test environment
         uses: ./.github/actions/setup-test-environment
@@ -160,6 +169,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup test environment
         uses: ./.github/actions/setup-test-environment
@@ -220,6 +231,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup test environment
         uses: ./.github/actions/setup-test-environment
@@ -272,6 +285,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup test environment
         uses: ./.github/actions/setup-test-environment
@@ -325,6 +340,10 @@ jobs:
     # migrated off keycloak. Releases still gate on this.
     continue-on-error: ${{ inputs.trigger_context == 'pr' }}
     steps:
+      # Infrastructure tests intentionally do NOT use inputs.ref here.
+      # The Konveyor Hub is always deployed at @main, so the infra setup
+      # scripts (seed-hub.sh, auth helpers) and test code must come from
+      # main to stay compatible with the deployed Hub's auth endpoints.
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,7 @@ jobs:
     with:
       vsix_artifact_name: "vsix-artifacts"
       trigger_context: "release"
+      ref: ${{ inputs.ref }}
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 

--- a/changes/unreleased/fix-e2e-ref-mismatch.yaml
+++ b/changes/unreleased/fix-e2e-ref-mismatch.yaml
@@ -1,0 +1,3 @@
+kind: bugfix
+description: >
+  Fixed E2E tests checking out main instead of the release branch during patch releases, causing test-code/extension-code version mismatches.


### PR DESCRIPTION
## Summary

The `e2e-tests.yml` reusable workflow did not accept a `ref` input, so every `actions/checkout@v4` defaulted to the top-level trigger's ref. During patch releases dispatched from `main`, test code came from `main` while the VSIX was built from the release branch.

After PR #1419 (OIDC auth) landed on `main`, the test page object expected UI elements not present in `release-0.4`, causing all `@requires-minikube` tests to time out and block the release.

**Failed run:** https://github.com/konveyor/editor-extensions/actions/runs/27542475621
**Tracking issue for full solution:** #1444

## Changes

### 1. Thread `ref` through the E2E workflow

- **`e2e-tests.yml`**: New `ref` input. Setup and tier0-3 checkout steps use `ref: ${{ inputs.ref || github.sha }}`.
- **`release.yml`**: Passes `ref: ${{ inputs.ref }}` (e.g., `release-0.4`).
- **`ci-repo.yml`**: Passes `ref: ${{ github.sha }}`.

### 2. Skip infrastructure tests for release branches

Infrastructure tests are skipped entirely (`if: ${{ !startsWith(inputs.ref, 'release-') }}`) for release branches. The Hub is always deployed from `@main`, so seed scripts, auth helpers, and test code must all come from `main`. When the release-branch extension doesn't speak the current Hub's auth protocol, these tests cannot pass. See #1444 for the longer-term fix (version-pinned Hub deployment).

The existing `continue-on-error` for PRs is unchanged.

## Why this unblocks 0.4

| Job | Checkout ref | Result |
|---|---|---|
| tier0-3 | `release-0.4` (test code matches VSIX) | Pass |
| Infrastructure | Skipped (release branch) | N/A |

tier0-3 already passed with `main` test code in the failed run. With `release-0.4` test code (a subset of `main`), they will continue to pass.

## Scenario analysis

| Scenario | `inputs.ref` | tier0-3 checkout | Infra runs? |
|---|---|---|---|
| Patch release (`release-0.4`) | `release-0.4` | `release-0.4` | Skipped |
| Pre-release / cut release | `main` | `main` | Yes |
| CI push to `main` | `github.sha` | `main` HEAD | Yes |
| CI PR | `github.sha` | merge commit | Yes (continue-on-error) |

## Test plan

- CI on this PR: `ref` = `github.sha`, same as current behavior
- After merge, re-run patch release for `release-0.4`