### PR TITLE
:bug: Show absolute date for token expiry over 24 hours

### DIFF
--- a/changes/unreleased/1451-token-expiry-display.yaml
+++ b/changes/unreleased/1451-token-expiry-display.yaml
@@ -1,0 +1,4 @@
+kind: bugfix
+description: >
+  Show absolute date for token expiry over 24 hours instead of unrealistic
+  hour count (e.g. "on Jun 17, 2036" instead of "in 87599h 59m").

--- a/webview-ui/src/components/HubSettings/HubConnectionStatus.tsx
+++ b/webview-ui/src/components/HubSettings/HubConnectionStatus.tsx
@@ -33,6 +33,10 @@ function formatRelativeTime(epochMs: number): string {
   const minutes = Math.floor(diff / 60000);
   const hours = Math.floor(minutes / 60);
 
+  if (hours >= 24) {
+    const date = new Date(epochMs);
+    return `on ${date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}`;
+  }
   if (hours > 0) {
     return `in ${hours}h ${minutes % 60}m`;
   }


### PR DESCRIPTION
## Summary

- Long-lived tokens (e.g. 10-year PATs from OIDC exchange) displayed expiry as "87599h 59m" which is meaningless
- For tokens expiring more than 24h out, now shows a locale-formatted absolute date (e.g. "Token expires on Jun 17, 2036")
- Tokens under 24h keep the existing countdown format ("in 8h 30m", "in 45m", "expiring soon")

> **Note:** The hardcoded 10-year PAT lifespan (`PAT_LIFESPAN_HOURS = 87600` in `HubConnectionManager.ts`) may also warrant revisiting — it's not configurable and a shorter default with refresh could be more appropriate.

Closes #1451

## Test plan

- [ ] Verify token expiry > 24h displays as absolute date (e.g. "on Jun 17, 2036")
- [ ] Verify token expiry < 24h still shows relative time ("in 8h 30m")
- [ ] Verify token expiry < 1 minute shows "expiring soon"
- [ ] Verify expired token shows "expired"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token expiry times now display as calendar dates (e.g., "on January 15") when expiring 24 hours or later, instead of relative countdown format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->