### PR TITLE
:bug: Add compatibility check for C# and Go extensions

### DIFF
--- a/changes/unreleased/add-version-check-go-csharp.yaml
+++ b/changes/unreleased/add-version-check-go-csharp.yaml
@@ -1,0 +1,6 @@
+kind: bugfix
+description: >
+  Added version compatibility check at activation time for Go and C# provider extensions to prevent silent failures when running with an incompatible core extension.
+extensions:
+  - go
+  - csharp

--- a/vscode/csharp/src/extension.ts
+++ b/vscode/csharp/src/extension.ts
@@ -15,6 +15,7 @@ import {
   EXTENSION_DISPLAY_NAME,
   EXTENSION_ID,
   EXTENSION_NAME,
+  EXTENSION_VERSION,
 } from "./utilities/constants";
 
 /**
@@ -109,6 +110,27 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.window.showErrorMessage(message);
     return;
   }
+
+  // Check version compatibility
+  const csharpExtVersion = EXTENSION_VERSION;
+  const coreExtVersion = coreApi.version;
+  if (csharpExtVersion !== coreExtVersion) {
+    const message =
+      `Version mismatch detected!\n\n` +
+      `${EXTENSION_DISPLAY_NAME} (v${csharpExtVersion}) is not compatible with the core extension (v${coreExtVersion}).\n\n` +
+      `Please ensure both extensions are at the same version. This mismatch can cause analysis failures and unexpected behavior.`;
+    logger.error(message, {
+      csharpVersion: csharpExtVersion,
+      coreVersion: coreExtVersion,
+    });
+    vscode.window.showErrorMessage(message);
+    return;
+  }
+
+  logger.info("Version compatibility check passed", {
+    csharpVersion: csharpExtVersion,
+    coreVersion: coreExtVersion,
+  });
 
   // Create socket path for C# provider communication
   const providerSocketPath = generateSafePipeName(EXTENSION_NAME); // GRPC socket for c-sharp-analyzer-provider

--- a/vscode/go/src/extension.ts
+++ b/vscode/go/src/extension.ts
@@ -14,6 +14,7 @@ import {
   EXTENSION_DISPLAY_NAME,
   EXTENSION_ID,
   EXTENSION_NAME,
+  EXTENSION_VERSION,
 } from "./utilities/constants";
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -103,6 +104,27 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.window.showErrorMessage(message);
     return;
   }
+
+  // Check version compatibility
+  const goExtVersion = EXTENSION_VERSION;
+  const coreExtVersion = coreApi.version;
+  if (goExtVersion !== coreExtVersion) {
+    const message =
+      `Version mismatch detected!\n\n` +
+      `${EXTENSION_DISPLAY_NAME} (v${goExtVersion}) is not compatible with the core extension (v${coreExtVersion}).\n\n` +
+      `Please ensure both extensions are at the same version. This mismatch can cause analysis failures and unexpected behavior.`;
+    logger.error(message, {
+      goVersion: goExtVersion,
+      coreVersion: coreExtVersion,
+    });
+    vscode.window.showErrorMessage(message);
+    return;
+  }
+
+  logger.info("Version compatibility check passed", {
+    goVersion: goExtVersion,
+    coreVersion: coreExtVersion,
+  });
 
   // Create socket paths for communication
   const providerSocketPath = generateSafePipeName(EXTENSION_NAME); // GRPC socket for kai-analyzer-rpc

--- a/vscode/java/src/extension.ts
+++ b/vscode/java/src/extension.ts
@@ -262,7 +262,7 @@ async function initializeProviders(
   if (javaExtVersion !== coreExtVersion) {
     const message =
       `Version mismatch detected!\n\n` +
-      `Konveyor Java extension (v${javaExtVersion}) is not compatible with Konveyor Core extension (v${coreExtVersion}).\n\n` +
+      `${EXTENSION_DISPLAY_NAME} (v${javaExtVersion}) is not compatible with the core extension (v${coreExtVersion}).\n\n` +
       `Please ensure both extensions are at the same version. This mismatch can cause analysis failures and unexpected behavior.`;
     logger.error(message, {
       javaVersion: javaExtVersion,

--- a/vscode/javascript/src/extension.ts
+++ b/vscode/javascript/src/extension.ts
@@ -81,7 +81,7 @@ export async function activate(context: vscode.ExtensionContext) {
   if (javascriptExtVersion !== coreExtVersion) {
     const message =
       `Version mismatch detected!\n\n` +
-      `Konveyor JavaScript extension (v${javascriptExtVersion}) is not compatible with Konveyor Core extension (v${coreExtVersion}).\n\n` +
+      `${EXTENSION_DISPLAY_NAME} (v${javascriptExtVersion}) is not compatible with the core extension (v${coreExtVersion}).\n\n` +
       `Please ensure both extensions are at the same version. This mismatch can cause analysis failures and unexpected behavior.`;
     logger.error(message, {
       javascriptVersion: javascriptExtVersion,


### PR DESCRIPTION
Resolves #1448

Add compatibility checks for Go and C# extensions.

Updated message literals to use branded name.

<img width="437" height="352" alt="image" src="https://github.com/user-attachments/assets/ae49178e-9582-4354-8acc-fa1175845f9a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extension startup checks so incompatible version combinations are detected early and clearly reported.
  * Prevents related features from loading when the core and language extensions are out of sync, avoiding unstable behavior.
  * Updated compatibility error messages to use consistent product names across C#, Go, Java, and JavaScript extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->