### PR TITLE
:bug: Defer health-poll reconnect until second consecutive failure

### DIFF
--- a/agentic/tests/solutionServerClient.test.ts
+++ b/agentic/tests/solutionServerClient.test.ts
@@ -1,0 +1,219 @@
+import * as winston from "winston";
+import {
+  SolutionServerClient,
+  SolutionServerClientError,
+} from "../src/clients/solutionServerClient";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeLogger(): winston.Logger {
+  return winston.createLogger({
+    level: "error", // keep test output quiet
+    silent: true,
+  });
+}
+
+/** Build a connected client by injecting a mock MCP client. */
+function buildConnectedClient(): {
+  client: SolutionServerClient;
+  mockMcpClient: { listTools: jest.Mock; listResources: jest.Mock; close: jest.Mock };
+} {
+  const client = new SolutionServerClient("https://hub.example.com", "fake-token", makeLogger());
+
+  // Simulate a successful connection: poke internal state the same way
+  // connect() would after a successful transport handshake.
+  const mockMcpClient = {
+    listTools: jest.fn().mockResolvedValue({ tools: [{ name: "tool_a" }] }),
+    listResources: jest.fn().mockResolvedValue({ resources: [{ name: "res_a" }] }),
+    close: jest.fn().mockResolvedValue(undefined),
+  };
+  // Inject mock MCP client via the private field (test-only access)
+  (client as any).mcpClient = mockMcpClient;
+  (client as any).isConnected = true;
+
+  return { client, mockMcpClient };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("SolutionServerClient", () => {
+  describe("getServerCapabilities", () => {
+    it("returns cached capabilities on success", async () => {
+      const { client } = buildConnectedClient();
+
+      const caps = await client.getServerCapabilities(true);
+      expect(caps.tools).toHaveLength(1);
+      expect(caps.resources).toHaveLength(1);
+    });
+
+    it("throws SolutionServerClientError on connection error (fetch failed)", async () => {
+      const { client, mockMcpClient } = buildConnectedClient();
+
+      // Simulate a connection failure on listTools
+      mockMcpClient.listTools.mockRejectedValueOnce(
+        Object.assign(new Error("fetch failed"), {
+          cause: { code: "ECONNRESET" },
+        }),
+      );
+
+      await expect(client.getServerCapabilities(true)).rejects.toThrow(SolutionServerClientError);
+      // Client should now be marked as disconnected
+      expect(client.isConnected).toBe(false);
+    });
+
+    it("fires the connection state listener on connection error", async () => {
+      const { client, mockMcpClient } = buildConnectedClient();
+
+      const stateChanges: boolean[] = [];
+      client.setConnectionStateListener((connected) => {
+        stateChanges.push(connected);
+      });
+
+      // Simulate a connection failure
+      mockMcpClient.listTools.mockRejectedValueOnce(
+        Object.assign(new Error("fetch failed"), {
+          cause: { code: "ECONNRESET" },
+        }),
+      );
+
+      await expect(client.getServerCapabilities(true)).rejects.toThrow();
+
+      // The listener should have been notified of the disconnect
+      expect(stateChanges).toEqual([false]);
+    });
+
+    it("closes the stale MCP client on connection error", async () => {
+      const { client, mockMcpClient } = buildConnectedClient();
+
+      mockMcpClient.listTools.mockRejectedValueOnce(
+        Object.assign(new Error("fetch failed"), {
+          cause: { code: "UND_ERR_CONNECT_TIMEOUT" },
+        }),
+      );
+
+      await expect(client.getServerCapabilities(true)).rejects.toThrow();
+
+      // The stale client should have been closed
+      expect(mockMcpClient.close).toHaveBeenCalled();
+      // Internal mcpClient should be null now
+      expect((client as any).mcpClient).toBeNull();
+    });
+
+    it("rethrows non-connection errors without side-effects", async () => {
+      const { client, mockMcpClient } = buildConnectedClient();
+
+      const listener = jest.fn();
+      client.setConnectionStateListener(listener);
+
+      // A non-connection error (e.g. protocol/parse error)
+      mockMcpClient.listTools.mockRejectedValueOnce(new Error("Invalid JSON"));
+
+      await expect(client.getServerCapabilities(true)).rejects.toThrow("Invalid JSON");
+
+      // Should NOT have disconnected or notified
+      expect(client.isConnected).toBe(true);
+      expect(listener).not.toHaveBeenCalled();
+      expect(mockMcpClient.close).not.toHaveBeenCalled();
+    });
+
+    it("detects UND_ERR codes as connection errors", async () => {
+      const { client, mockMcpClient } = buildConnectedClient();
+
+      mockMcpClient.listTools.mockRejectedValueOnce(
+        Object.assign(new Error("other failure"), {
+          cause: { code: "UND_ERR_SOCKET" },
+        }),
+      );
+
+      await expect(client.getServerCapabilities(true)).rejects.toThrow(SolutionServerClientError);
+      expect(client.isConnected).toBe(false);
+    });
+  });
+
+  describe("setConnectionStateListener", () => {
+    it("does not fire on initial construction", () => {
+      const client = new SolutionServerClient(
+        "https://hub.example.com",
+        "fake-token",
+        makeLogger(),
+      );
+
+      const listener = jest.fn();
+      client.setConnectionStateListener(listener);
+
+      // No state change should fire just from setting the listener
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("fires on disconnect", async () => {
+      const { client } = buildConnectedClient();
+
+      const stateChanges: boolean[] = [];
+      client.setConnectionStateListener((connected) => {
+        stateChanges.push(connected);
+      });
+
+      await client.disconnect();
+
+      expect(stateChanges).toEqual([false]);
+    });
+
+    it("can be detached by setting null", async () => {
+      const { client } = buildConnectedClient();
+
+      const listener = jest.fn();
+      client.setConnectionStateListener(listener);
+      client.setConnectionStateListener(null);
+
+      await client.disconnect();
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateBearerToken", () => {
+    it("suppresses connection notifications during token update", async () => {
+      const { client, mockMcpClient } = buildConnectedClient();
+
+      const stateChanges: boolean[] = [];
+      client.setConnectionStateListener((connected) => {
+        stateChanges.push(connected);
+      });
+
+      // Mock connect() to simulate a successful reconnection.
+      jest.spyOn(client, "connect").mockImplementation(async () => {
+        // Simulate what connect() does internally
+        (client as any).mcpClient = mockMcpClient;
+        (client as any).isConnected = true;
+        (client as any).cachedCapabilities = { tools: [], resources: [] };
+      });
+
+      await client.updateBearerToken("new-token");
+
+      // The disconnect → reconnect cycle should NOT have fired the listener
+      // because notifications are suppressed during token update
+      expect(stateChanges).toEqual([]);
+
+      jest.restoreAllMocks();
+    });
+
+    it("notifies if final state differs after token update failure", async () => {
+      const { client } = buildConnectedClient();
+
+      const stateChanges: boolean[] = [];
+      client.setConnectionStateListener((connected) => {
+        stateChanges.push(connected);
+      });
+
+      // Mock connect() to fail — client stays disconnected
+      jest.spyOn(client, "connect").mockRejectedValue(new Error("connection failed"));
+
+      await expect(client.updateBearerToken("new-token")).rejects.toThrow("connection failed");
+
+      // Final state is disconnected (was connected), so listener should fire
+      expect(stateChanges).toContainEqual(false);
+
+      jest.restoreAllMocks();
+    });
+  });
+});

--- a/changes/unreleased/fix-health-poll-aggressive-reconnect.yaml
+++ b/changes/unreleased/fix-health-poll-aggressive-reconnect.yaml
@@ -1,0 +1,3 @@
+kind: bugfix
+description: >
+  Fixed health poll aggressively reconnecting the solution server on the first transient failure, which disrupted other MCP clients sharing the same ingress.

--- a/vscode/core/src/extension.ts
+++ b/vscode/core/src/extension.ts
@@ -750,18 +750,27 @@ class VsCodeExtension {
               draft.solutionServerConnected = false;
             });
 
-            // Attempt to re-establish the connection automatically — stale
-            // MCP connections drop after idle periods (see issue #1433)
-            const reconnected = await this.state.hubConnectionManager.reconnectSolutionServer();
-            if (reconnected) {
-              consecutiveFailures = 0;
-              pollInterval = 10000;
-              this.state.mutateServerState((draft) => {
-                draft.solutionServerConnected = true;
-              });
-            } else if (consecutiveFailures === 1) {
-              // Exponential backoff: 10s -> 30s -> 60s, then a slow 5m
-              // heartbeat so the connection can recover without manual retry
+            // Only attempt reconnection after multiple consecutive failures —
+            // a single transient error (e.g. a momentary network blip) should
+            // not tear down and replace the MCP session, because that disrupts
+            // other clients sharing the same ingress / HTTP/2 connection pool.
+            // Stale MCP connections (issue #1433) produce sustained failures,
+            // so waiting for ≥ 2 consecutive failures before reconnecting
+            // still detects them reliably while avoiding false positives.
+            if (consecutiveFailures >= 2) {
+              const reconnected = await this.state.hubConnectionManager.reconnectSolutionServer();
+              if (reconnected) {
+                consecutiveFailures = 0;
+                pollInterval = 10000;
+                this.state.mutateServerState((draft) => {
+                  draft.solutionServerConnected = true;
+                });
+              }
+            }
+
+            // Exponential backoff: 10s -> 30s -> 60s, then a slow 5m
+            // heartbeat so the connection can recover without manual retry
+            if (consecutiveFailures === 1) {
               pollInterval = 30000;
             } else if (consecutiveFailures < 5) {
               pollInterval = 60000;


### PR DESCRIPTION
## Summary

Fixes the Scheduled Prerelease #215 regression ([CI run](https://github.com/konveyor/editor-extensions/actions/runs/29006777904)) introduced by #1468.

## Problem

The health poll introduced in #1468 calls `reconnectSolutionServer()` on the **very first** `getServerCapabilities()` failure. `reconnectSolutionServer()` tears down the existing MCP session, creates a new `SolutionServerClient`, and fires `onWorkflowDisposal(false)`. In the minikube E2E environment, this session churn causes the nginx ingress to return **HTTP 421 (Misdirected Request)** to other MCP clients sharing the same HTTP/2 connection pool — breaking the infrastructure tests.

Two tests failed:
- `hub-configuration.test.ts` — timed out waiting for "Successfully connected to Hub solution server" notification
- `analysis-validation.test.ts` — `Error POSTing to endpoint (HTTP 421): Misdirected Request` from the test's independent MCP client

The previous 9+ scheduled prereleases all passed; the single new commit between the last success and this failure was #1468.

## Fix

Gate `reconnectSolutionServer()` behind `consecutiveFailures >= 2` so transient errors (single-poll network blips) are absorbed by the existing backoff without replacing the MCP session.

- **Transient errors**: First failure backs off to 30s, no session replacement. If the next poll succeeds, the failure counter resets — no disruption.
- **Genuine stale connections** (issue #1433): Produce sustained failures, so the second consecutive failure still triggers recovery — with only ~30s additional latency, acceptable for idle-timeout scenarios.

The backoff schedule is now unconditional (always applied based on failure count) rather than being an `else` branch of the reconnection attempt.

## Tests

Added `agentic/tests/solutionServerClient.test.ts` with 11 unit tests covering `SolutionServerClient` behaviors introduced by #1468:
- `getServerCapabilities()` error classification (connection vs non-connection errors)
- Connection state listener fire/suppress semantics
- Stale client cleanup on connection errors
- `updateBearerToken()` notification suppression

## Changes

| File | What |
|------|------|
| `vscode/core/src/extension.ts` | Gate `reconnectSolutionServer()` behind `consecutiveFailures >= 2`; make backoff schedule unconditional |
| `agentic/tests/solutionServerClient.test.ts` | New: 11 unit tests for SolutionServerClient connection state management |
| `changes/unreleased/fix-health-poll-aggressive-reconnect.yaml` | Changelog fragment |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary solution-server reconnect attempts after transient health-check failures.
  * The server now reconnects only after multiple consecutive failures, helping prevent disruptions to other connected clients.
  * Improved handling and reporting of connection-state changes during failures and token updates.

* **Tests**
  * Added coverage for capability retrieval, connection failures, listener notifications, and token-update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->