### PR TITLE
:bug: Validate custom rules file types in profile file dialog

### DIFF
--- a/changes/unreleased/580-validate-custom-rules-file-types.yaml
+++ b/changes/unreleased/580-validate-custom-rules-file-types.yaml
@@ -1,0 +1,7 @@
+kind: bugfix
+description: >
+  Validate file types when selecting custom rules for a profile. The file
+  dialog now filters to YAML rule files, and any non-YAML files that slip
+  through (e.g. on platforms where dialog filters are not enforced) are
+  skipped with a warning instead of being silently added to the profile.
+  Folders are still accepted as rule directories.

--- a/vscode/core/src/utilities/profiles/profileActions.ts
+++ b/vscode/core/src/utilities/profiles/profileActions.ts
@@ -1,5 +1,6 @@
+import { basename } from "path";
 import { ExtensionState } from "src/extensionState";
-import { OpenDialogOptions, window } from "vscode";
+import { FileType, OpenDialogOptions, Uri, window, workspace } from "vscode";
 import { getUserProfiles, saveUserProfiles } from "./profileService";
 import { updateConfigErrors } from "../configuration";
 
@@ -9,7 +10,7 @@ export async function handleConfigureCustomRules(profileId: string, state: Exten
     canSelectFolders: true,
     canSelectFiles: true,
     openLabel: "Select Custom Rules",
-    filters: { "All Files": ["*"] },
+    filters: { "YAML rule files": ["yaml", "yml"] },
   };
 
   const fileUris = await window.showOpenDialog(options);
@@ -17,7 +18,32 @@ export async function handleConfigureCustomRules(profileId: string, state: Exten
     return;
   }
 
-  const customRules = fileUris.map((uri) => uri.fsPath);
+  // Dialog filters don't apply to folders and are not enforced on all
+  // platforms, so validate the selection: directories are accepted as rule
+  // directories, files must be YAML.
+  const validUris: Uri[] = [];
+  const skippedNames: string[] = [];
+  for (const uri of fileUris) {
+    const stat = await workspace.fs.stat(uri);
+    const isDirectory = (stat.type & FileType.Directory) !== 0;
+    const isYamlFile = uri.fsPath.endsWith(".yaml") || uri.fsPath.endsWith(".yml");
+    if (isDirectory || isYamlFile) {
+      validUris.push(uri);
+    } else {
+      skippedNames.push(basename(uri.fsPath));
+    }
+  }
+
+  if (skippedNames.length > 0) {
+    window.showWarningMessage(
+      `Skipped non-YAML file(s): ${skippedNames.join(", ")}. Custom rules must be .yaml or .yml files, or folders containing them.`,
+    );
+  }
+  if (validUris.length === 0) {
+    return;
+  }
+
+  const customRules = validUris.map((uri) => uri.fsPath);
 
   const profile = state.data.profiles.find((p) => p.id === profileId);
   if (!profile) {


### PR DESCRIPTION
Fixes #580

## Summary

The "Select Custom Rules" dialog (Manage Profile → Configure Custom Rules) accepted any file type — `.java`, `.png`, etc. were silently added to the profile as custom rules.

## Changes

- Filter the file dialog to YAML rule files (`.yaml`/`.yml`), matching the webview upload path which already enforces YAML-only
- Validate the selection after the dialog closes, since dialog filters don't apply to folders and aren't enforced on all platforms: non-YAML files are skipped with a warning listing the skipped names
- Folders are still accepted as rule directories
- Adds a changelog fragment

## Verification

- `tsc --noEmit` clean on `vscode/core`
- `eslint` clean on the changed file
- `npm run changelog:validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Custom rule selection now accepts YAML rule files and directories while ignoring unsupported file types.
  - Invalid selections are skipped with a warning, helping prevent unintended files from being added.
  - The configuration flow now stops when no valid rule inputs remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->