### PR TITLE
:test_tube: De-flake tier1 'Auto Accept on Save' tab close

### DIFF
--- a/tests/e2e/pages/tab-manager.page.ts
+++ b/tests/e2e/pages/tab-manager.page.ts
@@ -103,9 +103,27 @@ export class TabManager {
   public async closeTabByName(tabName: string): Promise<void> {
     const tabSelector = `.tab[role="tab"][data-resource-name="${tabName}"]`;
     const tab = this.window.locator(tabSelector);
-    await expect(tab).toBeVisible({ timeout: 10000 });
+    await expect(tab.first()).toBeVisible({ timeout: 10000 });
+
+    // Focus the tab before closing it. The close button is only reliably
+    // rendered/visible for the active tab; for inactive tabs the `.tab-actions`
+    // subtree can be briefly detached while VS Code re-renders the tab (e.g.
+    // during the dirty -> clean transition right after an auto-accept-on-save),
+    // which made the DOM click flaky.
+    await this.focusTabByName(tabName);
+
     const closeBtn = tab.locator('.tab-actions .action-label.codicon-close').first();
-    await expect(closeBtn).toBeVisible({ timeout: 5000 });
-    await closeBtn.click();
+    try {
+      await expect(closeBtn).toBeVisible({ timeout: 5000 });
+      await closeBtn.click();
+    } catch {
+      // Fallback: close the active editor via the VS Code command. This is more
+      // reliable than a DOM click while the tab is still re-rendering. The tab
+      // was focused above, so the active editor is the one we intend to close.
+      await this.vsCode.executeQuickCommand('View: Close Editor');
+    }
+
+    // Verify the tab is actually gone before continuing.
+    await expect(tab).toHaveCount(0, { timeout: 10000 });
   }
 }

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -11,7 +11,9 @@ export default defineConfig({
   outputDir: 'test-output',
   globalSetup: require.resolve('./global.setup.ts'),
   forbidOnly: !!process.env.CI,
-  retries: 0,
+  // Retry in CI so a single flaky E2E interaction doesn't red the whole
+  // (release-blocking) tier. Local runs keep 0 retries for fast feedback.
+  retries: process.env.CI ? 2 : 0,
   workers: 1,
   timeout: !!process.env.WEB_ENV ? 600000 : 120000,
 


### PR DESCRIPTION
## Problem

The `tier1` job has been failing frequently on both `main` and `release-0.6`, blocking patch releases. The culprit is a single flaky test:

`e2e/tests/base/plugin-settings.test.ts › Plugin Settings - Analyze on Save › Enable "Auto Accept on Save" setting`

It fails in `TabManager.closeTabByName('CatalogService.java')` at the close-button step. The failure mode **varies run-to-run**, which is the tell for a timing/render race rather than a code regression:

- **Element not found** — e.g. Patch Release run [32236624704](https://github.com/konveyor/editor-extensions/actions/runs/32236624704/job/96073936896) (main): `expect(closeBtn).toBeVisible()` → `<element(s) not found>`.
- **Found but not clickable** — e.g. CI run 31706377411 (main) and 32149593086 (release-0.6): the button resolves to `<a class="action-label codicon codicon-close">` but `.click()` times out.

### Root cause

`ReviewInEditor` opens an inline vertical diff. On `File: Save`, the extension auto-accepts and mutates the buffer, and the test immediately calls `closeTabByName`. The tab's close button only renders reliably for the **active** tab; for an inactive tab the `.tab-actions` subtree can be briefly detached while VS Code re-renders during the dirty → clean transition. With `retries: 0`, a single such flake reds the whole (release-blocking) tier.

## Changes

- **`closeTabByName`**: focus the tab first (so its close button is reliably rendered), fall back to the `View: Close Editor` command if the DOM click races a re-render, and assert the tab is actually gone.
- **`playwright.config.ts`**: `retries: process.env.CI ? 2 : 0` so a single flaky interaction doesn't red the tier; local runs keep fast 0-retry feedback.

## Verification

Can't reliably run the full Electron E2E stack locally, so this needs to bake in CI — please watch the `tier1` job. `tsc`/`eslint` clean for the changed files (only pre-existing warnings remain).

## Follow-ups (not in this PR)

- Separate real bug: auto-accept-on-save calls `acceptAll(doc.uri.fsPath)` (`vscode/core/src/extension.ts:836`) while the handler map is keyed by `uri.toString()` (`manager.ts`; the manual path in `commands.ts` uses `uri.toString()`), so the willSave cleanup likely no-ops. Predates this regression; worth a dedicated `:bug:`.
- Cherry-pick this to `release-0.6` (identical code there).