### PR TITLE
:bug: Fix auto-accept-on-save saving un-accepted diffs (fsPath vs URI)

### DIFF
--- a/changes/unreleased/1488-auto-accept-on-save-uri.yaml
+++ b/changes/unreleased/1488-auto-accept-on-save-uri.yaml
@@ -1,0 +1,9 @@
+kind: bugfix
+description: >
+  Fix "Auto Accept on Save" saving files with un-accepted inline diffs. The
+  save handler looked up the diff by its URI string but then tried to accept
+  it by filesystem path, so the accept silently no-oped and the file was saved
+  with the pending diff still in the buffer. The correct URI is now used, so
+  saving accepts and clears the diff as intended.
+extensions:
+  - core

--- a/vscode/core/src/extension.ts
+++ b/vscode/core/src/extension.ts
@@ -832,8 +832,12 @@ class VsCodeExtension {
             if (handler && handler.hasDiffForCurrentFile()) {
               try {
                 // Accept all diffs BEFORE the save operation
-                // This ensures the document is saved in its final state
-                await this.state.staticDiffAdapter?.acceptAll(doc.uri.fsPath);
+                // This ensures the document is saved in its final state.
+                // Pass the URI string (not fsPath): the vertical diff handler
+                // map is keyed by `uri.toString()`, so passing fsPath here made
+                // the lookup miss and the accept silently no-op, saving a buffer
+                // that still contained the un-accepted diff.
+                await this.state.staticDiffAdapter?.acceptAll(fileUri);
                 this.state.logger.info(
                   `Auto-accepted all diff decorations for ${doc.fileName} before save`,
                 );


### PR DESCRIPTION
## Problem

With **Auto Accept on Save** enabled, saving a file that has a pending inline diff was supposed to accept all changes and save the final state. Instead, the accept **silently no-oped** and the file was saved with the un-accepted diff still in the buffer — while the user was shown `Auto-accepted all diff changes for <file> - saving final state`.

## Root cause

In `onWillSaveTextDocument` (`vscode/core/src/extension.ts`):

```ts
const fileUri = doc.uri.toString();                       // used for lookup
const handler = verticalDiffManager.getHandlerForFile(fileUri);
if (handler && handler.hasDiffForCurrentFile()) {
  await staticDiffAdapter.acceptAll(doc.uri.fsPath);      // <-- wrong form
  ...
}
```

`acceptAll` → `verticalDiffManager.clearForFileUri(fileUri)`, and the handler map is **keyed by `uri.toString()`** (`diff/vertical/manager.ts`). Passing `doc.uri.fsPath` (e.g. `/path/File.java` vs `file:///path/File.java`) misses the map, so `handler.clear(accept)` never runs — no accept, no cleanup. The manual **Accept All Changes** command (`commands.ts`) already uses `uri.toString()`, which is why only the save path was affected.

## Fix

Pass the already-computed `fileUri` (URI string) to `acceptAll`.

## Affected branches

Present on both `main` and `release-0.6` (identical code). This PR targets `main`; labeled for cherry-pick to `release-0.6`.

## Verification

Exercised by the `tier1` e2e test `Enable "Auto Accept on Save"` (de-flaked separately in the companion PR). Please watch `tier1` in CI, since the full Electron E2E stack isn't reproducible locally.