### PR TITLE
:bug: Surface analyzer error during server startup

### DIFF
--- a/changes/unreleased/surface-analyzer-errors-to-output-channel.yaml
+++ b/changes/unreleased/surface-analyzer-errors-to-output-channel.yaml
@@ -1,0 +1,3 @@
+kind: enhancement
+description: >
+  Surface analyzer process errors to the extension output channel by promoting stderr logging from debug to warn level, tailing analyzer.log for ERROR/FATAL lines during startup, and adding progress feedback with early abort detection during pipe connection retries.

--- a/vscode/core/src/client/analyzerClient.ts
+++ b/vscode/core/src/client/analyzerClient.ts
@@ -370,15 +370,17 @@ export class AnalyzerClient {
     });
 
     analyzerRpcServer.stderr.on("data", (data) => {
-      const msg = data.toString().trimEnd();
-      if (!msg) {
-        return;
-      }
-      // Progress JSON (from -progress-output stderr) stays at debug level
-      if (msg.includes('"stage"')) {
-        this.logger.debug(`[analyzer-rpc-server stderr] ${msg}`);
-      } else {
-        this.logger.warn(`[analyzer-rpc-server stderr] ${msg}`);
+      for (const line of data.toString().split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+        // Progress JSON (from -progress-output stderr) stays at debug level
+        if (trimmed.includes('"stage"')) {
+          this.logger.debug(`[analyzer-rpc-server stderr] ${trimmed}`);
+        } else {
+          this.logger.warn(`[analyzer-rpc-server stderr] ${trimmed}`);
+        }
       }
     });
 

--- a/vscode/core/src/client/analyzerClient.ts
+++ b/vscode/core/src/client/analyzerClient.ts
@@ -32,6 +32,7 @@ import { TaskManager } from "src/taskManager/types";
 import { Logger } from "winston";
 import { executeExtensionCommand } from "../commands";
 import { ProviderRegistry } from "../api";
+import { AnalyzerLogTailer } from "./analyzerLogTailer";
 
 export class AnalyzerClient {
   // Progress percentage ranges for each stage
@@ -46,6 +47,7 @@ export class AnalyzerClient {
   private analyzerRpcServer: ChildProcessWithoutNullStreams | null = null;
   private analyzerRpcConnection?: rpc.MessageConnection | null;
   private currentProgressCallback?: (event: ProgressEvent) => void;
+  private logTailer: AnalyzerLogTailer | null = null;
 
   constructor(
     private extContext: vscode.ExtensionContext,
@@ -151,6 +153,7 @@ export class AnalyzerClient {
     const [analyzerRpcServer, analyzerPid] = this.startAnalysisServer(pipeName);
     analyzerRpcServer.on("exit", (code, signal) => {
       this.logger.info(`Analyzer RPC server terminated [signal: ${signal}, code: ${code}]`);
+      this.stopLogTailer();
       if (code) {
         vscode.window.showErrorMessage(
           `Analyzer RPC server failed. Status code: ${code}. Please see the output channel for details.`,
@@ -161,11 +164,13 @@ export class AnalyzerClient {
     });
     analyzerRpcServer.on("close", (code, signal) => {
       this.logger.info(`Analyzer RPC server closed [signal: ${signal}, code: ${code}]`);
+      this.stopLogTailer();
       this.fireServerStateChange("stopped");
       this.analyzerRpcServer = null;
     });
     analyzerRpcServer.on("error", (err) => {
       this.logger.error("Analyzer RPC server error", err);
+      this.stopLogTailer();
       this.fireServerStateChange("startFailed");
       this.analyzerRpcServer = null;
       vscode.window.showErrorMessage(
@@ -174,6 +179,11 @@ export class AnalyzerClient {
     });
     this.analyzerRpcServer = analyzerRpcServer;
     this.logger.info(`Analyzer RPC server started successfully [pid: ${analyzerPid}]`);
+
+    // Start tailing analyzer.log to surface errors in the extension output channel
+    const analyzerLogPath = path.join(paths().serverLogs.fsPath, "analyzer.log");
+    this.logTailer = new AnalyzerLogTailer(analyzerLogPath, this.logger);
+    this.logTailer.start();
 
     const socket: Socket = await this.getSocket(pipeName);
     socket.addListener("connectionAttempt", () => {
@@ -221,6 +231,7 @@ export class AnalyzerClient {
 
     this.analyzerRpcConnection.onNotification("started", (_: []) => {
       this.logger.info("Server initialization complete");
+      this.stopLogTailer();
       this.fireServerStateChange("running");
     });
     this.analyzerRpcConnection.onNotification("analysis.progress", (params: unknown) => {
@@ -253,9 +264,18 @@ export class AnalyzerClient {
   }
 
   protected async getSocket(pipeName: string): Promise<Socket> {
-    const MAX_RETRIES = 150; // retry for 5 minutes to connect to the analyzer pipe
+    const MAX_RETRIES = 150;
     const RETRY_DELAY = 2000;
+    const LOG_EVERY_N_ATTEMPTS = 10;
+
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      // Abort early if the analyzer process has already exited
+      if (this.analyzerRpcServer && this.analyzerRpcServer.exitCode !== null) {
+        throw new Error(
+          `Analyzer process exited with code ${this.analyzerRpcServer.exitCode} before the pipe became available.`,
+        );
+      }
+
       const s = new Socket();
       try {
         await new Promise<void>((resolve, reject) => {
@@ -267,6 +287,7 @@ export class AnalyzerClient {
           s.once("error", onError);
           s.connect(pipeName);
         });
+        this.logger.info(`Connected to analyzer pipe after ${attempt} attempt(s)`);
         return s;
       } catch (err) {
         s.destroy();
@@ -276,6 +297,12 @@ export class AnalyzerClient {
             err,
           });
           break;
+        }
+        if (attempt % LOG_EVERY_N_ATTEMPTS === 0) {
+          const elapsedSec = Math.round((attempt * RETRY_DELAY) / 1000);
+          this.logger.info(
+            `Waiting for analyzer pipe... (attempt ${attempt}/${MAX_RETRIES}, ${elapsedSec}s elapsed)`,
+          );
         }
         await setTimeout(RETRY_DELAY);
       }
@@ -342,11 +369,11 @@ export class AnalyzerClient {
       env: serverEnv,
     });
 
-    // Progress updates are now received via RPC notifications (analysis.progress)
-    // The stderr-based progress parsing has been removed to avoid duplicate progress updates
     analyzerRpcServer.stderr.on("data", (data) => {
-      // Log stderr output for debugging
-      this.logger.debug(`Analyzer stderr: ${data.toString()}`);
+      const msg = data.toString().trimEnd();
+      if (msg) {
+        this.logger.warn(`[analyzer-rpc-server stderr] ${msg}`);
+      }
     });
 
     return [analyzerRpcServer, analyzerRpcServer.pid];
@@ -360,6 +387,13 @@ export class AnalyzerClient {
       : !Extension.getInstance(this.extContext).isProductionMode;
   }
 
+  private stopLogTailer(): void {
+    if (this.logTailer) {
+      this.logTailer.stop();
+      this.logTailer = null;
+    }
+  }
+
   /**
    * Shutdown and, if necessary, hard stops the server.
    *
@@ -370,6 +404,7 @@ export class AnalyzerClient {
   public async stop(): Promise<void> {
     this.logger.info(`Stopping the analyzer rpc server...`);
     this.fireServerStateChange("stopping");
+    this.stopLogTailer();
 
     // First close the RPC connection if it exists
     if (this.analyzerRpcConnection) {

--- a/vscode/core/src/client/analyzerClient.ts
+++ b/vscode/core/src/client/analyzerClient.ts
@@ -269,11 +269,11 @@ export class AnalyzerClient {
     const LOG_EVERY_N_ATTEMPTS = 10;
 
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-      // Abort early if the analyzer process has already exited
-      if (this.analyzerRpcServer && this.analyzerRpcServer.exitCode !== null) {
-        throw new Error(
-          `Analyzer process exited with code ${this.analyzerRpcServer.exitCode} before the pipe became available.`,
-        );
+      // Abort early if the analyzer process has already exited.
+      // The exit/close/error handlers set this.analyzerRpcServer to null,
+      // so a null check catches the case where the process exited during a retry delay.
+      if (!this.analyzerRpcServer || this.analyzerRpcServer.exitCode !== null) {
+        throw new Error("Analyzer process exited before the pipe became available.");
       }
 
       const s = new Socket();
@@ -371,7 +371,13 @@ export class AnalyzerClient {
 
     analyzerRpcServer.stderr.on("data", (data) => {
       const msg = data.toString().trimEnd();
-      if (msg) {
+      if (!msg) {
+        return;
+      }
+      // Progress JSON (from -progress-output stderr) stays at debug level
+      if (msg.includes('"stage"')) {
+        this.logger.debug(`[analyzer-rpc-server stderr] ${msg}`);
+      } else {
         this.logger.warn(`[analyzer-rpc-server stderr] ${msg}`);
       }
     });

--- a/vscode/core/src/client/analyzerLogTailer.ts
+++ b/vscode/core/src/client/analyzerLogTailer.ts
@@ -1,0 +1,94 @@
+import * as fs from "fs";
+import { Logger } from "winston";
+
+/**
+ * Incrementally tails the analyzer log file during startup and surfaces
+ * ERROR/FATAL-level lines to the extension's output channel via the logger.
+ *
+ * Uses polling with incremental reads so it works reliably on all platforms
+ * (fs.watch is unreliable on network filesystems and some Windows setups).
+ */
+export class AnalyzerLogTailer {
+  private intervalHandle: ReturnType<typeof setInterval> | null = null;
+  private lastSize = 0;
+  private buffer = "";
+
+  private static readonly ERROR_PATTERNS: ReadonlyArray<RegExp> = [
+    /"level"\s*:\s*"error"/i,
+    /"level"\s*:\s*"fatal"/i,
+    /\blevel=error\b/i,
+    /\blevel=fatal\b/i,
+  ];
+
+  constructor(
+    private readonly logFilePath: string,
+    private readonly logger: Logger,
+    private readonly pollIntervalMs = 1000,
+  ) {}
+
+  start(): void {
+    if (this.intervalHandle) {
+      return;
+    }
+
+    this.lastSize = this.getCurrentFileSize();
+    this.buffer = "";
+    this.intervalHandle = setInterval(() => this.poll(), this.pollIntervalMs);
+  }
+
+  stop(): void {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+  }
+
+  private getCurrentFileSize(): number {
+    try {
+      return fs.statSync(this.logFilePath).size;
+    } catch {
+      return 0;
+    }
+  }
+
+  private poll(): void {
+    const currentSize = this.getCurrentFileSize();
+    if (currentSize <= this.lastSize) {
+      return;
+    }
+
+    let fd: number;
+    try {
+      fd = fs.openSync(this.logFilePath, "r");
+    } catch {
+      return;
+    }
+
+    try {
+      const bytesToRead = currentSize - this.lastSize;
+      const buf = Buffer.alloc(bytesToRead);
+      fs.readSync(fd, buf, 0, bytesToRead, this.lastSize);
+      this.lastSize = currentSize;
+      this.processChunk(buf.toString("utf-8"));
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+
+  private processChunk(chunk: string): void {
+    this.buffer += chunk;
+    const lines = this.buffer.split("\n");
+    this.buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed && this.isErrorLine(trimmed)) {
+        this.logger.error(`[analyzer.log] ${trimmed}`);
+      }
+    }
+  }
+
+  private isErrorLine(line: string): boolean {
+    return AnalyzerLogTailer.ERROR_PATTERNS.some((pattern) => pattern.test(line));
+  }
+}

--- a/vscode/core/src/client/analyzerLogTailer.ts
+++ b/vscode/core/src/client/analyzerLogTailer.ts
@@ -31,7 +31,7 @@ export class AnalyzerLogTailer {
       return;
     }
 
-    this.lastSize = this.getCurrentFileSize();
+    this.lastSize = 0;
     this.buffer = "";
     this.intervalHandle = setInterval(() => this.poll(), this.pollIntervalMs);
   }


### PR DESCRIPTION
Resolves #1422 

Surface analyzer log errors to core extension's output during server status.

When the analyzer encounters errors during startup, these errors are only written to the analyzer.log file and never surfaced to the user. The extension's start button remains in a spinner state for 5 minutes with no indication of what went wrong, forcing users to manually locate and inspect the log file.

This:

```typescript
analyzerRpcServer.stderr.on("data", (data) => {
      // Log stderr output for debugging
      this.logger.debug(`Analyzer stderr: ${data.toString()}`);
```

Did not surface analyzer errors because they are written to the log file, not to stderr.

### Before

<img width="1270" height="100" alt="image" src="https://github.com/user-attachments/assets/79caed96-1b82-4b54-b900-062077745ed9" />


### After

<img width="1174" height="197" alt="image" src="https://github.com/user-attachments/assets/bda685e5-71bd-425a-be92-67229fe16b3d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analyzer **ERROR/FATAL** messages are now streamed to the VS Code output channel while the analyzer starts.
  * Added live connection feedback while the extension waits for analyzer pipes, including early abort when startup fails and periodic “waiting” updates.
* **Bug Fixes**
  * Improved analyzer stderr visibility by logging most stderr output at **warning** level (with stage-related lines at lower verbosity).
  * Retry behavior now detects analyzer exit during wait periods and reports successful connections more clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->