### PR TITLE
:bug: match hub label selector semantics for synced profiles

### DIFF
--- a/changes/unreleased/1478-hub-label-selector-semantics.yaml
+++ b/changes/unreleased/1478-hub-label-selector-semantics.yaml
@@ -1,0 +1,7 @@
+kind: bugfix
+description: >
+  Build the label selector for hub-synced analysis profiles the same way the
+  hub's analyzer addon does, by ANDing source labels with target labels instead
+  of ORing every label together. Analyzing an application in the IDE with a
+  profile synced from the hub no longer reports a different set of issues than
+  running the same profile on the hub.

--- a/shared/src/__tests__/labelSelector.test.ts
+++ b/shared/src/__tests__/labelSelector.test.ts
@@ -113,73 +113,131 @@ describe("buildLabelSelector", () => {
   });
 });
 
+// These cases mirror RuleSelector.String() in tackle2-addon-analyzer
+// (cmd/rules.go). The IDE must produce byte-identical selectors to the Hub for
+// the same profile, otherwise a synced profile yields different issues in each.
 describe("buildLabelSelectorFromLabels", () => {
-  it("should return correct format when no labels are provided", () => {
+  it("should return an empty selector when no labels are provided", () => {
     const result = buildLabelSelectorFromLabels([], []);
     expect(result).toBe("");
   });
 
-  it("should handle only sources", () => {
+  it("should not parenthesize a lone source", () => {
     const result = buildLabelSelectorFromLabels(["konveyor.io/source=java-ee"], []);
-    expect(result).toBe("(konveyor.io/source=java-ee)");
+    expect(result).toBe("konveyor.io/source=java-ee");
   });
 
-  it("should handle only targets", () => {
+  it("should not parenthesize a lone target", () => {
     const result = buildLabelSelectorFromLabels(["konveyor.io/target=spring-boot"], []);
-    expect(result).toBe("(konveyor.io/target=spring-boot)");
+    expect(result).toBe("konveyor.io/target=spring-boot");
   });
 
-  it("should handle sources and targets together", () => {
+  it("should AND sources with targets rather than OR them", () => {
     const result = buildLabelSelectorFromLabels(
       ["konveyor.io/source=java-ee", "konveyor.io/target=spring-boot"],
       [],
     );
-    expect(result).toBe("(konveyor.io/source=java-ee || konveyor.io/target=spring-boot)");
+    expect(result).toBe("(konveyor.io/source=java-ee&&konveyor.io/target=spring-boot)");
   });
 
-  it("should handle excluded labels", () => {
+  it("should OR within each of sources and targets, and AND across them", () => {
+    const result = buildLabelSelectorFromLabels(
+      [
+        "konveyor.io/source=weblogic",
+        "konveyor.io/source=websphere",
+        "konveyor.io/target=eap8",
+        "konveyor.io/target=cloud-readiness",
+      ],
+      [],
+    );
+    expect(result).toBe(
+      "((konveyor.io/source=weblogic||konveyor.io/source=websphere)&&" +
+        "(konveyor.io/target=cloud-readiness||konveyor.io/target=eap8))",
+    );
+  });
+
+  it("should negate a single excluded label", () => {
     const result = buildLabelSelectorFromLabels(
       ["konveyor.io/source=java-ee", "konveyor.io/target=spring-boot"],
       ["konveyor.io/target=eap7"],
     );
     expect(result).toBe(
-      "(konveyor.io/source=java-ee || konveyor.io/target=spring-boot) && !konveyor.io/target=eap7",
+      "((konveyor.io/source=java-ee&&konveyor.io/target=spring-boot)&&!konveyor.io/target=eap7)",
     );
   });
 
-  it("should handle multiple excluded labels", () => {
+  it("should negate multiple excluded labels as a group", () => {
     const result = buildLabelSelectorFromLabels(
       ["konveyor.io/source=java-ee"],
       ["konveyor.io/target=eap7", "konveyor.io/target=eap6"],
     );
     expect(result).toBe(
-      "(konveyor.io/source=java-ee) && !konveyor.io/target=eap7 && !konveyor.io/target=eap6",
+      "(konveyor.io/source=java-ee&&!(konveyor.io/target=eap6||konveyor.io/target=eap7))",
     );
   });
 
-  it("should handle other namespace labels", () => {
+  // The Hub builds rules.labels.included by ranging over a Go map, so the order
+  // it hands us changes between bundle downloads. The selector we derive has to
+  // be stable, otherwise every sync rewrites profile.yaml in the workspace.
+  it("should produce the same selector regardless of the order labels arrive in", () => {
+    const labels = [
+      "konveyor.io/target=cloud-readiness",
+      "konveyor.io/source=websphere",
+      "konveyor.io/target=openliberty",
+      "konveyor.io/source=javaee",
+    ];
+    const shuffled = [
+      "konveyor.io/source=websphere",
+      "konveyor.io/target=openliberty",
+      "konveyor.io/source=javaee",
+      "konveyor.io/target=cloud-readiness",
+    ];
+
+    expect(buildLabelSelectorFromLabels(shuffled, [])).toBe(
+      buildLabelSelectorFromLabels(labels, []),
+    );
+  });
+
+  it("should OR non-konveyor.io labels with the source/target clause", () => {
     const result = buildLabelSelectorFromLabels(
       ["other.namespace/label=value", "konveyor.io/source=java-ee"],
       [],
     );
-    expect(result).toBe("(other.namespace/label=value || konveyor.io/source=java-ee)");
+    expect(result).toBe("(other.namespace/label=value||konveyor.io/source=java-ee)");
   });
 
-  it("should handle other konveyor.io labels", () => {
+  it("should treat konveyor.io labels that are neither source nor target as other", () => {
     const result = buildLabelSelectorFromLabels(
       ["konveyor.io/other=value", "konveyor.io/source=java-ee"],
       [],
     );
-    expect(result).toBe("(konveyor.io/other=value || konveyor.io/source=java-ee)");
+    expect(result).toBe("(konveyor.io/other=value||konveyor.io/source=java-ee)");
   });
 
-  it("should include duplicate labels as provided", () => {
+  it("should de-duplicate included and excluded labels", () => {
     const result = buildLabelSelectorFromLabels(
       ["konveyor.io/source=java-ee", "konveyor.io/source=java-ee"],
       ["konveyor.io/target=eap7", "konveyor.io/target=eap7"],
     );
+    expect(result).toBe("(konveyor.io/source=java-ee&&!konveyor.io/target=eap7)");
+  });
+
+  // Captured from a live Hub: profile with targets Containerization + Open
+  // Liberty and additional source labels javaee + websphere. The Hub's analyzer
+  // addon logged exactly this selector; the extension must match it.
+  it("should reproduce the selector a live Hub used for a websphere->openliberty profile", () => {
+    const result = buildLabelSelectorFromLabels(
+      [
+        "konveyor.io/source=javaee",
+        "konveyor.io/source=websphere",
+        "konveyor.io/target=cloud-readiness",
+        "konveyor.io/target=openliberty",
+      ],
+      [],
+    );
     expect(result).toBe(
-      "(konveyor.io/source=java-ee || konveyor.io/source=java-ee) && !konveyor.io/target=eap7 && !konveyor.io/target=eap7",
+      "((konveyor.io/source=javaee||konveyor.io/source=websphere)&&" +
+        "(konveyor.io/target=cloud-readiness||konveyor.io/target=openliberty))",
     );
   });
 });

--- a/shared/src/labelSelector.ts
+++ b/shared/src/labelSelector.ts
@@ -1,22 +1,109 @@
+const KONVEYOR_IO = "konveyor.io";
+
 /**
- * Builds a label selector string from included and excluded label arrays
+ * Returns the (optional) namespace of a label, e.g. "konveyor.io" for
+ * "konveyor.io/source=java-ee". Mirrors Go's Label.Namespace().
+ */
+function labelNamespace(label: string): string {
+  const parts = label.split("/");
+  return parts.length > 1 ? parts[0] : "";
+}
+
+/**
+ * Returns the name of a label, e.g. "source" for "konveyor.io/source=java-ee".
+ * Mirrors Go's Label.Name(): everything after the last "/", up to the "=".
+ */
+function labelName(label: string): string {
+  const slash = label.lastIndexOf("/");
+  const base = slash === -1 ? label : label.slice(slash + 1);
+  return base.split("=")[0];
+}
+
+/** Joins operands, parenthesizing only when there is more than one. */
+function join(operator: string, operands: string[]): string {
+  const packed = operands.filter((s) => s.length > 0);
+  switch (packed.length) {
+    case 0:
+      return "";
+    case 1:
+      return packed[0];
+    default:
+      return `(${packed.join(operator)})`;
+  }
+}
+
+/** Joins operands and negates the result. */
+function notjoin(operator: string, operands: string[]): string {
+  const packed = operands.filter((s) => s.length > 0);
+  switch (packed.length) {
+    case 0:
+      return "";
+    case 1:
+      return `!${packed[0]}`;
+    default:
+      return `!(${packed.join(operator)})`;
+  }
+}
+
+/**
+ * De-duplicates and sorts.
+ *
+ * The Hub builds a bundle's `rules.labels.included` by ranging over a Go map
+ * (ApBundle.expandIncluded), so the order it arrives in changes from one request
+ * to the next. Sorting keeps the selector we derive stable, which matters
+ * because it gets written into the workspace at
+ * .konveyor/hub-profiles/<id>/profile.yaml on every sync. Order carries no
+ * meaning in a selector, `(a||b)` and `(b||a)` match the same rules.
+ */
+const normalize = (list: string[]): string[] => [...new Set(list)].sort();
+
+/**
+ * Builds a label selector from a Hub analysis profile's included/excluded labels.
+ *
+ * This is a faithful port of RuleSelector.String() in tackle2-addon-analyzer
+ * (cmd/rules.go). Source and target labels are NOT simply OR-ed together: they
+ * are partitioned and AND-ed, because the pair encodes a migration path
+ * ("from these sources, to these targets"). OR-ing them instead pulls in rules
+ * for unrelated destinations.
+ *
+ * The Hub flattens target labels into `rules.labels.included` when it builds a
+ * profile bundle (ApBundle.expandIncluded), so the source/target split has to be
+ * recovered here from the label names.
+ *
+ *   (other...) || ((sources...) && (targets...)) && !(excluded...)
+ *
+ * Keep this in sync with the Hub: if the two disagree, an analysis run in the
+ * IDE reports a different set of issues than the same profile run on the Hub.
  */
 export function buildLabelSelectorFromLabels(included: string[], excluded: string[] = []): string {
-  const includedPart = included.length > 0 ? included.join(" || ") : "";
-  const excludedPart = excluded.length > 0 ? excluded.map((e) => `!${e}`).join(" && ") : "";
-  if (!includedPart && !excludedPart) {
-    return "";
+  const other: string[] = [];
+  const sources: string[] = [];
+  const targets: string[] = [];
+
+  for (const label of normalize(included)) {
+    if (labelNamespace(label) !== KONVEYOR_IO) {
+      other.push(label);
+      continue;
+    }
+    switch (labelName(label)) {
+      case "source":
+        sources.push(label);
+        break;
+      case "target":
+        targets.push(label);
+        break;
+      default:
+        other.push(label);
+    }
   }
 
-  if (includedPart && !excludedPart) {
-    return `(${includedPart})`;
-  }
+  const ands = [join("||", sources), join("||", targets)];
 
-  if (!includedPart && excludedPart) {
-    return excludedPart;
-  }
+  let selector = join("||", other);
+  selector = join("||", [selector, join("&&", ands)]);
+  selector = join("&&", [selector, notjoin("||", normalize(excluded))]);
 
-  return `(${includedPart}) && ${excludedPart}`;
+  return selector;
 }
 
 /**

--- a/tests/e2e/tests/ccm/hub-profile-label-selector.test.ts
+++ b/tests/e2e/tests/ccm/hub-profile-label-selector.test.ts
@@ -1,0 +1,107 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import * as yaml from 'js-yaml';
+
+import { expect, test } from '../../fixtures/test-repo-fixture';
+import { HubConfigurationPage } from '../../pages/hub-configuration.page';
+import { VSCode } from '../../pages/vscode.page';
+import { SEC } from '../../utilities/consts';
+import { getHubConfig } from '../../utilities/utils';
+import * as VSCodeFactory from '../../utilities/vscode.factory';
+
+/**
+ * The hub's analyzer addon builds its label selector by splitting the profile's
+ * included labels into sources and targets and ANDing the two groups
+ * (RuleSelector.String() in tackle2-addon-analyzer). The extension has to derive
+ * the same selector from the synced bundle, otherwise analyzing with a
+ * hub-managed profile reports a different set of issues than the hub does.
+ *
+ * Depends on the "Label Selector" profile created by tests/scripts/seed-hub.sh:
+ * targets Containerization and Open Liberty, plus additional source labels
+ * javaee and websphere. The hub flattens the target labels into
+ * rules.labels.included when it builds the bundle, so all four arrive at the
+ * extension in a single list with nothing marking which is which.
+ *
+ * The application's source code is irrelevant here. Nothing is analyzed, we only
+ * check what the sync wrote to disk.
+ */
+const SELECTOR_PROFILE_NAME = 'Label Selector';
+
+const EXPECTED_LABEL_SELECTOR =
+  '((konveyor.io/source=javaee||konveyor.io/source=websphere)&&' +
+  '(konveyor.io/target=cloud-readiness||konveyor.io/target=openliberty))';
+
+interface SyncedProfile {
+  metadata?: { name?: string; source?: string };
+  spec?: { labelSelector?: string; useDefaultRules?: boolean };
+}
+
+/**
+ * Reads every profile.yaml the extension wrote under .konveyor/hub-profiles.
+ */
+function readSyncedProfiles(repoDir: string): SyncedProfile[] {
+  const hubProfilesDir = path.resolve(repoDir, '.konveyor', 'hub-profiles');
+  if (!fs.existsSync(hubProfilesDir)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(hubProfilesDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(hubProfilesDir, entry.name, 'profile.yaml'))
+    .filter((profileYaml) => fs.existsSync(profileYaml))
+    .map((profileYaml) => yaml.load(fs.readFileSync(profileYaml, 'utf-8')) as SyncedProfile);
+}
+
+function findSelectorProfile(repoDir: string): SyncedProfile | undefined {
+  return readSyncedProfiles(repoDir).find(
+    (profile) => profile.metadata?.name === SELECTOR_PROFILE_NAME
+  );
+}
+
+test.describe(
+  'Hub profile label selector',
+  {
+    tag: ['@tier3', '@requires-minikube'],
+  },
+  () => {
+    test.setTimeout(600000);
+    let vscodeApp: VSCode;
+
+    test.beforeAll(async ({ testRepoData }) => {
+      test.setTimeout(600000);
+      vscodeApp = await VSCodeFactory.init(testRepoData['coolstore']);
+
+      const hubConfigPage = await HubConfigurationPage.open(vscodeApp);
+      await hubConfigPage.fillForm(
+        getHubConfig({ profileSyncEnabled: true, solutionServerEnabled: false })
+      );
+    });
+
+    test('synced profile uses the same label selector as the hub', async () => {
+      expect(vscodeApp.repoDir, 'repoDir must be set to locate the synced profile').toBeTruthy();
+      const repoDir = vscodeApp.repoDir!;
+
+      // Wait on the file rather than on a notification. The sync toast can be
+      // dismissed or missed, but the profile landing on disk is the thing we
+      // actually care about.
+      await expect
+        .poll(() => findSelectorProfile(repoDir) !== undefined, {
+          message: `expected the "${SELECTOR_PROFILE_NAME}" profile to sync from the hub`,
+          timeout: 120 * SEC,
+          intervals: [2 * SEC],
+        })
+        .toBe(true);
+
+      const profile = findSelectorProfile(repoDir)!;
+      console.log('Synced label selector:', profile.spec?.labelSelector);
+
+      expect(profile.spec?.labelSelector).toBe(EXPECTED_LABEL_SELECTOR);
+    });
+
+    test.afterAll(async () => {
+      await vscodeApp?.closeVSCode();
+    });
+  }
+);

--- a/tests/scripts/seed-hub.sh
+++ b/tests/scripts/seed-hub.sh
@@ -83,6 +83,71 @@ else
   echo "✓ Analysis Profile created with ID: $ANALYSIS_PROFILE_ID"
 fi
 
+# 1b. Get or Create Analysis Profile "Label Selector"
+#
+# Exercises a profile that carries BOTH source and target labels. The hub's
+# analyzer addon ANDs the two groups together rather than ORing everything, so
+# this is what hub-profile-label-selector.test.ts asserts the extension derives.
+# Kept separate from "Coolstore" so analysis expectations there stay untouched.
+echo ""
+echo "Getting or creating Analysis Profile 'Label Selector'..."
+
+SELECTOR_PROFILE_ID=$(echo "$ALL_PROFILES" | jq -r '.[] | select(.name=="Label Selector") | .id // empty' | head -n 1)
+
+if [ -n "$SELECTOR_PROFILE_ID" ]; then
+  echo "✓ Analysis Profile already exists with ID: $SELECTOR_PROFILE_ID"
+else
+  # Resolve targets by label rather than by display name. The target named
+  # "Containerization" carries konveyor.io/target=cloud-readiness, and there is
+  # no konveyor.io/target=containerization label.
+  ALL_TARGETS=$(curl -k -s -X GET \
+    "${HUB_URL}/hub/targets" \
+    -H "Authorization: Bearer ${TOKEN}")
+
+  resolve_target_by_label() {
+    echo "$ALL_TARGETS" | jq -r --arg l "konveyor.io/target=$1" \
+      '[.[] | select(any(.labels[]?; .label == $l))] | .[0].id // empty'
+  }
+
+  CLOUD_READINESS_ID=$(resolve_target_by_label cloud-readiness)
+  OPENLIBERTY_ID=$(resolve_target_by_label openliberty)
+
+  if [ -z "$CLOUD_READINESS_ID" ] || [ -z "$OPENLIBERTY_ID" ]; then
+    echo "ERROR: Failed to resolve targets (cloud-readiness=$CLOUD_READINESS_ID openliberty=$OPENLIBERTY_ID)"
+    exit 1
+  fi
+
+  SELECTOR_PROFILE_RESPONSE=$(curl -k -s -X POST \
+    "${HUB_URL}/hub/analysis/profiles" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -d "$(jq -n \
+      --argjson cr "$CLOUD_READINESS_ID" \
+      --argjson ol "$OPENLIBERTY_ID" \
+      '{
+        name: "Label Selector",
+        mode: { withDeps: false },
+        scope: { withKnownLibs: false, packages: { included: [], excluded: [] } },
+        rules: {
+          targets: [ {id: $cr}, {id: $ol} ],
+          labels: {
+            included: ["konveyor.io/source=javaee", "konveyor.io/source=websphere"],
+            excluded: []
+          }
+        }
+      }')")
+
+  SELECTOR_PROFILE_ID=$(echo "$SELECTOR_PROFILE_RESPONSE" | jq -r '.id // empty')
+
+  if [ -z "$SELECTOR_PROFILE_ID" ]; then
+    echo "ERROR: Failed to create 'Label Selector' Analysis Profile"
+    echo "Response: $SELECTOR_PROFILE_RESPONSE"
+    exit 1
+  fi
+
+  echo "✓ Analysis Profile created with ID: $SELECTOR_PROFILE_ID"
+fi
+
 # 2. Get or Create Archetype "coolstore"
 echo ""
 echo "Getting or creating Archetype 'coolstore'..."
@@ -135,27 +200,29 @@ CURRENT_ARCHETYPE=$(curl -k -s -X GET \
   "${HUB_URL}/hub/archetypes/${ARCHETYPE_ID}" \
   -H "Authorization: Bearer ${TOKEN}")
 
-# Check if the archetype already has the Coolstore analysis profile
+# Check that the archetype has both analysis profiles
 HAS_PROFILE=$(echo "$CURRENT_ARCHETYPE" | jq -r '.profiles[]? | select(.analysisProfile.id == '${ANALYSIS_PROFILE_ID}') | .analysisProfile.id // empty')
+HAS_SELECTOR_PROFILE=$(echo "$CURRENT_ARCHETYPE" | jq -r '.profiles[]? | select(.analysisProfile.id == '${SELECTOR_PROFILE_ID}') | .analysisProfile.id // empty')
 
-if [ -n "$HAS_PROFILE" ]; then
-  echo "✓ Archetype already has the Coolstore Analysis Profile"
+if [ -n "$HAS_PROFILE" ] && [ -n "$HAS_SELECTOR_PROFILE" ]; then
+  echo "✓ Archetype already has both Analysis Profiles"
 else
-  # 4. Update Archetype with Analysis Profile
+  # 4. Update Archetype with Analysis Profiles
   echo ""
-  echo "Updating Archetype with Analysis Profile..."
+  echo "Updating Archetype with Analysis Profiles..."
 
   # Extract criteria from current archetype (default to empty array if null)
   CRITERIA=$(echo "$CURRENT_ARCHETYPE" | jq '.criteria // []')
 
   echo "DEBUG: Current criteria: $CRITERIA"
-  echo "DEBUG: Analysis Profile ID: $ANALYSIS_PROFILE_ID"
+  echo "DEBUG: Analysis Profile IDs: $ANALYSIS_PROFILE_ID (Coolstore), $SELECTOR_PROFILE_ID (Label Selector)"
 
   # Build the payload using jq to ensure valid JSON
   PAYLOAD=$(jq -n \
     --argjson criteria "$CRITERIA" \
     --arg name "coolstore" \
     --argjson profileId "$ANALYSIS_PROFILE_ID" \
+    --argjson selectorProfileId "$SELECTOR_PROFILE_ID" \
     '{
       name: $name,
       description: "",
@@ -169,6 +236,12 @@ else
           name: "coolstore",
           analysisProfile: {
             id: ($profileId | tonumber)
+          }
+        },
+        {
+          name: "label-selector",
+          analysisProfile: {
+            id: ($selectorProfileId | tonumber)
           }
         }
       ]
@@ -251,5 +324,6 @@ fi
 echo ""
 echo "=== Hub seeding completed successfully ==="
 echo "  Analysis Profile ID: $ANALYSIS_PROFILE_ID"
+echo "  Label Selector Profile ID: $SELECTOR_PROFILE_ID"
 echo "  Archetype ID: $ARCHETYPE_ID"
 echo "  Application ID: $APPLICATION_ID"


### PR DESCRIPTION
> [!NOTE]
> The e2e test here passes against a local minikube hub but has not run in CI yet.

Fixes #1479

## Summary

- Analyzing with a hub-synced profile returns a different set of issues than the same profile run on the hub. `buildLabelSelectorFromLabels` ORs every label in the bundle's `rules.labels.included` together. `RuleSelector.String()` in `tackle2-addon-analyzer` splits them into sources, targets and other, then ANDs sources with targets. ORing drags in rules for unrelated targets, eap6 and eap7 in the reported case.
- The hub flattens target labels into `rules.labels.included` when it builds the bundle (`ApBundle.expandIncluded`), so the split has to be recovered from the label names.
- Port `RuleSelector.String()`, then sort within each group. `expandIncluded` builds that list by ranging over a Go map, so the order changes between bundle downloads. Without sorting we rewrite `.konveyor/hub-profiles/<id>/profile.yaml` with a differently ordered selector on every sync. Order carries no meaning in a selector.
- Only `ProfileSyncClient` calls this, and the profile editor already ANDs via `buildLabelSelector`, so the sync path was the odd one out.

## Verification

Stood up konveyor on minikube and reproduced the reported setup: targets Containerization and Open Liberty, additional source labels javaee and websphere. The addon logged this, and it is what the extension now derives from the same bundle:

```
((konveyor.io/source=javaee||konveyor.io/source=websphere)&&(konveyor.io/target=cloud-readiness||konveyor.io/target=openliberty))
```

Then ran both sides end to end on a second profile, with `withDeps` off so the mode gap below could not confound it: targets Containerization, Quarkus and Jakarta EE 9 plus source label java-ee, analyzing coolstore. Rules that fired:

| ruleset | hub | IDE |
|---|---|---|
| quarkus/springboot | 25 | 25 |
| eap8/eap7 | 11 | 11 |
| eap7/weblogic/tests/data | 1 | 1 |
| cloud-readiness | 1 | 1 |
| discovery-rules | 6 | — |
| technology-usage | 17 | — |

38 shared, and **zero** fired in the IDE that the hub does not fire, which is the symptom this fixes. The remaining 23 are tag emitting rules carrying `konveyor.io/include=always`, with null category and effort. The hub surfaces tags as insights while the IDE records violations only, so that gap is a reporting difference rather than a selector one.

On what "matches" means: the addon builds its selector from the profile in the DB, which has a stable order, while the bundle ranges over a Go map. For the second profile the two strings differ in operand order and still select the same rules. The guarantee is semantic equivalence, not byte equality.

## Tests

- `labelSelector.test.ts` rewritten. The old cases asserted the OR behavior. Added the selector captured off the live hub, and a case that the same labels shuffled produce the same selector.
- New `hub-profile-label-selector.test.ts` (`@tier3 @requires-minikube`) reads the synced `profile.yaml` out of the workspace and asserts the selector. It waits on the file rather than a sync notification, since the toast can be missed.
- `seed-hub.sh` grows a second profile, "Label Selector", carrying both source and target labels, attached to the coolstore archetype. The existing "Coolstore" profile is untouched so the analysis expectations elsewhere do not move. Also fixes an early exit that would have skipped attaching new profiles to an already-seeded hub.

## One deliberate difference from #1479

The issue proposes `(targets) && (sources) || (discovery)`, matching kantra and `buildLabelSelector`. This implements the hub addon's form instead, which has no `(discovery)` term, because the goal is parity with what the hub actually runs:

- The addon's own selector contains no `(discovery)`. Captured twice off a live hub.
- Discovery rules still fire on the hub regardless, because `LabelSelector.Matches` short-circuits on `konveyor.io/include=always` before evaluating the expression. 781 rules carry that label; exactly 1 rule carries a bare `discovery` label without it.
- So appending `|| (discovery)` would make the IDE match rules the hub does not, reintroducing divergence in the other direction.

Happy to switch if we would rather track kantra than the hub, but that is a different goal than the reported bug. The issue is right that a bare `konveyor.io/source` label acts as a wildcard, `matchAny` returns true on an empty value; 346 rules carry one.

## Notes

- The hub target named "Containerization" carries the label `konveyor.io/target=cloud-readiness`. There is no `konveyor.io/target=containerization`. Cost me a round of wrong numbers.
- `npm run build` at the root exits 0 even when a workspace build fails, and the workspaces are not reliably built in dependency order (`shared`'s prebuild rimrafs `dist`, and core can build before it comes back). Both bit me here. Unrelated to this change, worth separate issues.
- `npm test` does not run on node 26, mocha's bundled yargs blows up before loading any test file. Ran these through node's own runner instead.
- CI is red on this branch for two reasons that are both broken on main and fixed in #1480.

## Not fixed here

- `mode.withDeps` and `scope.withKnownLibs` are still dropped, since every provider hardcodes `analysisMode: "source-only"`. Issue counts will still differ between hub and IDE for any profile that sets them.
- The hub drops rules for a target you explicitly selected when those rules carry no `konveyor.io/source` label, because analyzer-lsp treats an absent key as false. Separately, `konveyor.io/source=javaee` matches an order of magnitude fewer rules than `java-ee`, and the hub UI offers both. Both upstream.

## Test plan

- [x] `labelSelector.test.ts`
- [x] Hub and IDE fire the same rules for the same profile, verified end to end against a live hub
- [x] `hub-profile-label-selector.test.ts` against a local minikube hub
- [ ] Same test in CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hub-synced analysis profile label matching so source and target labels combine correctly, keeping IDE and hub issue results consistent.

* **Tests**
  * Added coverage for grouped label matching, exclusions, duplicate labels, stable ordering, and real-world hub selector scenarios.
  * Added end-to-end validation for synchronized profile selectors.

* **Chores**
  * Updated test data setup to include a label-selector analysis profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->