### PR TITLE
:sparkles: Replace hand-rolled OIDC with oauth4webapi

### DIFF
--- a/changes/unreleased/1453-oidc-oauth4webapi.yaml
+++ b/changes/unreleased/1453-oidc-oauth4webapi.yaml
@@ -1,0 +1,5 @@
+kind: enhancement
+description: >
+  Replace hand-rolled OIDC implementation with oauth4webapi for spec-compliant
+  discovery, token exchange, refresh, and end-session. Sign-out now properly
+  invalidates the server-side OIDC session.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1321,7 +1321,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1852,8 +1851,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
@@ -1952,7 +1950,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1976,7 +1973,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2007,6 +2003,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
       "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -2035,6 +2032,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
       "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
@@ -2049,6 +2047,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
       "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
@@ -2063,6 +2062,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
       "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -3630,7 +3630,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.22.tgz",
       "integrity": "sha512-DxXoI8JEg/ocFnC2M5hWK9Fi6VQDjVNZuR5Dpx8LSFmrsI0dp+WfD78g8PSCZwndpVWl0bkYD9Fz+OdHTrwX7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -3860,7 +3859,6 @@
       "integrity": "sha512-kmnmVs32MFWbV5X6BInC1/TfCs7y1ugwxv1xHsAIj/DyUfoe7vtO0alRUgbQa57+yRGHBBjlNcEk33SCAt5/dA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@microsoft/api-extractor-model": "7.33.4",
         "@microsoft/tsdoc": "~0.16.0",
@@ -4066,7 +4064,6 @@
       "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
       "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@monaco-editor/loader": "^1.5.0"
       },
@@ -4502,7 +4499,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -7037,7 +7033,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -7049,7 +7044,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -7158,7 +7152,6 @@
       "integrity": "sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.55.0",
@@ -7188,7 +7181,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -8211,7 +8203,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8265,7 +8256,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8995,7 +8985,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10586,7 +10575,8 @@
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
       "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true
     },
     "node_modules/domutils": {
       "version": "3.2.2",
@@ -11034,7 +11024,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -11105,7 +11094,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11166,7 +11154,6 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11650,7 +11637,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -12919,7 +12905,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
       "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -13178,7 +13163,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -14153,7 +14137,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -15124,7 +15107,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -16137,6 +16119,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -17702,6 +17685,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/obj-case": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/obj-case/-/obj-case-0.2.1.tgz",
@@ -17893,7 +17885,6 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.21.0.tgz",
       "integrity": "sha512-26dQFi76dB8IiN/WKGQOV+yKKTTlRCxQjoi2WLt0kMcH8pvxVyvfdBDkld5GTl7W1qvBpwVOtFcsqktj3fBRpA==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -18478,7 +18469,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18639,7 +18629,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -18860,7 +18849,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -19194,7 +19182,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -19213,7 +19200,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -19617,7 +19603,8 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -22001,7 +21988,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -22211,7 +22197,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22646,7 +22631,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -23584,7 +23568,6 @@
       "integrity": "sha512-Gdj3X74CLJJ8zy4URmK42W7wTZUJrqL+z8nyGEr4dTN0kb3nVs+ZvjbTOqRYPD7qX4tUmwyHL9Q9K6T1seW6Yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -23634,7 +23617,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -24220,7 +24202,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -24353,7 +24334,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -24363,7 +24343,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }
@@ -24411,7 +24390,11 @@
       "name": "@editor-extensions/shared",
       "version": "0.6.0"
     },
-    "vscode": {},
+    "vscode": {
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "vscode/core": {
       "name": "konveyor-core",
       "version": "0.6.0",
@@ -24425,6 +24408,7 @@
         "https-proxy-agent": "^7.0.6",
         "jsesc": "^3.1.0",
         "mustache": "^4.2.0",
+        "oauth4webapi": "^3.8.6",
         "undici": "^7.14.0",
         "winston": "^3.17.0",
         "winston-transport-vscode": "^0.1.0"

--- a/vscode/core/package.json
+++ b/vscode/core/package.json
@@ -506,6 +506,7 @@
     "https-proxy-agent": "^7.0.6",
     "jsesc": "^3.1.0",
     "mustache": "^4.2.0",
+    "oauth4webapi": "^3.8.6",
     "undici": "^7.14.0",
     "winston": "^3.17.0",
     "winston-transport-vscode": "^0.1.0"

--- a/vscode/core/src/hub/HubConnectionManager.ts
+++ b/vscode/core/src/hub/HubConnectionManager.ts
@@ -661,7 +661,16 @@ export class HubConnectionManager {
    * Logout from OIDC (clear stored tokens).
    */
   public async oidcLogout(): Promise<void> {
-    // Disconnect all active clients first
+    // End the OIDC session on the server before clearing local state
+    if (this.oidcAuthCode) {
+      try {
+        await this.oidcAuthCode.endSession();
+      } catch (error) {
+        this.logger.warn("Failed to end OIDC session on server", { error });
+      }
+    }
+
+    // Disconnect all active clients
     await this.disconnect();
 
     if (this.oidcAuthCode) {

--- a/vscode/core/src/hub/HubConnectionManager.ts
+++ b/vscode/core/src/hub/HubConnectionManager.ts
@@ -88,6 +88,7 @@ export class HubConnectionManager {
   private username: string = "";
   private password: string = "";
   private usingPAT: boolean = false;
+  private patId: number | null = null;
   private isInteractiveLoginInProgress: boolean = false;
   private authSucceeded: boolean = false;
   private connectionError: string = "";
@@ -684,7 +685,9 @@ export class HubConnectionManager {
     this.refreshToken = null;
     this.usingPAT = false;
     this.authSucceeded = false;
+    await this.revokePAT();
     await this.clearPAT();
+    this.patId = null;
     this.clearTokenRefreshTimer();
     this.logger.info("OIDC tokens and PAT cleared, disconnected from Hub");
   }
@@ -904,11 +907,12 @@ export class HubConnectionManager {
       // Success — switch to PAT
       this.bearerToken = data.token;
       this.usingPAT = true;
+      this.patId = data.id ?? null;
       // PATs are long-lived; use null to signal "no expiration" to the UI
       this.tokenExpiresAt = data.expiration ? new Date(data.expiration).getTime() : null;
 
       // Persist PAT
-      await this.storePAT(data.token);
+      await this.storePAT(data.token, this.patId);
 
       this.logger.info("Successfully exchanged OIDC token for PAT", {
         patId: data.id,
@@ -932,7 +936,7 @@ export class HubConnectionManager {
   /**
    * Store PAT in VS Code SecretStorage.
    */
-  private async storePAT(token: string): Promise<void> {
+  private async storePAT(token: string, id: number | null): Promise<void> {
     if (!this.extensionContext) {
       return;
     }
@@ -940,7 +944,7 @@ export class HubConnectionManager {
       const key = this.getPATStorageKey();
       await this.extensionContext.secrets.store(
         key,
-        JSON.stringify({ token, username: this.username }),
+        JSON.stringify({ token, username: this.username, id }),
       );
       this.logger.info("PAT stored in SecretStorage");
     } catch (error) {
@@ -964,9 +968,12 @@ export class HubConnectionManager {
       }
       // Support both legacy (plain token) and new (JSON with username) formats
       try {
-        const parsed = JSON.parse(raw) as { token: string; username?: string };
+        const parsed = JSON.parse(raw) as { token: string; username?: string; id?: number };
         if (parsed.username) {
           this.username = parsed.username;
+        }
+        if (parsed.id) {
+          this.patId = parsed.id;
         }
         return parsed.token;
       } catch {
@@ -975,6 +982,27 @@ export class HubConnectionManager {
       }
     } catch {
       return null;
+    }
+  }
+
+  /**
+   * Revoke PAT on the Hub server via DELETE /auth/tokens/:id.
+   */
+  private async revokePAT(): Promise<void> {
+    if (!this.patId || !this.bearerToken) {
+      return;
+    }
+    const fetchFn = this.scopedFetch ?? fetch;
+    const url = `${this.config.url}/hub/auth/tokens/${this.patId}`;
+    try {
+      await fetchFn(url, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${this.bearerToken}` },
+        signal: AbortSignal.timeout(TOKEN_EXCHANGE_TIMEOUT_MS),
+      });
+      this.logger.info("PAT revoked on Hub", { patId: this.patId });
+    } catch (error) {
+      this.logger.warn("Failed to revoke PAT on Hub", { patId: this.patId, error });
     }
   }
 

--- a/vscode/core/src/hub/OIDCAuthCodeFlow.ts
+++ b/vscode/core/src/hub/OIDCAuthCodeFlow.ts
@@ -1,50 +1,29 @@
 /**
  * OIDC Authorization Code + PKCE Flow for Konveyor Hub.
  *
- * Implements OAuth 2.0 Authorization Code Grant with PKCE (RFC 7636)
- * against the hub's builtin OIDC provider (PR #1042).
- *
- * Flow:
- *   1. Generate PKCE code_verifier + code_challenge (S256)
- *   2. Start a local loopback HTTP server for the callback
- *   3. Build authorize URL and open in browser via vscode.env.openExternal
- *   4. Receive authorization code on loopback server callback
- *   5. Exchange code for tokens at /oidc/token endpoint
- *   6. Store tokens via OIDCTokenStorage
- *
- * Uses a local HTTP server on 127.0.0.1 (RFC 8252 §7.3) instead of
- * custom protocol handlers (vscode://) for reliable cross-browser support.
+ * Uses oauth4webapi for spec-compliant OIDC discovery, token exchange,
+ * refresh, and end-session. The loopback callback server (OIDCLoopbackServer)
+ * is still ours — oauth4webapi handles the protocol, not the transport.
  *
  * @module OIDCAuthCodeFlow
  */
 import * as vscode from "vscode";
-import { randomBytes, createHash } from "crypto";
+import * as oauth from "oauth4webapi";
 import { OIDCLoopbackServer } from "./OIDCLoopbackServer";
 
 // ─── Shared OIDC Types ─────────────────────────────────────────────────────
-
-/** Successful token response from the token endpoint. */
-export interface OIDCTokenResponse {
-  access_token: string;
-  token_type: string;
-  expires_in?: number;
-  refresh_token?: string;
-  id_token?: string;
-  scope?: string;
-}
 
 /** Persisted token set. */
 export interface OIDCTokens {
   accessToken: string;
   refreshToken: string | null;
+  idToken: string | null;
   expiresAt: number | null;
 }
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const OIDC_SCOPES = "openid profile email offline_access";
-const AUTHORIZE_PATH = "/authorize";
-const TOKEN_PATH = "/token";
 const TOKEN_EXPIRY_BUFFER_MS = 30_000; // 30s before actual expiry
 
 /** Timeout for waiting for the auth callback (5 minutes). */
@@ -83,76 +62,39 @@ export class OIDCAuthCodeStateError extends OIDCAuthCodeError {
   }
 }
 
-// ─── PKCE Helpers ────────────────────────────────────────────────────────────
-
-/**
- * Generate a cryptographically random PKCE code_verifier.
- * Per RFC 7636, must be 43-128 characters from [A-Z] / [a-z] / [0-9] / "-" / "." / "_" / "~".
- * We use 64 bytes of randomness, base64url-encoded (yields 86 chars).
- */
-function generateCodeVerifier(): string {
-  return randomBytes(64).toString("base64url");
-}
-
-/**
- * Generate S256 code_challenge from a code_verifier.
- * code_challenge = BASE64URL(SHA256(code_verifier))
- */
-function generateCodeChallenge(verifier: string): string {
-  return createHash("sha256").update(verifier).digest("base64url");
-}
-
-/**
- * Generate a cryptographically random state parameter for CSRF protection.
- */
-function generateState(): string {
-  return randomBytes(32).toString("base64url");
-}
-
 // ─── Main Class ──────────────────────────────────────────────────────────────
 
-/**
- * Manages OIDC Authorization Code + PKCE flow against the Konveyor Hub
- * builtin OIDC provider.
- *
- * Uses a local loopback HTTP server (RFC 8252) to receive the auth callback,
- * which is more reliable than vscode:// protocol handlers across browsers.
- */
 export class OIDCAuthCodeFlow {
   private readonly issuerUrl: string;
   private readonly clientId: string;
-  private readonly customFetch: typeof fetch;
+  private readonly client: oauth.Client;
+  private readonly fetchOptions: { [oauth.customFetch]: typeof fetch } | undefined;
 
   private accessToken: string | null = null;
   private refreshToken: string | null = null;
+  private idToken: string | null = null;
   private expiresAt: number | null = null;
   private loginInProgress: boolean = false;
+  private authServer: oauth.AuthorizationServer | null = null;
 
-  /**
-   * @param issuerUrl    Hub's OIDC issuer URL (e.g. "https://hub.example.com/oidc")
-   * @param clientId     Registered OIDC client ID (e.g. "kai-ide")
-   * @param customFetch  Optional fetch override (for insecure TLS, etc.)
-   */
   constructor(issuerUrl: string, clientId: string, customFetch?: typeof fetch) {
     this.issuerUrl = issuerUrl.replace(/\/$/, "");
     this.clientId = clientId;
-    this.customFetch = customFetch ?? fetch;
+    this.client = { client_id: clientId };
+    if (customFetch) {
+      this.fetchOptions = { [oauth.customFetch]: customFetch };
+    }
   }
 
   // ─── Token State ───────────────────────────────────────────────────────────
 
-  /**
-   * Restore tokens from persistent storage (call on startup).
-   */
   public setTokens(tokens: OIDCTokens): void {
     this.accessToken = tokens.accessToken;
     this.refreshToken = tokens.refreshToken;
+    this.idToken = tokens.idToken;
     this.expiresAt = tokens.expiresAt;
   }
 
-  /**
-   * Get current tokens for persistence to storage.
-   */
   public getTokens(): OIDCTokens | null {
     if (!this.accessToken) {
       return null;
@@ -160,13 +102,11 @@ export class OIDCAuthCodeFlow {
     return {
       accessToken: this.accessToken,
       refreshToken: this.refreshToken,
+      idToken: this.idToken,
       expiresAt: this.expiresAt,
     };
   }
 
-  /**
-   * Get the Authorization header value.
-   */
   public getHeader(): string | null {
     if (!this.accessToken) {
       return null;
@@ -174,16 +114,10 @@ export class OIDCAuthCodeFlow {
     return `Bearer ${this.accessToken}`;
   }
 
-  /**
-   * Whether any token is stored (may be expired).
-   */
   public hasToken(): boolean {
     return !!this.accessToken;
   }
 
-  /**
-   * Whether the current access token is likely still valid.
-   */
   public isTokenValid(): boolean {
     if (!this.accessToken) {
       return false;
@@ -194,9 +128,6 @@ export class OIDCAuthCodeFlow {
     return Date.now() < this.expiresAt - TOKEN_EXPIRY_BUFFER_MS;
   }
 
-  /**
-   * Get milliseconds until token needs refresh (for scheduling).
-   */
   public getTimeUntilRefresh(): number {
     if (!this.expiresAt) {
       return 0;
@@ -205,22 +136,38 @@ export class OIDCAuthCodeFlow {
     return Math.max(0, remaining);
   }
 
-  /**
-   * Clear all stored tokens (for logout/disconnect).
-   */
   public clearTokens(): void {
     this.accessToken = null;
     this.refreshToken = null;
+    this.idToken = null;
     this.expiresAt = null;
+  }
+
+  public async endSession(): Promise<void> {
+    const as = await this.discover();
+    if (!as.end_session_endpoint) {
+      return;
+    }
+
+    const params = new URLSearchParams({ client_id: this.clientId });
+    if (this.idToken) {
+      params.set("id_token_hint", this.idToken);
+    }
+
+    const url = `${as.end_session_endpoint}?${params.toString()}`;
+    const fetchFn = this.fetchOptions?.[oauth.customFetch] ?? fetch;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 30_000);
+    try {
+      await fetchFn(url, { signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   // ─── Authentication Flows ──────────────────────────────────────────────────
 
-  /**
-   * Full login flow: try refresh first, fall back to auth code flow.
-   */
   public async login(cancellationToken?: vscode.CancellationToken): Promise<OIDCTokens> {
-    // Try refresh first if we have a refresh token
     if (this.refreshToken) {
       const refreshed = await this.refresh();
       if (refreshed) {
@@ -228,68 +175,37 @@ export class OIDCAuthCodeFlow {
       }
     }
 
-    // Fall back to full authorization code flow
     return this.authCodeLogin(cancellationToken);
   }
 
-  /**
-   * Refresh the access token using the stored refresh token.
-   * @returns true if refresh succeeded, false if re-login is needed.
-   */
   public async refresh(): Promise<boolean> {
     if (!this.refreshToken) {
       return false;
     }
 
-    const params = new URLSearchParams({
-      grant_type: "refresh_token",
-      refresh_token: this.refreshToken,
-      client_id: this.clientId,
-    });
-
     try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 30_000);
-      let response: Response;
-      try {
-        response = await this.customFetch(`${this.issuerUrl}${TOKEN_PATH}`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-            Accept: "application/json",
-          },
-          body: params.toString(),
-          signal: controller.signal,
-        });
-      } finally {
-        clearTimeout(timeout);
-      }
+      const as = await this.discover();
+      const response = await oauth.refreshTokenGrantRequest(
+        as,
+        this.client,
+        oauth.None(),
+        this.refreshToken,
+        {
+          [oauth.allowInsecureRequests]: true,
+          ...this.fetchOptions,
+        },
+      );
 
-      if (!response.ok) {
-        // Refresh token expired or revoked
-        this.refreshToken = null;
-        return false;
-      }
+      const result = await oauth.processRefreshTokenResponse(as, this.client, response);
 
-      const data = (await response.json()) as OIDCTokenResponse;
-      this.updateTokensFromResponse(data);
+      this.updateTokensFromResponse(result);
       return true;
     } catch {
-      // Network error — don't clear refresh token, might work later
+      this.refreshToken = null;
       return false;
     }
   }
 
-  /**
-   * Initiate Authorization Code + PKCE flow using a loopback server.
-   *
-   * 1. Start local HTTP server on random port
-   * 2. Generate PKCE verifier + challenge
-   * 3. Open browser to authorize endpoint with redirect_uri pointing to loopback
-   * 4. Receive callback on loopback server
-   * 5. Exchange code for tokens
-   * 6. Stop loopback server
-   */
   public async authCodeLogin(cancellationToken?: vscode.CancellationToken): Promise<OIDCTokens> {
     if (this.loginInProgress) {
       throw new OIDCAuthCodeError(
@@ -304,35 +220,44 @@ export class OIDCAuthCodeFlow {
     let cancellationDisposable: vscode.Disposable | undefined;
 
     try {
-      // Step 1: Start loopback server
+      const as = await this.discover();
+
       await server.start();
       const redirectUri = server.getRedirectUri();
 
-      // Step 2: Generate PKCE parameters
-      const codeVerifier = generateCodeVerifier();
-      const codeChallenge = generateCodeChallenge(codeVerifier);
-      const state = generateState();
+      const codeVerifier = oauth.generateRandomCodeVerifier();
+      const codeChallenge = await oauth.calculatePKCECodeChallenge(codeVerifier);
+      const state = oauth.generateRandomState();
 
-      // Register state with server for CSRF validation
       server.setExpectedState(state);
 
-      // Step 3: Build authorize URL with loopback redirect
-      const authorizeUrl = this.buildAuthorizeUrl(codeChallenge, state, redirectUri);
+      if (!as.authorization_endpoint) {
+        throw new OIDCAuthCodeError(
+          "Authorization endpoint not found in discovery",
+          "discovery_failed",
+        );
+      }
 
-      // Set up timeout
+      const authUrl = new URL(as.authorization_endpoint);
+      authUrl.searchParams.set("response_type", "code");
+      authUrl.searchParams.set("client_id", this.clientId);
+      authUrl.searchParams.set("redirect_uri", redirectUri);
+      authUrl.searchParams.set("scope", OIDC_SCOPES);
+      authUrl.searchParams.set("code_challenge", codeChallenge);
+      authUrl.searchParams.set("code_challenge_method", "S256");
+      authUrl.searchParams.set("state", state);
+
       timeoutHandle = setTimeout(() => {
         server.abort(new OIDCAuthCodeTimeoutError());
       }, AUTH_CALLBACK_TIMEOUT_MS);
 
-      // Handle cancellation
       if (cancellationToken) {
         cancellationDisposable = cancellationToken.onCancellationRequested(() => {
           server.abort(new OIDCAuthCodeCancelledError());
         });
       }
 
-      // Step 4: Open browser
-      const opened = await vscode.env.openExternal(vscode.Uri.parse(authorizeUrl));
+      const opened = await vscode.env.openExternal(vscode.Uri.parse(authUrl.toString()));
       if (!opened) {
         throw new OIDCAuthCodeError(
           "Failed to open browser for authentication. Please try again.",
@@ -340,7 +265,6 @@ export class OIDCAuthCodeFlow {
         );
       }
 
-      // Show progress notification
       vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
@@ -358,18 +282,33 @@ export class OIDCAuthCodeFlow {
         },
       );
 
-      // Step 5: Wait for callback
       const result = await server.waitForCallback();
 
-      // Step 6: Exchange code for tokens
-      const tokens = await this.exchangeCodeForTokens(result.code, codeVerifier, redirectUri);
+      const callbackParams = new URLSearchParams({ code: result.code, state: result.state });
+      const response = await oauth.authorizationCodeGrantRequest(
+        as,
+        this.client,
+        oauth.None(),
+        callbackParams,
+        redirectUri,
+        codeVerifier,
+        {
+          [oauth.allowInsecureRequests]: true,
+          ...this.fetchOptions,
+        },
+      );
+
+      const tokenResult = await oauth.processAuthorizationCodeResponse(as, this.client, response, {
+        expectedNonce: oauth.expectNoNonce,
+      });
+
+      this.updateTokensFromResponse(tokenResult);
 
       vscode.window.showInformationMessage("Successfully signed in to Konveyor Hub");
 
-      return tokens;
+      return this.getTokens()!;
     } finally {
       this.loginInProgress = false;
-      // Always clean up
       if (timeoutHandle) {
         clearTimeout(timeoutHandle);
       }
@@ -378,93 +317,42 @@ export class OIDCAuthCodeFlow {
     }
   }
 
-  // ─── Private: Authorization ────────────────────────────────────────────────
+  // ─── Private ──────────────────────────────────────────────────────────────
 
-  /**
-   * Build the OIDC authorize endpoint URL with PKCE parameters.
-   */
-  private buildAuthorizeUrl(codeChallenge: string, state: string, redirectUri: string): string {
-    const params = new URLSearchParams({
-      response_type: "code",
-      client_id: this.clientId,
-      redirect_uri: redirectUri,
-      scope: OIDC_SCOPES,
-      code_challenge: codeChallenge,
-      code_challenge_method: "S256",
-      state: state,
+  private async discover(): Promise<oauth.AuthorizationServer> {
+    if (this.authServer) {
+      return this.authServer;
+    }
+
+    const issuer = new URL(this.issuerUrl);
+    const response = await oauth.discoveryRequest(issuer, {
+      [oauth.allowInsecureRequests]: true,
+      algorithm: "oidc",
+      ...this.fetchOptions,
     });
 
-    return `${this.issuerUrl}${AUTHORIZE_PATH}?${params.toString()}`;
+    this.authServer = await oauth.processDiscoveryResponse(issuer, response);
+    return this.authServer;
   }
 
-  /**
-   * Exchange authorization code for tokens at the token endpoint.
-   */
-  private async exchangeCodeForTokens(
-    code: string,
-    codeVerifier: string,
-    redirectUri: string,
-  ): Promise<OIDCTokens> {
-    const params = new URLSearchParams({
-      grant_type: "authorization_code",
-      code: code,
-      redirect_uri: redirectUri,
-      client_id: this.clientId,
-      code_verifier: codeVerifier,
-    });
+  private updateTokensFromResponse(result: oauth.TokenEndpointResponse): void {
+    this.accessToken = result.access_token;
 
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 30_000);
-    let response: Response;
-    try {
-      response = await this.customFetch(`${this.issuerUrl}${TOKEN_PATH}`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-          Accept: "application/json",
-        },
-        body: params.toString(),
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeout);
+    if (result.refresh_token) {
+      this.refreshToken = result.refresh_token;
     }
 
-    if (!response.ok) {
-      const body = await response.text().catch(() => "");
-      throw new OIDCAuthCodeError(
-        `Token exchange failed: ${response.status} ${response.statusText}${body ? ` - ${body}` : ""}`,
-        "token_exchange_failed",
-      );
+    if (result.id_token) {
+      this.idToken = result.id_token;
     }
 
-    const data = (await response.json()) as OIDCTokenResponse;
-    this.updateTokensFromResponse(data);
-    return this.getTokens()!;
-  }
-
-  // ─── Private: Helpers ──────────────────────────────────────────────────────
-
-  /**
-   * Update internal token state from a successful token response.
-   */
-  private updateTokensFromResponse(data: OIDCTokenResponse): void {
-    this.accessToken = data.access_token;
-
-    if (data.refresh_token) {
-      this.refreshToken = data.refresh_token;
-    }
-
-    if (data.expires_in) {
-      this.expiresAt = Date.now() + data.expires_in * 1000;
+    if (result.expires_in) {
+      this.expiresAt = Date.now() + result.expires_in * 1000;
     } else {
-      this.expiresAt = this.extractExpiryFromJWT(data.access_token);
+      this.expiresAt = this.extractExpiryFromJWT(result.access_token);
     }
   }
 
-  /**
-   * Extract exp claim from a JWT (without verification — just for scheduling).
-   */
   private extractExpiryFromJWT(token: string): number | null {
     try {
       const parts = token.split(".");
@@ -476,17 +364,15 @@ export class OIDCAuthCodeFlow {
         return payload.exp * 1000;
       }
     } catch {
-      // Not a valid JWT — that's ok
+      // Not a valid JWT
     }
     return null;
   }
 
-  /**
-   * Dispose of all resources.
-   */
   public dispose(): void {
     this.accessToken = null;
     this.refreshToken = null;
+    this.idToken = null;
     this.expiresAt = null;
   }
 }

--- a/vscode/core/src/hub/OIDCTokenStorage.ts
+++ b/vscode/core/src/hub/OIDCTokenStorage.ts
@@ -23,6 +23,7 @@ const STORAGE_KEY_PREFIX = "konveyor.oidc.tokens";
 interface StoredTokenData {
   accessToken: string;
   refreshToken: string | null;
+  idToken: string | null;
   expiresAt: number | null;
   storedAt: number; // Unix ms — when tokens were stored
 }
@@ -69,6 +70,7 @@ export class OIDCTokenStorage {
     const data: StoredTokenData = {
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken,
+      idToken: tokens.idToken,
       expiresAt: tokens.expiresAt,
       storedAt: Date.now(),
     };
@@ -107,6 +109,7 @@ export class OIDCTokenStorage {
       return {
         accessToken: data.accessToken,
         refreshToken: data.refreshToken ?? null,
+        idToken: data.idToken ?? null,
         expiresAt: data.expiresAt ?? null,
       };
     } catch {

--- a/vscode/core/src/hub/index.ts
+++ b/vscode/core/src/hub/index.ts
@@ -8,7 +8,7 @@ export {
   OIDCAuthCodeTimeoutError,
   OIDCAuthCodeStateError,
 } from "./OIDCAuthCodeFlow";
-export type { OIDCTokenResponse, OIDCTokens } from "./OIDCAuthCodeFlow";
+export type { OIDCTokens } from "./OIDCAuthCodeFlow";
 export { OIDCTokenStorage } from "./OIDCTokenStorage";
 export { OIDCLoopbackServer } from "./OIDCLoopbackServer";
 export type { OAuthCallbackResult } from "./OIDCLoopbackServer";


### PR DESCRIPTION
## Summary

- Replace the ~500-line hand-rolled OIDC implementation with [oauth4webapi](https://github.com/panva/oauth4webapi), a zero-dependency, spec-compliant OIDC client (3.8M weekly downloads)
- Discovery via `.well-known/openid-configuration` replaces hardcoded `/authorize` and `/token` paths
- PKCE, token exchange, and refresh handled by the library with proper response validation
- Store `id_token` and call `end_session_endpoint` on sign-out for proper server-side logout
- Identical public API surface on `OIDCAuthCodeFlow` — no changes needed in consumers
- `OIDCLoopbackServer` unchanged — still handles the browser callback

Net result: -274 lines removed, +157 lines added

Supersedes #1454
Closes #1453
Ref #1455

## Test plan

- [ ] OIDC sign-in via browser (auth code + PKCE flow through loopback server)
- [ ] Token refresh works after sign-in
- [ ] Sign-out ends the OIDC session server-side (re-login requires credentials)
- [ ] Graceful handling when Hub is unreachable during discovery
- [ ] Backward compatibility with stored tokens that don't have `idToken` field
- [ ] Webpack bundle builds successfully (ESM import handled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced OIDC authentication with spec-compliant discovery, token exchange, refresh, and session management.
  * Added proper server-side OIDC session invalidation on sign-out.
  * Personal Access Tokens are now revoked during logout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->