### PR TITLE
:bug: Update solution server status on stale MCP connection loss

### DIFF
--- a/agentic/src/clients/solutionServerClient.ts
+++ b/agentic/src/clients/solutionServerClient.ts
@@ -110,6 +110,9 @@ export class SolutionServerClientError extends Error {
   }
 }
 
+/** Listener invoked whenever the client's connection state transitions. */
+export type SolutionServerConnectionListener = (connected: boolean) => void;
+
 /**
  * Client for interacting with the MCP solution server.
  *
@@ -124,6 +127,7 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
   private currentClientId: string = "";
   private logger: Logger;
   private cachedCapabilities: SolutionServerCapabilities | null = null;
+  private connectionStateListener: SolutionServerConnectionListener | null = null;
   public isConnected: boolean = false;
 
   constructor(
@@ -140,6 +144,24 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
     this.logger = logger.child({
       component: "SolutionServerClient",
     });
+  }
+
+  /**
+   * Register a listener that fires whenever the connection state changes.
+   * Used by HubConnectionManager to propagate disconnects (e.g. stale MCP
+   * connections detected mid-request) to the webview status UI.
+   */
+  public setConnectionStateListener(listener: SolutionServerConnectionListener | null): void {
+    this.connectionStateListener = listener;
+  }
+
+  /** Set isConnected and notify the listener when the value transitions. */
+  private setConnected(connected: boolean): void {
+    const changed = this.isConnected !== connected;
+    this.isConnected = connected;
+    if (changed) {
+      this.connectionStateListener?.(connected);
+    }
   }
 
   public async connect(): Promise<void> {
@@ -211,7 +233,7 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
         new StreamableHTTPClientTransport(serverUrlObj, transportOptions),
       );
       this.logger.info("Connected to MCP solution server");
-      this.isConnected = true;
+      this.setConnected(true);
       return true;
     } catch (error) {
       this.logger.warn(`Failed to connect with original URL (${this.serverUrl})`, error);
@@ -239,7 +261,7 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
         this.logger.info(
           `Connected to MCP solution server using alternative URL: ${alternativeUrl}`,
         );
-        this.isConnected = true;
+        this.setConnected(true);
         return true;
       } catch (error) {
         this.logger.error(`Failed to connect with alternative URL (${alternativeUrl})`, error);
@@ -269,7 +291,7 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
         this.mcpClient = null;
       }
 
-      this.isConnected = false;
+      this.setConnected(false);
       this.logger.info("Disconnected from MCP solution server");
     } catch (error) {
       this.logger.error("Error during disconnect", error);
@@ -361,7 +383,8 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
         errorMessage.toLowerCase().includes("etimedout") ||
         errorCode === "ECONNRESET" ||
         errorCode === "ECONNREFUSED" ||
-        errorCode === "ETIMEDOUT";
+        errorCode === "ETIMEDOUT" ||
+        (typeof errorCode === "string" && errorCode.startsWith("UND_ERR"));
 
       if (isConnectionError) {
         // Connection error - log detailed diagnostic information
@@ -375,17 +398,17 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
           fullError: JSON.stringify(error, Object.getOwnPropertyNames(error)),
         });
 
-        // Mark as disconnected
-        this.isConnected = false;
+        // Mark as disconnected and notify the connection state listener
+        this.setConnected(false);
 
         // Close the stale MCP client to prevent resource leaks
         await this.closeStaleClient();
 
-        // Return empty capabilities instead of throwing
-        return {
-          tools: [],
-          resources: [],
-        };
+        // Propagate the failure so callers (e.g. the health poll) register
+        // the disconnect instead of mistaking empty capabilities for success
+        throw new SolutionServerClientError(
+          `Solution server connection failure: ${errorCode ?? errorMessage}`,
+        );
       }
 
       this.logger.error("Failed to get server capabilities", error);
@@ -793,7 +816,8 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
         errorMessage.toLowerCase().includes("network") ||
         errorCode === "ECONNRESET" ||
         errorCode === "ECONNREFUSED" ||
-        errorCode === "ETIMEDOUT";
+        errorCode === "ETIMEDOUT" ||
+        (typeof errorCode === "string" && errorCode.startsWith("UND_ERR"));
 
       if (isNotFoundError) {
         // Treat "not found" as a normal case - the violation simply has no hint in the database
@@ -826,8 +850,9 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
           },
         );
 
-        // Mark as disconnected so future calls will know
-        this.isConnected = false;
+        // Mark as disconnected and notify the connection state listener so
+        // the status UI reflects the lost connection
+        this.setConnected(false);
 
         // Close the stale MCP client to prevent resource leaks
         await this.closeStaleClient();

--- a/agentic/src/clients/solutionServerClient.ts
+++ b/agentic/src/clients/solutionServerClient.ts
@@ -128,6 +128,7 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
   private logger: Logger;
   private cachedCapabilities: SolutionServerCapabilities | null = null;
   private connectionStateListener: SolutionServerConnectionListener | null = null;
+  private suppressConnectionNotifications: number = 0;
   public isConnected: boolean = false;
 
   constructor(
@@ -159,7 +160,7 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
   private setConnected(connected: boolean): void {
     const changed = this.isConnected !== connected;
     this.isConnected = connected;
-    if (changed) {
+    if (changed && this.suppressConnectionNotifications === 0) {
       this.connectionStateListener?.(connected);
     }
   }
@@ -206,6 +207,14 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
   }
 
   private async attemptConnectionWithSlashRetry(): Promise<boolean> {
+    // Pin the client instance: a concurrent connection-failure handler can
+    // null this.mcpClient (closeStaleClient) mid-connect, and optional
+    // chaining on null would otherwise report a vacuous "success"
+    const mcpClient = this.mcpClient;
+    if (!mcpClient) {
+      return false;
+    }
+
     const serverUrlObj = new URL(this.serverUrl);
     const redirectAwareFetch = createRedirectAwareFetch(
       serverUrlObj,
@@ -229,9 +238,11 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
     // First attempt with original URL
     try {
       this.logger.debug(`Connecting to MCP server at: ${this.serverUrl}`);
-      await this.mcpClient?.connect(
-        new StreamableHTTPClientTransport(serverUrlObj, transportOptions),
-      );
+      await mcpClient.connect(new StreamableHTTPClientTransport(serverUrlObj, transportOptions));
+      if (this.mcpClient !== mcpClient) {
+        // Client was torn down while we were connecting
+        return false;
+      }
       this.logger.info("Connected to MCP solution server");
       this.setConnected(true);
       return true;
@@ -255,9 +266,13 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
 
       try {
         this.logger.debug(`Retrying connection to MCP server at: ${alternativeUrl}`);
-        await this.mcpClient?.connect(
+        await mcpClient.connect(
           new StreamableHTTPClientTransport(alternativeUrlObj, alternativeTransportOptions),
         );
+        if (this.mcpClient !== mcpClient) {
+          // Client was torn down while we were connecting
+          return false;
+        }
         this.logger.info(
           `Connected to MCP solution server using alternative URL: ${alternativeUrl}`,
         );
@@ -309,10 +324,22 @@ export class SolutionServerClient extends KaiWorkflowEventEmitter {
     this.bearerToken = newToken;
 
     if (wasConnected) {
-      // Reconnect with new token - MCP SDK uses token during connection setup
-      this.logger.info("Reconnecting MCP client with new token");
-      await this.disconnect();
-      await this.connect();
+      // Reconnect with new token - MCP SDK uses token during connection setup.
+      // Suppress connection state notifications for the transient disconnect —
+      // a routine token refresh shouldn't flash the status UI. Notify only if
+      // the final state ends up different from where we started. A counter
+      // (not detaching the listener) keeps this reentrancy-safe and preserves
+      // an external detach that happens while we're suspended at an await.
+      this.suppressConnectionNotifications++;
+      try {
+        await this.disconnect();
+        await this.connect();
+      } finally {
+        this.suppressConnectionNotifications--;
+        if (this.suppressConnectionNotifications === 0 && this.isConnected !== wasConnected) {
+          this.connectionStateListener?.(this.isConnected);
+        }
+      }
     }
   }
 

--- a/changes/unreleased/1468-fix-stale-solution-server-status.yaml
+++ b/changes/unreleased/1468-fix-stale-solution-server-status.yaml
@@ -1,0 +1,6 @@
+kind: bugfix
+description: >
+  Update the Solution Server status chip when the MCP connection goes stale
+  and automatically reconnect. Connection failures detected mid-request are
+  now broadcast to the webview, and the health poll retries the connection
+  with backoff instead of stopping after repeated failures.

--- a/changes/unreleased/1468-fix-token-refresh-client-churn.yaml
+++ b/changes/unreleased/1468-fix-token-refresh-client-churn.yaml
@@ -1,0 +1,8 @@
+kind: bugfix
+description: >
+  Preserve Hub client instances across token refreshes instead of replacing
+  them, so workflows keep a working solution server client (and its clientId
+  session state), and rebuild the LLM proxy model provider with the refreshed
+  token so solution generation no longer fails with 401 after a refresh.
+extensions:
+  - core

--- a/changes/unreleased/fix-no-expiry-token-refresh-loop.yaml
+++ b/changes/unreleased/fix-no-expiry-token-refresh-loop.yaml
@@ -1,0 +1,7 @@
+kind: bugfix
+description: >
+  Treat a Hub token without a known expiry (a PAT minted with no
+  expiration/lifespan, or an OIDC token with no expires_in and no exp claim)
+  as long-lived instead of already expired, so the refresh timer no longer
+  falls into an immediate-refresh loop that mints tokens against the Hub at
+  request speed and prevents connect() from ever completing.

--- a/vscode/core/src/extension.ts
+++ b/vscode/core/src/extension.ts
@@ -588,6 +588,16 @@ class VsCodeExtension {
       this.context.subscriptions.push(this.diffStatusBarItem);
       this.checkContinueInstalled();
 
+      // Broadcast solution server connection state changes to the webview so
+      // the status chip reflects disconnects the client detects internally
+      // (e.g. a stale MCP connection timing out mid-request)
+      this.state.hubConnectionManager.setSolutionServerConnectionCallback((connected) => {
+        this.state.logger.info("Solution server connection state changed", { connected });
+        this.state.mutateServerState((draft) => {
+          draft.solutionServerConnected = connected;
+        });
+      });
+
       // Set up workflow disposal callback for when Hub clients reconnect
       // This handles both solution server changes and LLM proxy availability
       this.state.hubConnectionManager.setWorkflowDisposalCallback((tokenRefreshOnly) => {
@@ -740,23 +750,27 @@ class VsCodeExtension {
               draft.solutionServerConnected = false;
             });
 
-            // Exponential backoff: 10s -> 30s -> 60s (max)
-            if (consecutiveFailures === 1) {
+            // Attempt to re-establish the connection automatically — stale
+            // MCP connections drop after idle periods (see issue #1433)
+            const reconnected = await this.state.hubConnectionManager.reconnectSolutionServer();
+            if (reconnected) {
+              consecutiveFailures = 0;
+              pollInterval = 10000;
+              this.state.mutateServerState((draft) => {
+                draft.solutionServerConnected = true;
+              });
+            } else if (consecutiveFailures === 1) {
+              // Exponential backoff: 10s -> 30s -> 60s, then a slow 5m
+              // heartbeat so the connection can recover without manual retry
               pollInterval = 30000;
-            } else if (consecutiveFailures >= 2) {
+            } else if (consecutiveFailures < 5) {
               pollInterval = 60000;
+            } else {
+              pollInterval = 300000;
             }
           }
 
-          // Schedule next poll unless we've had too many failures
-          if (consecutiveFailures < 5) {
-            scheduleNextPoll(withJitter(pollInterval));
-          } else {
-            // Stop polling after 5 consecutive failures - will resume on manual retry or config change
-            this.state.logger.info(
-              "Stopping connection polling after repeated failures. Will resume on demand.",
-            );
-          }
+          scheduleNextPoll(withJitter(pollInterval));
         }, delay);
       };
 

--- a/vscode/core/src/hub/HubConnectionManager.ts
+++ b/vscode/core/src/hub/HubConnectionManager.ts
@@ -118,6 +118,18 @@ export class HubConnectionManager {
   // Mutex: coalesce concurrent connect() calls into a single in-flight operation
   private connectPromise: Promise<void> | null = null;
 
+  // Mutex: coalesce concurrent reconnectSolutionServer() calls
+  private reconnectPromise: Promise<boolean> | null = null;
+
+  // Bumped on every manager-level disconnect (full connect, logout, config
+  // change). An in-flight reconnect whose epoch no longer matches must discard
+  // its result instead of resurrecting a connection built from stale state.
+  private connectionEpoch: number = 0;
+
+  // True while oidcLogout tears down auth state; set synchronously at its
+  // entry so an in-flight reconnect can never install a client mid-logout
+  private teardownInProgress: boolean = false;
+
   constructor(defaultConfig: HubConfig, logger: Logger) {
     this.config = defaultConfig;
     this.logger = logger.child({
@@ -153,19 +165,29 @@ export class HubConnectionManager {
    * Create a solution server client wired to the connection state callback.
    */
   private createSolutionServerClient(): SolutionServerClient {
-    const client = new SolutionServerClient(
+    const client = this.buildSolutionServerClient();
+    this.attachConnectionListener(client);
+    return client;
+  }
+
+  /** Construct a solution server client without a connection state listener. */
+  private buildSolutionServerClient(): SolutionServerClient {
+    return new SolutionServerClient(
       this.config.url,
       this.bearerToken,
       this.logger,
       this.scopedFetch ?? undefined,
     );
+  }
+
+  /** Wire a client's connection state transitions to the webview callback. */
+  private attachConnectionListener(client: SolutionServerClient): void {
     client.setConnectionStateListener((connected) => {
       if (!connected) {
         this.logger.warn("Solution server connection lost");
       }
       this.onSolutionServerConnectionChange?.(connected);
     });
-    return client;
   }
 
   /**
@@ -555,8 +577,11 @@ export class HubConnectionManager {
             await this.solutionServerClient.connect();
           }
         } catch (error) {
-          // Keep the instance — the health poll (reconnectSolutionServer) can
-          // recover the connection without stranding workflow references
+          // Keep the instance — the health poll (reconnectSolutionServer) will
+          // recover the connection. But report it as replaced: the client is
+          // left disconnected and the poll's recovery mints a new instance, so
+          // workflows must be disposed rather than run against this one.
+          solutionClientReplaced = true;
           this.logger.error("Failed to update solution server client token", error);
         }
       } else {
@@ -634,6 +659,19 @@ export class HubConnectionManager {
       // A full connect() is in flight; let it establish the client
       return false;
     }
+    if (this.reconnectPromise) {
+      // A reconnect is already in flight; share its outcome
+      return this.reconnectPromise;
+    }
+    this.reconnectPromise = this._reconnectSolutionServer();
+    try {
+      return await this.reconnectPromise;
+    } finally {
+      this.reconnectPromise = null;
+    }
+  }
+
+  private async _reconnectSolutionServer(): Promise<boolean> {
     if (!this.config.enabled || !this.config.features.solutionServer.enabled) {
       return false;
     }
@@ -641,38 +679,82 @@ export class HubConnectionManager {
       // No usable token — reconnecting requires re-authentication (sign in)
       return false;
     }
+    if (this.isRefreshingTokens || this.teardownInProgress) {
+      // Token refresh reconnects the clients itself; logout is tearing state
+      // down — racing either would corrupt the client they're working on
+      return false;
+    }
 
+    const epoch = this.connectionEpoch;
+
+    // Build and connect the replacement first, so concurrent readers never
+    // observe a null client mid-reconnect; the stale (disconnected) instance
+    // stays in place until the new one is confirmed live. The listener is
+    // attached only after the epoch check below, so a discarded client never
+    // broadcasts state.
+    let newClient: SolutionServerClient | null = null;
+    try {
+      this.logger.info("Attempting solution server reconnection");
+      newClient = this.buildSolutionServerClient();
+      await newClient.connect();
+    } catch (error) {
+      this.logger.warn("Solution server reconnection failed", { error });
+      // A partially-connected client (transport up, listTools failed) would
+      // otherwise leak its MCP session
+      await newClient?.disconnect().catch(() => {});
+      return false;
+    }
+
+    // Re-check every invalidating condition at the swap point: a full
+    // connect(), logout, token refresh, or config change that started while
+    // we were connecting means this client was built from stale config/token
+    const superseded =
+      this.connectPromise ||
+      this.teardownInProgress ||
+      this.isRefreshingTokens ||
+      epoch !== this.connectionEpoch ||
+      (this.config.auth.enabled && !this.bearerToken);
+    if (superseded) {
+      this.logger.info("Discarding reconnect result superseded by a newer connection change");
+      await newClient.disconnect().catch(() => {});
+      return false;
+    }
+
+    this.attachConnectionListener(newClient);
     const staleClient = this.solutionServerClient;
-    this.solutionServerClient = null;
+    this.solutionServerClient = newClient;
     if (staleClient) {
+      // Detach the listener so tearing down the old client can't broadcast a
+      // stale "disconnected" over the newly connected state
+      staleClient.setConnectionStateListener(null);
       try {
         await staleClient.disconnect();
       } catch (error) {
         this.logger.debug("Error disposing stale solution server client", { error });
       }
     }
+    this.logger.info("Solution server reconnected");
 
+    // Workflows capture the client instance at init — dispose so the next
+    // run picks up the new client (deferred if a workflow is running). Guarded:
+    // a throwing callback must not reject the reconnect (the health poll would
+    // die un-rescheduled).
     try {
-      this.logger.info("Attempting solution server reconnection");
-      const client = this.createSolutionServerClient();
-      await client.connect();
-      this.solutionServerClient = client;
-      this.logger.info("Solution server reconnected");
-
-      // Workflows capture the client instance at init — dispose so the next
-      // run picks up the new client (deferred if a workflow is running)
       this.onWorkflowDisposal?.(false);
-      return true;
     } catch (error) {
-      this.logger.warn("Solution server reconnection failed", { error });
-      return false;
+      this.logger.warn("Workflow disposal callback failed after reconnect", { error });
     }
+    return true;
   }
 
   /**
    * Disconnect from Hub and clean up all resources
    */
   public async disconnect(): Promise<void> {
+    // Invalidate any in-flight solution server reconnect — its result would
+    // be built from the pre-disconnect config/token
+    this.connectionEpoch++;
+
     if (!this.solutionServerClient && !this.profileSyncClient) {
       this.logger.silly("No Hub features connected, skipping disconnect");
       return;
@@ -767,6 +849,21 @@ export class HubConnectionManager {
    * Logout from OIDC (clear stored tokens).
    */
   public async oidcLogout(): Promise<void> {
+    // Block in-flight/new health-poll reconnects for the whole teardown — a
+    // reconnect completing mid-logout would resurrect a connection with the
+    // PAT the user is revoking
+    this.teardownInProgress = true;
+    try {
+      if (this.reconnectPromise) {
+        await this.reconnectPromise.catch(() => {});
+      }
+      await this.doOidcLogout();
+    } finally {
+      this.teardownInProgress = false;
+    }
+  }
+
+  private async doOidcLogout(): Promise<void> {
     // Server-side cleanup before clearing local state
     try {
       if (!this.oidcAuthCode && this.getAuthMethod() === "oidc") {
@@ -1351,9 +1448,18 @@ export class HubConnectionManager {
       this.logger.info(`Token refresh scheduled in ${Math.round(timeUntilRefresh / 1000)}s`);
       this.refreshTimer = setTimeout(() => this.refreshTokens(), timeUntilRefresh);
     } else if (this.bearerToken) {
-      // Token already needs refresh
-      this.logger.info("Token already expired or near expiry, refreshing now");
-      await this.refreshTokens();
+      if (this.isRefreshingTokens) {
+        // We're being called from within refreshTokens itself and the fresh
+        // token is already inside the expiry buffer. Recursing would hit the
+        // reentrancy guard and silently drop the refresh chain — arm a short
+        // timer instead so the chain stays alive.
+        this.logger.info("Fresh token already near expiry; scheduling follow-up refresh");
+        this.refreshTimer = setTimeout(() => this.refreshTokens(), REAUTH_DELAY_MS);
+      } else {
+        // Token already needs refresh
+        this.logger.info("Token already expired or near expiry, refreshing now");
+        await this.refreshTokens();
+      }
     }
   }
 
@@ -1361,9 +1467,24 @@ export class HubConnectionManager {
    * Refresh tokens using the appropriate flow.
    */
   private async refreshTokens(): Promise<void> {
+    if (this.isRefreshingTokens) {
+      // A refresh is already in flight (e.g. timer firing while a manual
+      // connect kicked one off) — running two concurrently would race
+      // updateBearerToken calls on the same client instances
+      this.logger.info("Token refresh already in progress, skipping");
+      return;
+    }
     this.isRefreshingTokens = true;
 
     try {
+      // Let any in-flight health-poll reconnect settle before touching the
+      // clients — its swap would otherwise tear down the instance we're about
+      // to update. (With isRefreshingTokens now set, the reconnect discards
+      // its result at the swap point rather than installing it.)
+      if (this.reconnectPromise) {
+        await this.reconnectPromise.catch(() => {});
+      }
+
       const method = this.getAuthMethod();
       let refreshed = false;
 

--- a/vscode/core/src/hub/HubConnectionManager.ts
+++ b/vscode/core/src/hub/HubConnectionManager.ts
@@ -1321,15 +1321,22 @@ export class HubConnectionManager {
   private async startTokenRefreshTimer(): Promise<void> {
     this.clearTokenRefreshTimer();
 
-    let timeUntilRefresh: number = 0;
+    // null = no known expiry; 0 = expired/due now. The two must not be
+    // conflated: a token without an expiry (PAT minted with no expiration/
+    // lifespan, or an OIDC token with no expires_in and no exp claim) is
+    // long-lived, and refreshing it "now" would mint a replacement that also
+    // lacks an expiry — recursing through refreshTokens() in a tight loop.
+    let timeUntilRefresh: number | null = null;
 
     if (this.getAuthMethod() === "oidc" && this.oidcAuthCode) {
       timeUntilRefresh = this.oidcAuthCode.getTimeUntilRefresh();
-    } else if (this.tokenExpiresAt) {
+    } else if (this.tokenExpiresAt !== null) {
       timeUntilRefresh = Math.max(0, this.tokenExpiresAt - TOKEN_EXPIRY_BUFFER_MS - Date.now());
     }
 
-    if (timeUntilRefresh > MAX_TIMER_MS) {
+    if (timeUntilRefresh === null) {
+      this.logger.info("Token has no known expiry; refresh timer not armed");
+    } else if (timeUntilRefresh > MAX_TIMER_MS) {
       // Delay exceeds Node's max timer. Wait the max, then re-evaluate rather
       // than refresh — a single setTimeout this large would overflow to 1ms and
       // spin the refresh/reconnect loop continuously.

--- a/vscode/core/src/hub/HubConnectionManager.ts
+++ b/vscode/core/src/hub/HubConnectionManager.ts
@@ -35,6 +35,9 @@ export type WorkflowDisposalCallback = (tokenRefreshOnly?: boolean) => void;
 // Callback type for profile sync (to trigger automatic sync)
 export type ProfileSyncCallback = () => Promise<void>;
 
+// Callback type for solution server connection state changes (broadcast to webview)
+export type SolutionServerConnectionCallback = (connected: boolean) => void;
+
 const TOKEN_EXPIRY_BUFFER_MS = 30000; // 30 second buffer
 // Node's setTimeout stores its delay in a 32-bit signed int. A larger delay
 // overflows, gets clamped to 1ms, and fires immediately — which for the token
@@ -79,6 +82,7 @@ export class HubConnectionManager {
   private solutionServerClient: SolutionServerClient | null = null;
   private profileSyncClient: ProfileSyncClient | null = null;
   private onWorkflowDisposal?: WorkflowDisposalCallback;
+  private onSolutionServerConnectionChange?: SolutionServerConnectionCallback;
 
   // Authentication state
   private bearerToken: string | null = null;
@@ -134,6 +138,34 @@ export class HubConnectionManager {
    */
   public setWorkflowDisposalCallback(callback: WorkflowDisposalCallback): void {
     this.onWorkflowDisposal = callback;
+  }
+
+  /**
+   * Set callback invoked when the solution server connection state changes,
+   * including disconnects the client detects internally (e.g. a stale MCP
+   * connection failing mid-request).
+   */
+  public setSolutionServerConnectionCallback(callback: SolutionServerConnectionCallback): void {
+    this.onSolutionServerConnectionChange = callback;
+  }
+
+  /**
+   * Create a solution server client wired to the connection state callback.
+   */
+  private createSolutionServerClient(): SolutionServerClient {
+    const client = new SolutionServerClient(
+      this.config.url,
+      this.bearerToken,
+      this.logger,
+      this.scopedFetch ?? undefined,
+    );
+    client.setConnectionStateListener((connected) => {
+      if (!connected) {
+        this.logger.warn("Solution server connection lost");
+      }
+      this.onSolutionServerConnectionChange?.(connected);
+    });
+    return client;
   }
 
   /**
@@ -453,12 +485,7 @@ export class HubConnectionManager {
     if (this.config.features.solutionServer.enabled) {
       try {
         this.logger.info("Connecting solution server client", { hubUrl: this.config.url });
-        this.solutionServerClient = new SolutionServerClient(
-          this.config.url,
-          this.bearerToken,
-          this.logger,
-          this.scopedFetch ?? undefined,
-        );
+        this.solutionServerClient = this.createSolutionServerClient();
         await this.solutionServerClient.connect();
         this.logger.info("Successfully connected to Hub solution server");
         vscode.window.showInformationMessage("Successfully connected to Hub solution server");
@@ -512,12 +539,7 @@ export class HubConnectionManager {
     if (this.config.features.solutionServer.enabled) {
       try {
         this.logger.info("Reconnecting solution server client", { hubUrl: this.config.url });
-        this.solutionServerClient = new SolutionServerClient(
-          this.config.url,
-          this.bearerToken,
-          this.logger,
-          this.scopedFetch ?? undefined,
-        );
+        this.solutionServerClient = this.createSolutionServerClient();
         await this.solutionServerClient.connect();
         this.logger.info("Successfully reconnected to Hub solution server");
       } catch (error) {
@@ -554,6 +576,53 @@ export class HubConnectionManager {
         vscode.window.showErrorMessage(`Failed to connect to Hub profile sync: ${errorMessage}`);
         this.profileSyncClient = null;
       }
+    }
+  }
+
+  /**
+   * Re-establish only the solution server connection using the current bearer
+   * token, without re-authenticating or disturbing other Hub features. Used
+   * by the health poll to recover from stale/dropped MCP connections.
+   *
+   * Returns true if the connection was re-established.
+   */
+  public async reconnectSolutionServer(): Promise<boolean> {
+    if (this.connectPromise) {
+      // A full connect() is in flight; let it establish the client
+      return false;
+    }
+    if (!this.config.enabled || !this.config.features.solutionServer.enabled) {
+      return false;
+    }
+    if (this.config.auth.enabled && !this.bearerToken) {
+      // No usable token — reconnecting requires re-authentication (sign in)
+      return false;
+    }
+
+    const staleClient = this.solutionServerClient;
+    this.solutionServerClient = null;
+    if (staleClient) {
+      try {
+        await staleClient.disconnect();
+      } catch (error) {
+        this.logger.debug("Error disposing stale solution server client", { error });
+      }
+    }
+
+    try {
+      this.logger.info("Attempting solution server reconnection");
+      const client = this.createSolutionServerClient();
+      await client.connect();
+      this.solutionServerClient = client;
+      this.logger.info("Solution server reconnected");
+
+      // Workflows capture the client instance at init — dispose so the next
+      // run picks up the new client (deferred if a workflow is running)
+      this.onWorkflowDisposal?.(false);
+      return true;
+    } catch (error) {
+      this.logger.warn("Solution server reconnection failed", { error });
+      return false;
     }
   }
 

--- a/vscode/core/src/hub/HubConnectionManager.ts
+++ b/vscode/core/src/hub/HubConnectionManager.ts
@@ -531,52 +531,95 @@ export class HubConnectionManager {
   }
 
   /**
-   * Reconnect solution server and profile sync clients with the current bearer token,
+   * Update solution server and profile sync clients with the current bearer token,
    * without re-authenticating. Used by token refresh to avoid double-minting tokens.
+   *
+   * Existing client instances are preserved (via updateBearerToken) so that a
+   * workflow's client reference captured at workflowManager.init — and session
+   * state like clientId — stays valid across token refreshes. A new instance is
+   * only created when a client is missing (e.g. its initial connection failed).
+   *
+   * Returns true if the solution server client instance was replaced, meaning
+   * workflows holding the old reference need a full disposal.
    */
-  private async reconnectClients(): Promise<void> {
-    // Connect Solution Server
-    if (this.config.features.solutionServer.enabled) {
-      try {
-        this.logger.info("Reconnecting solution server client", { hubUrl: this.config.url });
-        this.solutionServerClient = this.createSolutionServerClient();
-        await this.solutionServerClient.connect();
-        this.logger.info("Successfully reconnected to Hub solution server");
-      } catch (error) {
-        this.logger.error("Failed to reconnect solution server client", error);
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        vscode.window.showErrorMessage(`Failed to connect to Hub solution server: ${errorMessage}`);
-        this.solutionServerClient = null;
-      }
-    }
+  private async reconnectClients(): Promise<boolean> {
+    let solutionClientReplaced = false;
 
-    // Connect Profile Sync
-    if (this.config.features.profileSync.enabled) {
-      try {
-        this.logger.info("Reconnecting profile sync client");
-        this.profileSyncClient = new ProfileSyncClient(
-          this.config.url,
-          this.bearerToken,
-          this.logger,
-          this.scopedFetch ?? undefined,
-        );
-        await this.profileSyncClient.connect({ skipConnectivityCheck: true });
-        this.logger.info("Successfully reconnected to Hub profile sync");
-
-        const llmProxyConfig = this.profileSyncClient.getLLMProxyConfig();
-        if (llmProxyConfig) {
-          this.logger.info("LLM proxy available", { endpoint: llmProxyConfig.endpoint });
+    // Solution Server
+    if (this.config.features.solutionServer.enabled && this.bearerToken) {
+      if (this.solutionServerClient) {
+        try {
+          this.logger.info("Updating solution server client with refreshed token");
+          await this.solutionServerClient.updateBearerToken(this.bearerToken);
+          if (!this.solutionServerClient.isConnected) {
+            await this.solutionServerClient.connect();
+          }
+        } catch (error) {
+          // Keep the instance — the health poll (reconnectSolutionServer) can
+          // recover the connection without stranding workflow references
+          this.logger.error("Failed to update solution server client token", error);
         }
-
-        this.triggerProfileSync();
-        this.startProfileSyncTimer();
-      } catch (error) {
-        this.logger.error("Failed to reconnect profile sync client", error);
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        vscode.window.showErrorMessage(`Failed to connect to Hub profile sync: ${errorMessage}`);
-        this.profileSyncClient = null;
+      } else {
+        try {
+          this.logger.info("Reconnecting solution server client", { hubUrl: this.config.url });
+          this.solutionServerClient = this.createSolutionServerClient();
+          await this.solutionServerClient.connect();
+          solutionClientReplaced = true;
+          this.logger.info("Successfully reconnected to Hub solution server");
+        } catch (error) {
+          this.logger.error("Failed to reconnect solution server client", error);
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          vscode.window.showErrorMessage(
+            `Failed to connect to Hub solution server: ${errorMessage}`,
+          );
+          this.solutionServerClient = null;
+        }
       }
     }
+
+    // Profile Sync
+    if (this.config.features.profileSync.enabled && this.bearerToken) {
+      if (this.profileSyncClient) {
+        this.logger.info("Updating profile sync client with refreshed token");
+        this.profileSyncClient.updateBearerToken(this.bearerToken);
+        if (!this.profileSyncClient.isConnected) {
+          try {
+            await this.profileSyncClient.connect({ skipConnectivityCheck: true });
+            this.triggerProfileSync();
+            this.startProfileSyncTimer();
+          } catch (error) {
+            this.logger.error("Failed to reconnect profile sync client", error);
+          }
+        }
+      } else {
+        try {
+          this.logger.info("Reconnecting profile sync client");
+          this.profileSyncClient = new ProfileSyncClient(
+            this.config.url,
+            this.bearerToken,
+            this.logger,
+            this.scopedFetch ?? undefined,
+          );
+          await this.profileSyncClient.connect({ skipConnectivityCheck: true });
+          this.logger.info("Successfully reconnected to Hub profile sync");
+
+          const llmProxyConfig = this.profileSyncClient.getLLMProxyConfig();
+          if (llmProxyConfig) {
+            this.logger.info("LLM proxy available", { endpoint: llmProxyConfig.endpoint });
+          }
+
+          this.triggerProfileSync();
+          this.startProfileSyncTimer();
+        } catch (error) {
+          this.logger.error("Failed to reconnect profile sync client", error);
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          vscode.window.showErrorMessage(`Failed to connect to Hub profile sync: ${errorMessage}`);
+          this.profileSyncClient = null;
+        }
+      }
+    }
+
+    return solutionClientReplaced;
   }
 
   /**
@@ -1334,8 +1377,15 @@ export class HubConnectionManager {
         this.refreshRetryCount = 0;
         await this.startTokenRefreshTimer();
 
-        // Reconnect clients with new token (without re-authenticating)
-        await this.reconnectClients();
+        // Update clients with new token (without re-authenticating)
+        const solutionClientReplaced = await this.reconnectClients();
+
+        // Notify so the model provider is recreated with the new bearer token
+        // (it's baked into ChatOpenAI instances). tokenRefreshOnly=true keeps
+        // the workflow alive when the solution server client was preserved;
+        // if the instance had to be replaced, request a full disposal so the
+        // next run picks up the new client.
+        this.onWorkflowDisposal?.(!solutionClientReplaced);
       } else {
         this.logger.warn("Token refresh failed");
         this.handleRefreshFailure();

--- a/vscode/core/src/hub/HubConnectionManager.ts
+++ b/vscode/core/src/hub/HubConnectionManager.ts
@@ -505,17 +505,24 @@ export class HubConnectionManager {
 
     // Connect Solution Server
     if (this.config.features.solutionServer.enabled) {
+      let client: SolutionServerClient | null = null;
       try {
         this.logger.info("Connecting solution server client", { hubUrl: this.config.url });
-        this.solutionServerClient = this.createSolutionServerClient();
-        await this.solutionServerClient.connect();
+        client = this.createSolutionServerClient();
+        this.solutionServerClient = client;
+        await client.connect();
         this.logger.info("Successfully connected to Hub solution server");
         vscode.window.showInformationMessage("Successfully connected to Hub solution server");
       } catch (error) {
         this.logger.error("Failed to connect solution server client", error);
         const errorMessage = error instanceof Error ? error.message : String(error);
         vscode.window.showErrorMessage(`Failed to connect to Hub solution server: ${errorMessage}`);
-        this.solutionServerClient = null;
+        // A partially-connected client (transport up, listTools failed) would
+        // otherwise leak its MCP session
+        await client?.disconnect().catch(() => {});
+        if (this.solutionServerClient === client) {
+          this.solutionServerClient = null;
+        }
       }
     }
 
@@ -585,10 +592,12 @@ export class HubConnectionManager {
           this.logger.error("Failed to update solution server client token", error);
         }
       } else {
+        let client: SolutionServerClient | null = null;
         try {
           this.logger.info("Reconnecting solution server client", { hubUrl: this.config.url });
-          this.solutionServerClient = this.createSolutionServerClient();
-          await this.solutionServerClient.connect();
+          client = this.createSolutionServerClient();
+          this.solutionServerClient = client;
+          await client.connect();
           solutionClientReplaced = true;
           this.logger.info("Successfully reconnected to Hub solution server");
         } catch (error) {
@@ -597,7 +606,11 @@ export class HubConnectionManager {
           vscode.window.showErrorMessage(
             `Failed to connect to Hub solution server: ${errorMessage}`,
           );
-          this.solutionServerClient = null;
+          // Clean up a partially-connected client to avoid leaking its session
+          await client?.disconnect().catch(() => {});
+          if (this.solutionServerClient === client) {
+            this.solutionServerClient = null;
+          }
         }
       }
     }
@@ -854,6 +867,11 @@ export class HubConnectionManager {
     // PAT the user is revoking
     this.teardownInProgress = true;
     try {
+      // Quiesce a full connect() too — it could otherwise finish after the
+      // teardown and install a client with the just-revoked credentials
+      if (this.connectPromise) {
+        await this.connectPromise.catch(() => {});
+      }
       if (this.reconnectPromise) {
         await this.reconnectPromise.catch(() => {});
       }
@@ -1512,8 +1530,13 @@ export class HubConnectionManager {
         // (it's baked into ChatOpenAI instances). tokenRefreshOnly=true keeps
         // the workflow alive when the solution server client was preserved;
         // if the instance had to be replaced, request a full disposal so the
-        // next run picks up the new client.
-        this.onWorkflowDisposal?.(!solutionClientReplaced);
+        // next run picks up the new client. Guarded: a throwing callback must
+        // not make a successful refresh look failed to the retry handler.
+        try {
+          this.onWorkflowDisposal?.(!solutionClientReplaced);
+        } catch (error) {
+          this.logger.warn("Workflow disposal callback failed after token refresh", { error });
+        }
       } else {
         this.logger.warn("Token refresh failed");
         this.handleRefreshFailure();

--- a/vscode/core/src/hub/OIDCAuthCodeFlow.ts
+++ b/vscode/core/src/hub/OIDCAuthCodeFlow.ts
@@ -128,9 +128,14 @@ export class OIDCAuthCodeFlow {
     return Date.now() < this.expiresAt - TOKEN_EXPIRY_BUFFER_MS;
   }
 
-  public getTimeUntilRefresh(): number {
+  /**
+   * Milliseconds until the token should be refreshed, 0 if it is already due,
+   * or null if the token has no known expiry (isTokenValid() treats such
+   * tokens as valid indefinitely, so there is nothing to refresh).
+   */
+  public getTimeUntilRefresh(): number | null {
     if (!this.expiresAt) {
-      return 0;
+      return null;
     }
     const remaining = this.expiresAt - TOKEN_EXPIRY_BUFFER_MS - Date.now();
     return Math.max(0, remaining);


### PR DESCRIPTION
## Summary

Fixes #1433 — the Solution Server status chip stayed green after the MCP SSE connection went stale.

There were three compounding problems:

1. **No state propagation**: `SolutionServerClient` detected connection failures, set `isConnected = false`, and closed the stale client internally — but never notified `HubConnectionManager`, so `solutionServerConnected` was never broadcast to the webview.
2. **Health poll masked failures**: the 10s health poll calls `getServerCapabilities(true)`, but on connection errors that method swallowed the error and returned empty capabilities. The poll's success path then ran and set the chip back to green *right after* the client had detected the failure.
3. **Polling stopped permanently** after 5 consecutive failures with no way to resume (the manual restart command doesn't restart the poll loop), so the state could never recover automatically.

## Changes

**`agentic/src/clients/solutionServerClient.ts`**
- Add `setConnectionStateListener()` — fires on every `isConnected` transition (connect, disconnect, and stale-connection detection in `getServerCapabilities`/`getBestHint`)
- `getServerCapabilities()` now throws `SolutionServerClientError` on connection failure instead of returning empty capabilities, so the health poll registers the disconnect
- Classify undici `UND_ERR_*` codes (e.g. the `UND_ERR_CONNECT_TIMEOUT` from the issue's logs) as connection errors

**`vscode/core/src/hub/HubConnectionManager.ts`**
- Wire every created `SolutionServerClient` to a new `setSolutionServerConnectionCallback()` so state changes propagate out
- New `reconnectSolutionServer()`: lightweight reconnect that reuses the current bearer token without re-authenticating or disturbing other Hub features; triggers workflow disposal on success so the next workflow run picks up the new client instance

**`vscode/core/src/extension.ts`**
- Broadcast connection state changes to the webview (`solutionServerConnected`) — the chip now goes grey the moment a stale connection is detected, including mid-workflow
- Health poll auto-reconnects on failure and backs off to a slow 5-minute heartbeat instead of stopping permanently

## Behavior after this change

- Idle timeout (~18–30 min) → next request or poll detects the failure → chip turns grey immediately
- The poll then attempts reconnection automatically (10s → 30s → 60s → 5m backoff) and the chip returns to green once the connection is re-established — no manual restart needed

## Also: token refresh no longer replaces Hub client instances

While wiring the above, we found the other trigger of the same stale-client family: `refreshTokens()` called `reconnectClients()`, which built **new** `SolutionServerClient`/`ProfileSyncClient` instances on every token refresh — without disconnecting the old ones and without firing `onWorkflowDisposal`. This is a regression of #1273's fix (#1283, "don't nuke clientid for token refresh"), reintroduced by the OIDC rework in #1419 and shipping since v0.5.25. It only bites configs where the refresh timer actually arms (credentials auth, or OIDC when the PAT exchange fails — the happy OIDC path uses a long-lived PAT and never refreshes), but there the consequences compound: a mid-run workflow keeps an orphaned client whose token dies ~30s post-refresh (refresh fires `TOKEN_EXPIRY_BUFFER_MS` early), batch-review accept/reject goes out with an empty `client_id` (breaking success-rate correlation), the orphaned client's still-attached state listener flaps the status chip, and the hub-proxy model provider — whose token is baked into its `ChatOpenAI` instances — 401s every subsequent solution run with no auto-recovery.

**`vscode/core/src/hub/HubConnectionManager.ts`**
- `reconnectClients()` now updates the existing instances in place via `updateBearerToken()` (restoring the #1283 pattern), preserving workflow references and `clientId` session state; a new instance is created only when a client is missing, and on update failure the instance is kept so the health poll above can recover it
- `refreshTokens()` now fires `onWorkflowDisposal(tokenRefreshOnly)` after a successful refresh, so the extension rebuilds the model provider with the fresh token — `extension.ts`'s existing `tokenRefreshOnly` handling (skip workflow disposal, rebuild provider) finally gets exercised as its comment always claimed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solution Server status handling so connection changes are reflected immediately in the webview and the app can recover automatically.
  * Fixed stale connection behavior by continuing health polling with backoff and attempting reconnection after capability-load failures.
  * Reduced issues during token refresh by preserving existing client state when possible, preventing session churn and avoiding post-refresh 401 failures.
  * Prevented token refresh loops when no expiry is known, and improved reliability of capability/hint retrieval error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->